### PR TITLE
docs: centralize SDD/V-cycle contributing guide and clean up stale docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,69 +1,11 @@
 # Copilot Instructions for FRET
 
-These instructions apply to all GitHub Copilot chat and coding-agent interactions in this repository.
+GitHub Copilot and coding agents must follow [CONTRIBUTING.md](../CONTRIBUTING.md)
+as the authoritative development constitution (SDD, V-cycle, quality gates, agent
+policy).
 
-## Mandatory Rule
+For coding conventions, see [docs/guidelines.md](../docs/guidelines.md).
 
-Always follow [docs/guidelines.md](../docs/guidelines.md) as the authoritative coding standard.
-
-If there is any conflict between an ad hoc request and the guidelines, prioritize the guidelines unless the user explicitly asks to change the guidelines themselves.
-
-## ROS 2 Context
-
-FRET is a ROS 2 workspace with Python and C++ components for robotic manipulation. Respect ROS 2 conventions and best practices throughout all contributions.
-
-## Required Behaviors
-
-- Preserve ROS 2 architecture: nodes have single responsibilities, library code is separate from ROS communication.
-- Follow namespace-mirrors-directory convention for C++ code.
-- Keep launch files Python-based and parametric.
-- Add or update tests alongside behavior changes (Python unit tests required, integration tests recommended).
-- Use Google-style docstrings for Python and Doxygen comments for C++.
-- Keep formatting compliant with Black, isort, and clang-format.
-- Prefer minimal, focused diffs and avoid unrelated refactors.
-- Update CMakeLists.txt and package.xml when adding dependencies or files.
-- Ensure new files (URDF, config, launch) are installed via CMake install() directives.
-
-## ROS 2 Specific Requirements
-
-- **Nodes**: Each node has a well-defined, single responsibility.
-- **Topics/Services**: Use standard ROS 2 message types when possible.
-- **Parameters**: All configurable values must be ROS 2 parameters or YAML config files.
-- **QoS**: Use appropriate QoS profiles (sensor data, services, parameters).
-- **Transforms**: Use TF2 for coordinate transformations.
-- **Namespace conventions**: C++ namespaces mirror directory structure (`fret::control`, `fret::planning`, etc.).
-
-## Validation Checklist Before Finalizing
-
-- Tests relevant to the change pass locally.
-- Public APIs have typing and documentation.
-- Python formatting validated: `black --check src/ && isort --check-only src/`
-- C++ formatting validated: `clang-format --dry-run --Werror`
-- Launch files start without errors (smoke test).
-- Changes remain consistent with [docs/guidelines.md](../docs/guidelines.md).
-- An imperative order (do, implement, make, add...) is not only about writing the code. It must include all the V-cycle.
-
-### Respect the V-cycle
-
-As indicated above, all work of an AI must include all the descending and ascending steps of the cycle. For each row numbered below, the two actions (descend and ascend) must be done **at the same time**:
-
-1. **Add documentation of the work, feature, bug fix**: Use GitHub issues if possible, otherwise go directly into the GitHub PR and document every step in comments. This includes: goal/objectives and acceptance criteria.
-
-2. **Implement the architecture** of the code (classes, public interface, file organization, dependencies) and the **(functional) unit tests at the same time**. The testing must come first then coding: the performance of the algorithm is independent of its implementation. By reading the acceptance criteria above, you must already know which values to expect.
-
-3. **Do the coding**: This is the 3rd step: Fill the stubs left by the architecture definition. Implement algorithms, data structures, and private/local utilities. Add unit testing for private functions as well (fine testing/non-functional tests).
-
-4. **Then, run the tests**: Ideally proving 100% coverage (at least 90% would be great!). If this step fails, go back to step 2: Review your architecture, your functional tests, and go back to the cycle.
-
-5. **Implement high-level simulations** if all the testing are passing. Add visual inspection (either images or videos) if applicable. Add material for the presentation and documentation of the tool. Add the appropriate documentation of the newly implemented feature, or fix the lines affected by the changes. All GitHub workflows must pass: both at push and release! If something is wrong in this step, go back to step number 1.
-
-This completes the V-cycle. Once the acceptance criteria are met and all the GitHub workflows (autotests) are passing (both at push and release, test them all locally or add the tooling to test it), you can push your branch and trigger the review.
-
-## Common Pitfalls to Avoid
-
-- Don't mix ROS 2 communication logic with core algorithms (keep algorithms testable).
-- Don't forget to install new files in CMakeLists.txt.
-- Don't use blocking calls in high-frequency control loops.
-- Don't hardcode parameters; use ROS 2 parameter system or config files.
-- Don't skip the V-cycle steps; all code must have tests.
-- Don't violate C++ namespace conventions.
+Do not duplicate workflow rules in this file. If a request conflicts with
+CONTRIBUTING.md or the guidelines, prioritize those documents unless the user
+explicitly asks to change them.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,76 +1,19 @@
 # AGENTS Instructions
 
-This file defines repository-wide instructions for coding agents.
+Automated agents working in this repository must follow
+[CONTRIBUTING.md](CONTRIBUTING.md) as the **single source of truth** for
+development workflow, SDD, V-cycle stages, quality gates, and agent policy.
 
-## Scope
+For coding conventions (Python/C++, ROS 2 layout, formatting, naming), follow
+[docs/guidelines.md](docs/guidelines.md).
 
-Applies to all automated agents working in this repository.
-
-## Source of Truth
-
-Follow [docs/guidelines.md](docs/guidelines.md) as the authoritative standard for:
-
-- Architecture and package structure (ROS 2 ament_cmake layout)
-- Python and C++ naming conventions
-- ROS 2 resource naming (topics, services, parameters, nodes)
-- Docstring and documentation style
-- Formatting and typing
-- Testing and quality gates (V-cycle)
-
-## Agent Policy
-
-- Do not introduce patterns that violate [docs/guidelines.md](docs/guidelines.md).
-- Keep edits narrow and relevant to the task.
-- When changing behavior, update tests in the mirrored tests structure.
-- When adding public APIs, include type annotations and proper documentation (Google-style for Python, Doxygen for C++).
-- Prefer project-local conventions over generic defaults.
-- Respect ROS 2 ecosystem standards and best practices.
-
-An imperative order (do, implement, make, add...) is not only about writing the code. It must include all the V-cycle.
-
-### Respect the V-cycle
-
-As indicated above, all work of an AI must include all the descending and ascending steps of the cycle. For each row numbered below, the two actions (descend and ascend) must be done **at the same time**:
-
-1. **Add documentation of the work, feature, bug fix**: Use GitHub issues if possible, otherwise go directly into the GitHub PR and document every step in comments. This includes: goal/objectives and acceptance criteria.
-
-2. **Implement the architecture** of the code (classes, public interface, file organization, dependencies) and the **(functional) unit tests at the same time**. The testing must come first then coding: the performance of the algorithm is independent of its implementation. By reading the acceptance criteria above, you must already know which values to expect.
-
-3. **Do the coding**: This is the 3rd step: Fill the stubs left by the architecture definition. Implement algorithms, data structures, and private/local utilities. Add unit testing for private functions as well (fine testing/non-functional tests).
-
-4. **Then, run the tests**: Ideally proving 100% coverage (at least 90% would be great!). If this step fails, go back to step 2: Review your architecture, your functional tests, and go back to the cycle.
-
-5. **Implement high-level simulations** if all the testing are passing. Add visual inspection (either images or videos) if applicable. Add material for the presentation and documentation of the tool. Add the appropriate documentation of the newly implemented feature, or fix the lines affected by the changes. All GitHub workflows must pass: both at push and release! If something is wrong in this step, go back to step number 1.
-
-This completes the V-cycle. Once the acceptance criteria are met and all the GitHub workflows (autotests) are passing (both at push and release, test them all locally or add the tooling to test it), you can push your branch and trigger the review.
-
-## ROS 2 Specific Requirements
-
-When working with ROS 2 components:
-
-- **Build system**: Update both `CMakeLists.txt` and `package.xml` when adding dependencies or files.
-- **Installation**: Ensure new files (launch, config, URDF, meshes) are installed via `install()` directives.
-- **Namespaces**: C++ code must follow namespace-mirrors-directory convention.
-- **Nodes**: Each node has a clear, single responsibility.
-- **Parameters**: All configurable values must be ROS 2 parameters or YAML config files.
-- **Testing**: Unit tests use mocks to avoid ROS runtime; integration tests use launch_testing.
-
-## Pre-commit Validation
-
-Before completing any task, run the pre-flight checklist from [docs/guidelines.md](docs/guidelines.md):
-
-1. Build workspace: `./scripts/build.sh`
-2. Source environment: `source /opt/ros/jazzy/setup.bash && source install/setup.bash`
-3. Run unit tests: `pytest tests/ -v`
-4. Check Python formatting: `black --check src/ && isort --check-only src/`
-5. Check C++ formatting: `find src -name '*.cpp' -o -name '*.hpp' | xargs clang-format --dry-run --Werror`
-6. Launch smoke tests: Verify nodes start without errors
-
-## Conflict Resolution
-
-When instructions conflict, resolve in this order:
+**Do not duplicate** workflow or V-cycle rules in this file. When instructions
+conflict, resolve in this order:
 
 1. Direct maintainer request in the active task
-2. [docs/guidelines.md](docs/guidelines.md)
-3. ROS 2 official documentation
-4. This file
+2. [CONTRIBUTING.md](CONTRIBUTING.md)
+3. [docs/guidelines.md](docs/guidelines.md)
+4. ROS 2 official documentation
+
+An imperative order (implement, add, fix…) always implies the full V-cycle
+described in [CONTRIBUTING.md](CONTRIBUTING.md), not code alone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,73 +1,10 @@
 # CLAUDE Instructions
 
-This repository uses this file as persistent guidance for Claude-based coding agents.
+Claude-based agents must read [CONTRIBUTING.md](CONTRIBUTING.md) before making
+changes. It defines SDD, the 4-level V-cycle, constraint layers for AI work,
+and the pre-merge checklist.
 
-## Mandatory Standard
+For coding standards, see [docs/guidelines.md](docs/guidelines.md).
 
-Use [docs/guidelines.md](docs/guidelines.md) as the required coding and architecture reference for all changes.
-
-FRET is a ROS 2 workspace with Python and C++ components. Respect ROS 2 conventions and the architectural boundaries defined in the guidelines.
-
-## Required Practices
-
-- Follow ROS 2 best practices for node design, topic naming, and QoS settings.
-- Respect the namespace-mirrors-directory convention for C++ code.
-- Keep launch files Python-based and parametric.
-- Add tests with behavior changes and keep test layout mirrored with source layout.
-- Write Google-style docstrings for Python and Doxygen comments for C++.
-- Use explicit typing for public methods and APIs.
-- Keep changes small, composable, and aligned with existing style.
-- Ensure URDF/XACRO files are properly formatted and use parametric descriptions.
-
-## ROS 2 Specific Requirements
-
-- **Nodes**: Each node has a single, well-defined responsibility.
-- **Topics**: Use standard ROS 2 message types when possible; custom messages only when necessary.
-- **Parameters**: Declare all parameters with defaults and validation.
-- **Launch files**: Support command-line arguments for model selection and configuration.
-- **Build system**: Use ament_cmake; update both `CMakeLists.txt` and `package.xml` for new dependencies.
-- **Transforms**: Use TF2 for coordinate frame transformations.
-
-## Delivery Quality
-
-Before finishing a task, verify:
-
-- Relevant tests pass (Python unit tests at minimum).
-- New public APIs are documented and typed.
-- File organization and imports comply with [docs/guidelines.md](docs/guidelines.md).
-- ROS 2 nodes launch without errors (`ros2 launch` smoke test).
-- An imperative order (do, implement, make, add...) is not only about writing the code. It must include all the V-cycle.
-
-### Respect the V-cycle
-
-As indicated above, all work of an AI must include all the descending and ascending steps of the cycle. For each row numbered below, the two actions (descend and ascend) must be done **at the same time**:
-
-1. **Add documentation of the work, feature, bug fix**: Use GitHub issues if possible, otherwise go directly into the GitHub PR and document every step in comments. This includes: goal/objectives and acceptance criteria.
-
-2. **Implement the architecture** of the code (classes, public interface, file organization, dependencies) and the **(functional) unit tests at the same time**. The testing must come first then coding: the performance of the algorithm is independent of its implementation. By reading the acceptance criteria above, you must already know which values to expect.
-
-3. **Do the coding**: This is the 3rd step: Fill the stubs left by the architecture definition. Implement algorithms, data structures, and private/local utilities. Add unit testing for private functions as well (fine testing/non-functional tests).
-
-4. **Then, run the tests**: Ideally proving 100% coverage (at least 90% would be great!). If this step fails, go back to step 2: Review your architecture, your functional tests, and go back to the cycle.
-
-5. **Implement high-level simulations** if all the testing are passing. Add visual inspection (either images or videos) if applicable. Add material for the presentation and documentation of the tool. Add the appropriate documentation of the newly implemented feature, or fix the lines affected by the changes. All GitHub workflows must pass: both at push and release! If something is wrong in this step, go back to step number 1.
-
-This completes the V-cycle. Once the acceptance criteria are met and all the GitHub workflows (autotests) are passing (both at push and release, test them all locally or add the tooling to test it), you can push your branch and trigger the review.
-
-## ROS 2 Workspace Workflow
-
-When making changes that affect the ROS 2 workspace:
-
-1. **Build**: `./scripts/build.sh`
-2. **Source**: `source /opt/ros/jazzy/setup.bash && source install/setup.bash`
-3. **Test**: Run unit tests and launch smoke tests
-4. **Validate**: Check that nodes start without errors
-
-## Common Pitfalls to Avoid
-
-- Don't mix ROS 2 communication logic with core algorithms (keep algorithms testable).
-- Don't forget to install new files (URDF, config, launch) in `CMakeLists.txt`.
-- Don't use blocking calls in high-frequency control loops.
-- Don't hardcode parameters; use ROS 2 parameter system or config files.
-- Don't skip the V-cycle steps; all code must have tests.
-- Don't violate namespace conventions for C++ code.
+Do not duplicate workflow rules here. An imperative order always includes the
+full V-cycle from [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,72 @@
 # Contributing to FRET
 
-Thank you for contributing to the Full-stack Robotic Effector Trajectories project.
+This document is the **single source of truth** for how humans and AI agents
+contribute to FRET (Full-stack Robotic Effector Trajectories). It defines the
+development constitution: Specification-Driven Development (SDD), the V-cycle
+software development lifecycle, quality gates, and agent policy.
 
-## Prerequisites
+Do not duplicate these rules in other files. `AGENTS.md`, `CLAUDE.md`, and
+`.github/copilot-instructions.md` exist only as entry points that point here.
 
-- Ubuntu 24.04 (for ROS 2 Jazzy)
-- ROS 2 Jazzy Desktop
-- Python 3.12+
-- Git
-- Basic familiarity with ROS 2 concepts (nodes, topics, services, launch files)
+For **coding conventions** (naming, formatting, typing, ROS 2 layout), see
+[docs/guidelines.md](docs/guidelines.md). That file covers *how* code is
+written; this file covers *how work is planned, specified, verified, and merged*.
 
-## Setup
+## Table of contents
+
+1. [Ecosystem context](#ecosystem-context)
+2. [Development setup](#development-setup)
+3. [Spec-driven development (SDD)](#spec-driven-development-sdd)
+4. [FRET development stages (4-level V-cycle)](#fret-development-stages-4-level-v-cycle)
+5. [Combining SDD, V-cycle, and TDD](#combining-sdd-v-cycle-and-tdd)
+6. [Constraint layers for AI-assisted work](#constraint-layers-for-ai-assisted-work)
+7. [Requirement traceability](#requirement-traceability)
+8. [Quality gates](#quality-gates)
+9. [Definition of Ready and Definition of Done](#definition-of-ready-and-definition-of-done)
+10. [Pull request workflow](#pull-request-workflow)
+11. [ROS 2 contributions](#ros-2-contributions)
+12. [Rules for AI agents](#rules-for-ai-agents)
+13. [Reference documents](#reference-documents)
+14. [Pre-merge checklist](#pre-merge-checklist)
+
+---
+
+## Ecosystem context
+
+FRET is one project in a family of repositories that share the same SDD +
+V-cycle methodology, refined for AI-assisted development. Understanding that
+context helps contributors apply the method consistently.
+
+| Project | Role | SDD maturity |
+| --- | --- | --- |
+| **[Personal website](https://alexandrelheinen.pages.dev)** | Publishes methodology articles and project portfolio entries | Explains *why* SDD works with agents ([SDD and agentic AI for production-quality code](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/)) |
+| **[Luthier](https://github.com/alexandrelheinen/luthier)** | Python photogrammetry library | Reference implementation: `CONTRIBUTING.md` as constitution, `AC-*` traceability, governance CI |
+| **[Freshy](https://freshy-25e.pages.dev/explore)** | Mobile-first cooling-map app (Next.js, Cloudflare) | Product-level SDD in a private repo; stack documented on the website portfolio |
+| **[ARCO](https://github.com/alexandrelheinen/arco)** | Motion planning and control algorithms | First proving ground for constrained agentic development |
+| **FRET (this repo)** | ROS 2 end-to-end SCARA planning + control stack | 4-level V-cycle mapped to `docs/` specifications and pytest/launch_testing validation |
+
+### What FRET already provides
+
+FRET is a ROS 2 workspace with **pure-Python algorithm layers** (kinematics,
+planning, scene, validation) and a **thin ROS 2 layer** (nodes, topics, actions).
+The specification stack is in place:
+
+| Level | Specification artifacts | Validation artifacts |
+| --- | --- | --- |
+| 1 — Functional | [docs/requirements.md](docs/requirements.md) (`FR-*`), [docs/scenarios.md](docs/scenarios.md) (`SC-*`) | Scenario pass criteria, integration tests |
+| 2 — Architecture | [docs/architecture.md](docs/architecture.md), [docs/interfaces.md](docs/interfaces.md) | `tests/integration/`, `.github/workflows/integration.yml` |
+| 3 — Module API | Typed stubs under `src/fret/` | `tests/` mirroring `src/fret/` |
+| 4 — Implementation | Filled algorithms and ROS nodes | Full CI suite, SITL smoke tests |
+
+Project status, milestones, and roadmap: [docs/milestones.md](docs/milestones.md),
+[docs/roadmap.md](docs/roadmap.md). User-facing usage: [README.md](README.md),
+[docs/simulation.md](docs/simulation.md).
+
+---
+
+## Development setup
+
+**Requirements:** Ubuntu 24.04, ROS 2 Jazzy Desktop, Python 3.12+, Git.
 
 ```bash
 git clone https://github.com/alexandrelheinen/fret.git
@@ -18,169 +74,483 @@ cd fret
 ./scripts/install.sh -y
 ./scripts/setup.sh -y
 ./scripts/build.sh
-```
-
-## Development Workflow
-
-1. Create a feature branch from main.
-2. Implement the change with focused commits following the V-cycle.
-3. Add or update tests (Python unit tests required, integration tests recommended).
-4. Run local validation before opening a pull request.
-5. Ensure all CI checks pass.
-
-## Local Validation
-
-### Build and Source
-
-```bash
-./scripts/build.sh
 source /opt/ros/jazzy/setup.bash
 source install/setup.bash
 ```
 
-### Run Tests
+**Pure-Python work** (no ROS runtime) is supported for algorithm modules:
 
 ```bash
-# Python unit tests
-pytest tests/ -v
+pip install -e ".[dev]"
+pytest tests/ --ignore=tests/integration -v
 ```
 
-### Format Code
+Run the same checks CI runs before opening or updating a pull request:
 
 ```bash
-# Python formatting
-python -m black --check src/
-python -m isort --check-only src/
-
-# C++ formatting
-find src -name '*.cpp' -o -name '*.hpp' | xargs clang-format --dry-run --Werror
+bash scripts/check/pre_push.sh          # full gate (requires ROS)
+bash scripts/check/pre_push.sh --skip-ros   # formatting, types, unit tests only
 ```
 
-### Smoke Tests
+---
 
-Verify that launch files start without errors:
+## Spec-driven development (SDD)
+
+**Spec-driven development** treats written specifications—not code—as the
+primary artifact. Code, tests, and design notes are derived from and validated
+against those specs.
+
+In FRET, the **project-level specification** lives in `docs/` (requirements,
+scenarios, architecture, interfaces). Each **feature-level specification** is a
+GitHub issue or PR description with concrete acceptance criteria.
+
+### What a spec must contain
+
+Before implementation starts, the spec for a change must be clear enough that an
+independent reviewer (human or agent) could verify completion without guessing
+intent:
+
+| Element | Purpose | Where it lives |
+| --- | --- | --- |
+| **Intent** | Why the change exists | Issue title/body or PR summary |
+| **Scope** | What is in and out of bounds | Issue or PR description |
+| **Acceptance criteria** | Observable conditions of done | Issue checklist or PR test plan |
+| **Traceability** | Link to `FR-*` / `SC-*` when applicable | Issue, PR, or test docstrings |
+| **Constraints** | Non-negotiable rules (types, style, ROS layout) | This file + [docs/guidelines.md](docs/guidelines.md) |
+| **Design notes** | Interfaces, modules, edge cases (when non-trivial) | PR description or `docs/` |
+
+Write acceptance criteria in concrete, testable language (EARS-style: “When …,
+the system shall …”). Ambiguous specs produce ambiguous code—refine the spec
+before coding.
+
+### SDD workflow in this repo
+
+1. **Specify** — Capture intent, scope, and acceptance criteria in a GitHub
+   issue. Map criteria to existing `FR-*` / `SC-*` identifiers when the change
+   touches functional behavior.
+2. **Plan** — For non-trivial work, identify which V-cycle levels are affected,
+   which `docs/` files may need updates, and which test levels apply (unit /
+   integration / scenario / SITL).
+3. **Task** — Break the plan into focused commits. Each commit addresses one
+   logical step and traces back to at least one acceptance criterion.
+4. **Implement and verify** — Follow the V-cycle at each level: stubs and tests
+   before implementation where applicable; run quality gates locally before push.
+5. **Review** — PR review checks that code matches the spec and that tests prove
+   the acceptance criteria. **Humans merge; agents do not.**
+
+### Rigor levels
+
+| Level | When to use | Spec artifact |
+| --- | --- | --- |
+| **Spec-first** | Any merged change | Issue or PR with acceptance criteria |
+| **Spec-anchored** | Public API, architecture, or `docs/` changes | Above + design notes and test plan |
+| **Spec-as-source** | Large or AI-assisted features | Above + explicit task breakdown before coding |
+
+Default for FRET: **spec-first** minimum; **spec-anchored** when module
+boundaries, interfaces, or requirements change.
+
+### Rules
+
+- Do not implement without a written spec (issue scope or PR description with
+  acceptance criteria).
+- When requirements change mid-task, update the spec first, then code and tests.
+- Regressions: extend the spec with a failing test that encodes the bug, then fix.
+- Do not add duplicate workflow documentation outside this file and
+  [docs/guidelines.md](docs/guidelines.md).
+
+Further reading:
+[GitHub Spec Kit — Spec-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md),
+[SDD and agentic AI for production-quality code](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/)
+(author's article on constraint layers and the SDD V-cycle).
+
+---
+
+## FRET development stages (4-level V-cycle)
+
+FRET uses a **4-level V-cycle** as its software development lifecycle. Each
+level has a descending artifact (specification or design) and an ascending
+validation method. **Both sides of a level must be addressed before moving to the
+next.**
+
+An imperative order (implement, add, fix…) always implies the **full V-cycle**—not
+just the code.
+
+```
+Level 1 — Functional specification  ◄──────────────►  Scenario / acceptance validation
+  Level 2 — Architecture & interfaces  ◄──────────►  Integration validation
+    Level 3 — Module stubs & public API  ◄────────►  Unit tests
+      Level 4 — Implementation & private code  ◄──►  Full CI + SITL smoke tests
+```
+
+For agile delivery, treat each GitHub issue as one complete V (the **W-cycle**:
+chained small V-cycles). The next task starts from the verified output of the
+previous one.
+
+### Level 1 — Functional specifications
+
+| Side | Artifact | FRET location |
+| --- | --- | --- |
+| **Specify** | Numbered functional requirements, operational envelope, failure policies | [docs/requirements.md](docs/requirements.md) (`FR-*`) |
+| **Verify** | Named scenarios with quantitative pass criteria | [docs/scenarios.md](docs/scenarios.md) (`SC-*`) |
+
+**Rule:** No Level 2 work on new behavior until the relevant `FR-*` requirement
+exists and has a matching `SC-*` scenario or test.
+
+**CI gate:** Integration and scenario tests in `tests/integration/` and
+`tests/simulation/`.
+
+### Level 2 — Architecture and pipeline
+
+| Side | Artifact | FRET location |
+| --- | --- | --- |
+| **Specify** | Layer decomposition, data flows, typed contracts, QoS, FSMs | [docs/architecture.md](docs/architecture.md), [docs/interfaces.md](docs/interfaces.md) |
+| **Verify** | Inter-node contract tests | `tests/integration/`, `.github/workflows/integration.yml` |
+
+**Rule:** No Level 3 work on a new module boundary until
+[docs/interfaces.md](docs/interfaces.md) defines the typed interface.
+
+### Level 3 — Module stubs and unit tests
+
+| Side | Artifact | FRET location |
+| --- | --- | --- |
+| **Specify** | Public APIs: typed signatures, docstrings, `NotImplementedError` bodies | `src/fret/<module>/` |
+| **Verify** | Unit tests written **with** the stubs | `tests/` (mirrors `src/fret/`) |
+
+Use `@pytest.mark.xfail(strict=True, raises=NotImplementedError)` for methods not
+yet implemented. Remove `xfail` when Level 4 fills the stub.
+
+**CI gates:** `.github/workflows/tests.yml`, `.github/workflows/type_check.yml`
+(mypy strict on `src/`).
+
+**Rule:** Stub + test files for a module land in the same commit. No Level 4
+until stubs pass mypy and xfail tests behave as expected.
+
+### Level 4 — Implementation
+
+| Side | Artifact | FRET location |
+| --- | --- | --- |
+| **Specify** | Algorithms, data structures, ROS node wiring | `src/fret/` |
+| **Verify** | Full test suite, coverage ≥ 90%, smoke launches | All CI workflows |
+
+**Rule:** A feature is not done until CI is green and the relevant scenario
+passes (pytest and/or SITL as appropriate).
+
+### SDD mapping to the V-cycle (GitHub workflow)
+
+The [SDD V-cycle article](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/)
+maps naturally to GitHub:
+
+| V side | GitHub artifact | Agent / human action |
+| --- | --- | --- |
+| Left — Specify | **Issue** | Write what must be done, edge cases, tests that must pass (DoD) |
+| Left — Design | **Issue + `docs/`** | Architecture notes, interface updates when needed |
+| Right — Verify | **PR + CI** | Tests, formatting, types, integration; PR not mergeable until green |
+| Right — Accept | **Human merge** | Review verifiable artifacts (logs, plots, videos for physical behavior) |
+
+At the base of the V, the **agent loop** runs locally before each commit:
+format → lint → type-check → unit tests → fix until green. That loop is where
+most quality work happens.
+
+---
+
+## Combining SDD, V-cycle, and TDD
+
+SDD, the V-cycle, and test-driven development (TDD) operate at different layers.
+Use them together in this order:
+
+```
+SDD (what & why)  →  V-cycle (structure each level)  →  TDD (build each unit)
+     spec                 design ↔ tests                    red → green → refactor
+```
+
+| Step | Method | Activity |
+| --- | --- | --- |
+| 1 | **SDD** | Write intent, scope, acceptance criteria |
+| 2 | **V-cycle** | Map criteria to test levels (scenario → integration → unit) |
+| 3 | **V-cycle** | Update architecture / interface docs when boundaries change |
+| 4 | **TDD** | At Level 3–4: failing test → minimal code → refactor |
+| 5 | **V-cycle** | Run tests bottom-up; CI must pass |
+| 6 | **SDD** | Update spec/docs if behavior changed; PR proves all criteria |
+
+**TDD rules** (Kent Beck): do not write production code without a failing test;
+eliminate duplication. TDD executes **detailed design** at Level 3–4—it does not
+replace scenario or integration specs from Level 1–2.
+
+**Pause and re-spec** when acceptance criteria are ambiguous, scope grows beyond
+the issue, or integration tests reveal an unspecified requirement.
+
+---
+
+## Constraint layers for AI-assisted work
+
+To get production-quality output from coding agents, FRET uses three constraint
+layers (described in detail in the
+[SDD article](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/)).
+Together they make hallucination visible and expensive to ignore.
+
+### Layer 1 — Agent instructions (point to this file)
+
+`AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` must **only**
+direct agents to this document and [docs/guidelines.md](docs/guidelines.md).
+Keep them short. Models have limited context—essential rules live here, not
+scattered across ten files.
+
+### Layer 2 — CI/CD quality gates
+
+Automated checks enforce the method for humans and agents alike. No weakening
+gates to make CI green. See [Quality gates](#quality-gates).
+
+Agents must run local validation (`scripts/check/pre_push.sh` or equivalent
+steps) before pushing.
+
+### Layer 3 — Human merge
+
+Every change is merged by a maintainer after reviewing CI results and, when
+relevant, physical or visual evidence (simulation plots, Gazebo behavior, bag
+files). The agent does not decide when work is done.
+
+---
+
+## Requirement traceability
+
+Requirements must be traceable in both directions: from an acceptance criterion
+down to the test that proves it, and from any test back to the criterion.
+
+| Identifier | Document | Example |
+| --- | --- | --- |
+| `FR-<LAYER>-<NN>` | [docs/requirements.md](docs/requirements.md) | `FR-CTL-02` |
+| `SC-<NN>` | [docs/scenarios.md](docs/scenarios.md) | `SC-01` |
+| Milestone | [docs/milestones.md](docs/milestones.md) | MS-3 |
+
+**Rules:**
+
+- Reference `FR-*` / `SC-*` in issue text, PR descriptions, or test docstrings
+  when asserting observable behavior.
+- Every new functional requirement needs a scenario or test; a requirement with
+  no verification is an incomplete spec.
+- Do not silently skip tests (`skip`, `xfail`) without a `reason=` naming the
+  blocking requirement or tracking issue.
+
+---
+
+## Quality gates
+
+### Local validation
 
 ```bash
-# RViz visualization (terminate after visual confirmation)
-ros2 launch fret view.py model:=scara
+# Build and source
+./scripts/build.sh
+source /opt/ros/jazzy/setup.bash && source install/setup.bash
 
-# Gazebo simulation (terminate after visual confirmation)
-ros2 launch fret sim.py model:=scara
+# Recommended: all gates
+bash scripts/check/pre_push.sh
+
+# Or step by step:
+bash scripts/check/formatting.sh
+bash scripts/check/types.sh
+bash scripts/tests/unit.sh
+bash scripts/tests/smoke.sh          # requires ROS + xvfb
+bash scripts/tests/integration.sh    # requires ROS + xvfb
 ```
 
-## Coding Rules
+### CI workflows
 
-The authoritative coding standard is [docs/guidelines.md](docs/guidelines.md).
+| Workflow | Trigger | What it checks |
+| --- | --- | --- |
+| `formatting.yml` | PR | Black, isort, clang-format |
+| `type_check.yml` | PR | mypy strict on `src/` |
+| `tests.yml` | PR | pytest, smoke tests |
+| `integration.yml` | PR | `launch_testing` integration scenarios |
 
-All contributions, including AI-assisted changes, must follow this file.
+### Coverage and style
 
-### Key Conventions
+- Python unit test coverage target: **≥ 90%** on `src/fret`
+- Python: Google-style docstrings, `black` + `isort` (see [docs/guidelines.md](docs/guidelines.md))
+- C++: Doxygen, `clang-format`
+- Physical variables: `who_what` naming (e.g. `max_joint_velocity`, not `velocity_max`)
 
-- **Python**: Google-style docstrings, type annotations, `black` + `isort` formatting
-- **C++**: Doxygen comments, ROS 2 C++ style guide, `clang-format` formatting
-- **ROS 2**: Standard message types, proper QoS profiles, parameter-based configuration
-- **Testing**: V-cycle development, unit tests required, aim for 90%+ coverage
-- **Physical variables**: `who_what` naming (e.g., `max_joint_velocity`, not `velocity_max` or `vel_max`)
+---
 
-## V-Cycle Development
+## Definition of Ready and Definition of Done
 
-FRET follows a rigorous V-cycle development process. Every task must include:
+### Definition of Ready (before coding)
 
-1. **Requirements**: Document goals and acceptance criteria (GitHub issue or PR description)
-2. **Architecture + Functional Tests**: Design interfaces and write tests **before** implementation
-3. **Implementation + Fine Tests**: Fill stubs and add private function tests
-4. **Validation**: Run tests (target 100% coverage, minimum 90%)
-5. **Integration**: Update documentation, verify launches work, ensure CI passes
+- [ ] Intent, scope, and **acceptance criteria** are written (GitHub issue or PR).
+- [ ] Rigor level chosen (spec-first / spec-anchored / spec-as-source).
+- [ ] Affected V-cycle levels and test levels identified.
+- [ ] Linked `FR-*` / `SC-*` ids when behavior changes.
+- [ ] No undocumented new runtime dependency or public API break.
 
-**Never** submit code without corresponding tests. See [docs/guidelines.md](docs/guidelines.md) section 6 for full details.
+### Definition of Done (before merge)
 
-## Pull Request Checklist
+- [ ] All acceptance criteria verified by tests or documented manual checks.
+- [ ] Focused commits; conventional commit messages.
+- [ ] All required CI jobs green on the PR branch.
+- [ ] `docs/` updated when requirements, architecture, or interfaces changed.
+- [ ] No quality gate weakened to pass.
+- [ ] Human reviewer merged (agents do not self-merge).
 
-Before opening a PR, verify:
+---
 
-- [ ] Behavior changes are covered by tests
-- [ ] Public APIs are typed and documented
-- [ ] Python formatting passes (`black --check` and `isort --check-only`)
-- [ ] C++ formatting passes (`clang-format --dry-run`)
-- [ ] Unit tests pass (`pytest tests/ -v`)
-- [ ] Launch files start without errors
-- [ ] Documentation updated (README, guidelines, or docs/ as appropriate)
-- [ ] Commit messages follow conventional commits format
-- [ ] Branch is up-to-date with main
+## Pull request workflow
 
-## Documentation
+1. Branch from `main` with a descriptive name (e.g. `feat/pillar-scenario`,
+   `fix/planner-timeout`).
+2. Make **focused commits**—one logical step each.
+3. Open a PR against `main` with:
+   - **Summary** — what changed and why (1–3 bullets).
+   - **Test plan** — checklist of automated and manual verification.
+   - **Traceability** — `FR-*` / `SC-*` / milestone references when applicable.
+4. Ensure CI is green before requesting review.
+5. Address feedback in new commits (avoid force-push to `main`).
 
-Update documentation when adding or changing behavior:
+### Commit messages
 
-- [README.md](README.md) for user-facing changes (installation, usage, examples)
-- [docs/guidelines.md](docs/guidelines.md) for new coding rules or conventions
-- [docs/roadmap.md](docs/roadmap.md) for future work updates
-- Inline code documentation (docstrings/Doxygen) for all public APIs
-
-## ROS 2 Specific Contributions
-
-When contributing ROS 2 components:
-
-### Adding a New Node
-
-1. Create C++ source in `src/fret/src/<node_name>.cpp` or Python script
-2. Update `CMakeLists.txt` to build and install the executable
-3. Add corresponding launch file in `src/fret/launch/`
-4. Document node's topics, parameters, and purpose
-
-### Adding URDF/XACRO Models
-
-1. Create XACRO file in `src/fret/urdf/<model>.xacro`
-2. Optional: Add mesh generator in `src/fret/mesh/<model>.py`
-3. Optional: Add RViz config in `src/fret/rviz/<model>.rviz`
-4. Update CMakeLists.txt to install generated files
-5. Test with `ros2 launch fret view.py model:=<model>`
-
-### Adding Configuration
-
-1. Create YAML file in `src/fret/config/`
-2. Add comments explaining each parameter
-3. Update CMakeLists.txt to install config file
-4. Reference from launch file or node
-
-### Adding Dependencies
-
-1. Add to `package.xml` (both `<depend>` tag and rosdep key)
-2. Add `find_package()` call in `CMakeLists.txt`
-3. Document in README if it's not a standard ROS 2 package
-
-## Commit Messages
-
-Follow conventional commits format:
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-<type>(<scope>): <subject>
+<type>(<scope>): <imperative subject>
 
 <body>
 
 <footer>
 ```
 
-**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+Types: `feat`, `fix`, `docs`, `test`, `refactor`, `style`, `chore`, `build`, `ci`
 
-**Example**:
+Example:
+
 ```
-feat(control): add Jacobian pseudoinverse controller
+feat(planning): add pillar avoidance scenario SC-05
 
-Implement numerical Jacobian computation with damped least squares
-for singularity robustness. Controller tested with SCARA model
-in simulation.
+Implement workspace occupancy integration for two-cylinder world.
+Validates FR-PLN-01 and FR-SCN-03 in Gazebo SITL.
 
-Closes #23
+Closes #42
 ```
 
-## Getting Help
+---
 
-- Review existing code and tests for examples
-- Check [docs/guidelines.md](docs/guidelines.md) for detailed conventions
-- Open a GitHub issue for questions or clarifications
-- Reference [ROS 2 documentation](https://docs.ros.org/) for ROS-specific topics
+## ROS 2 contributions
+
+When contributing ROS 2 components, also update build metadata:
+
+### Adding a node
+
+1. Python script in `src/fret/ros/` or C++ in `src/fret/src/`
+2. `CMakeLists.txt` — build and install executable
+3. Launch file in `src/fret/launch/`
+4. Document topics, parameters, and purpose in [docs/modules/ros_nodes.md](docs/modules/ros_nodes.md)
+
+### Adding URDF/XACRO
+
+1. XACRO in `src/fret/urdf/<model>.xacro`
+2. Optional mesh generator in `src/fret/mesh/<model>.py`
+3. Optional RViz config in `src/fret/rviz/<model>.rviz`
+4. `CMakeLists.txt` install rules
+5. Smoke test: `ros2 launch fret view.py model:=<model>`
+
+### Adding configuration
+
+1. YAML in `src/fret/config/` with commented parameters
+2. `CMakeLists.txt` install rule
+3. Reference from launch file or node parameters
+
+### Adding dependencies
+
+1. `package.xml` and `CMakeLists.txt`
+2. Document in README if non-standard
+
+---
+
+## Rules for AI agents
+
+These rules apply to Cursor agents, Copilot, Claude Code, and any automated
+contributor.
+
+### Context and intent
+
+- Infer intent from the full conversation and issue scope, not only the latest message.
+- Treat mid-task messages as refinements unless the user clearly changes direction.
+- Read **this file** before making changes; it supersedes generic model habits.
+
+### Scope and files
+
+- Do not duplicate workflow rules in new markdown files.
+- Do not edit unrelated files unless explicitly asked.
+- An imperative order (implement, add, fix…) implies the **full V-cycle**, not code alone.
+
+### Execution order
+
+1. **SDD** — Confirm spec / acceptance criteria exist.
+2. **V-cycle** — Identify level; update `docs/` when Level 1–2 change.
+3. **Level 3** — Stubs + tests together when adding APIs.
+4. **Level 4** — Implement; run `scripts/check/pre_push.sh` (or `--skip-ros` when ROS unavailable).
+5. **PR** — Push; ensure CI green; do not claim done while checks fail.
+
+### Git safety
+
+- Never force-push to `main`.
+- Never skip hooks unless explicitly requested.
+- Never commit secrets.
+- Create commits when completing work that implies a PR.
+
+### Communication
+
+- Be precise; use code citations when referencing existing code.
+- Keep responses proportional to task complexity.
+
+---
+
+## Reference documents
+
+When an external guide conflicts with this file or [docs/guidelines.md](docs/guidelines.md),
+**this repository wins**.
+
+### FRET specifications
+
+| Document | Role |
+| --- | --- |
+| [docs/requirements.md](docs/requirements.md) | Level 1 — `FR-*` functional requirements |
+| [docs/scenarios.md](docs/scenarios.md) | Level 1 — `SC-*` scenario validation |
+| [docs/architecture.md](docs/architecture.md) | Level 2 — system design |
+| [docs/interfaces.md](docs/interfaces.md) | Level 2 — typed contracts, QoS, FSMs |
+| [docs/milestones.md](docs/milestones.md) | Milestone completion and MS-* traceability |
+| [docs/guidelines.md](docs/guidelines.md) | Coding standards and formatting |
+
+### Methodology (external)
+
+| Topic | Resource |
+| --- | --- |
+| SDD | [GitHub Spec Kit — spec-driven.md](https://github.com/github/spec-kit/blob/main/spec-driven.md) |
+| SDD + agents | [Author article — SDD and agentic AI](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/) |
+| V-model | [Teaching Agile — V-Model](https://teachingagile.com/sdlc/models/v-model) |
+| TDD | [Kent Beck — Canon TDD](https://newsletter.kentbeck.com/p/canon-tdd) |
+| ROS 2 | [ROS 2 documentation](https://docs.ros.org/) |
+
+---
+
+## Pre-merge checklist
+
+Every contributor (human or agent) must confirm before merge:
+
+- [ ] Spec is clear: intent, scope, and acceptance criteria addressed.
+- [ ] Work follows SDD → V-cycle → TDD at the appropriate levels.
+- [ ] `FR-*` / `SC-*` traceability updated when behavior changed.
+- [ ] `bash scripts/check/formatting.sh` passes.
+- [ ] `bash scripts/check/types.sh` passes.
+- [ ] `bash scripts/tests/unit.sh` passes (when ROS workspace available).
+- [ ] CI green on the PR branch.
+- [ ] Documentation updated when specs or public APIs changed.
+- [ ] No quality gate weakened to pass.
+- [ ] No secrets committed.
+- [ ] Public APIs typed and documented.
+
+If any item fails, fix forward—do not merge.
+
+---
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT License.
+By contributing, you agree that your contributions will be licensed under the
+MIT License.

--- a/README.md
+++ b/README.md
@@ -302,8 +302,9 @@ ros2 run plotjuggler plotjuggler
 
 ## Contributing
 
-Follow [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/guidelines.md](docs/guidelines.md).
-All contributions must follow the V-cycle and pass all CI checks.
+[CONTRIBUTING.md](CONTRIBUTING.md) is the single source of truth for humans and AI
+agents: SDD workflow, 4-level V-cycle stages, quality gates, and merge policy.
+Coding conventions live in [docs/guidelines.md](docs/guidelines.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ pip install numpy matplotlib pyyaml
 # 3. Install the fret package (pure-Python, no ROS)
 pip install -e . --no-deps
 
-# 4. Run the full A-to-B simulation (Milestone 3: planning + 50 Hz tracking)
-python3 scripts/simulate_milestone3_pipeline.py --output /tmp/sim_ms3
-
-# 5. Run the arc scenario (SC-05)
-bash scripts/simulate_arc.sh --output /tmp/sim_arc
+# 4. Run pure-Python validation (no ROS)
+pip install -e . --no-deps
+pytest tests/simulation/ -v
 ```
 
 For the full Gazebo SITL tutorial (requires Ubuntu 24.04 + ROS 2 Jazzy), see
@@ -66,7 +64,7 @@ For the full Gazebo SITL tutorial (requires Ubuntu 24.04 + ROS 2 Jazzy), see
 
 - [Simulation Tutorial (A-Z)](docs/simulation.md) — download, build, and run fretsim
 - [Project Roadmap](docs/roadmap.md) — phases 0–7
-- [Milestones](MILESTONES.md) — requirements table, completion status, MS-1 through MS-5
+- [Milestones](docs/milestones.md) — requirements table, completion status, MS-1 through MS-5
 - [Coding guidelines (authoritative)](docs/guidelines.md)
 - [Contributing guide](CONTRIBUTING.md)
 
@@ -129,13 +127,12 @@ PerceptionBridgeNode ──► /obstacle_cloud ──► SceneAcquisitionNode
 | `tests.yml` | PR, push | ROS 2 build, pytest, smoke tests |
 | `formatting.yml` | PR | Black, isort, clang-format |
 | `type_check.yml` | PR | mypy strict on `src/` |
-| `simulations_ci.yml` | PR (non-draft) | MS-1 through MS-4, SC-01, SC-05 pure-Python simulations |
-| `release.yml` | version tags | full suite |
+| `integration.yml` | PR (non-draft) | launch_testing inter-node scenarios |
 
 Run the same checks locally before pushing:
 
 ```bash
-bash scripts/pre_push.sh
+bash scripts/check/pre_push.sh
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,8 @@
 > - Functional requirements and operational envelope: [docs/requirements.md](requirements.md)
 > - Cross-module interface contracts, QoS assignments, node FSMs, error propagation: [docs/interfaces.md](interfaces.md)
 > - Named SITL validation scenarios: [docs/scenarios.md](scenarios.md)
-> - Coding standards and V-cycle: [docs/guidelines.md](guidelines.md)
+> - Development workflow (SDD, V-cycle): [CONTRIBUTING.md](../CONTRIBUTING.md)
+> - Coding standards: [docs/guidelines.md](guidelines.md)
 
 ## 1. UX / Developer Experience
 
@@ -168,10 +169,7 @@ Full QoS profile specifications are in [docs/interfaces.md](interfaces.md).
 | `src/fret/CMakeLists.txt` | 🔄 Evolve | Keep XACRO/mesh build loop; remove deleted node targets |
 | `src/fret/__init__.py` | ✅ Keep | Package marker |
 | `scripts/install.sh`, `build.sh`, `setup.sh` | ✅ Keep | Dev workflow scripts |
-| `scripts/benchmark_planner.py` | 🗑 Delete | References old implementation; to be rewritten later |
-| `scripts/validate_quality_gates.py` | 🔄 Evolve | Keep structure, update paths |
-| `scripts/scara/` (empty `__pycache__`) | 🗑 Delete | Empty artifact |
-| `docs/arco/` (entire folder) | 🗑 Delete | Old milestone specs, superseded by `docs/arco.md` |
+| `scripts/check/pre_push.sh` | ✅ Keep | Local CI gate runner |
 | `src/fret.egg-info/` | 🗑 Ignore | Build artifact, in `.gitignore` |
 
 ### Source tree

--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -235,93 +235,17 @@ Use modern C++ type practices:
 
 ## 6. Testing and the V-Cycle
 
-### V-Cycle Model
+Development workflow (SDD, 4-level V-cycle stages, constraint layers for AI agents,
+Definition of Ready/Done, and merge policy) is defined in
+[CONTRIBUTING.md](../CONTRIBUTING.md). **Do not duplicate** that material here.
 
-FRET uses a **4-level V-cycle** as its software development lifecycle (SDLC). Each level
-has a descending artifact (specification or implementation) and an ascending validation
-method. Both sides of each level must be completed before moving to the next.
+This section covers **test conventions** only.
 
-An imperative order (implement, add, fix...) always implies the full V-cycle — not just
-the code. Writing code without its matching test and documentation is a policy violation.
-
-```
-Level 1 — Functional specification  ◄──────────────►  Functional validation
-  Level 2 — Architecture & pipeline  ◄────────────►  Integration validation
-    Level 3 — Module stubs & public API  ◄────────►  Unit tests (CI/CD)
-      Level 4 — Implementation & private code  ◄──►  Tests pass (≥ 90% coverage)
-```
-
-### Level 1 — Functional Specifications
-
-**Descending artifact:** [docs/requirements.md](requirements.md) — numbered FR-xx
-requirements, operational envelope, performance bounds, and failure mode policies.
-
-**Ascending validation:** The scenario library in [docs/scenarios.md](scenarios.md).
-Each named scenario (SC-xx) has quantitative pass criteria derived directly from
-the FR-xx requirements. A scenario passes when all criteria are met simultaneously.
-
-**CI gate:** `integration_tests.yml` runs scenario-based `launch_testing` tests that
-assert the quantitative pass criteria automatically.
-
-**Rule:** No Level 2 work begins until [docs/requirements.md](requirements.md) is
-complete and all FR-xx requirements have a scenario or test that validates them.
-
-### Level 2 — Architecture and Pipeline Definition
-
-**Descending artifact:** [docs/architecture.md](architecture.md) +
-[docs/interfaces.md](interfaces.md). This includes: layer decomposition, data flow
-diagrams, interface contracts (typed data structures with invariants), QoS assignments
-per topic, node state machines, and error propagation paths.
-
-**Ascending validation:** Integration tests using `launch_testing`. These tests launch
-real nodes (or node stubs), inject messages at module boundaries, and assert that the
-contracts defined in [docs/interfaces.md](interfaces.md) are respected: correct message
-types, correct QoS, correct state machine transitions, correct error codes.
-
-**CI gate:** `integration_tests.yml` — see `.github/workflows/integration_tests.yml`.
-
-**Rule:** No Level 3 work begins until [docs/interfaces.md](interfaces.md) defines the
-full typed interface for every module boundary, including FSMs and error propagation.
-
-### Level 3 — Module Stubs and Unit Tests
-
-**Descending artifact:** Module files with complete public APIs: typed signatures,
-docstrings, `raise NotImplementedError` bodies. File layout mirrors `src/fret/`.
-
-**Ascending validation:** Unit tests in `tests/` created **at the same time** as the
-stubs. Each public method has a corresponding test that asserts the expected output for
-known inputs (derived from acceptance criteria) before any implementation exists. Tests
-for not-yet-implemented methods use `@pytest.mark.xfail(strict=True, raises=NotImplementedError)`.
-
-**CI gates:**
-- `tests.yml` — `pytest tests/ --cov=src/fret --cov-fail-under=90`
-- `type_check.yml` — `mypy src/ --strict`
-
-**Rule:** The stub + test file for a module are committed in the same commit. No Level 4
-work begins until the stub compiles cleanly under mypy and the xfail unit tests pass.
-
-### Level 4 — Implementation
-
-**Descending artifact:** Filled implementations replacing `NotImplementedError` stubs.
-Algorithms, data structures, and private utilities. Each private method added at this
-level also gets a fine-grained unit test.
-
-**Ascending validation:** Full test suite passes. The xfail markers are removed as
-implementations are completed. Coverage must remain ≥ 90%.
-
-**CI gates:** All workflows must be green: `formatting.yml`, `type_check.yml`,
-`tests.yml`, `integration_tests.yml`. The `release.yml` workflow runs the full suite
-on every version tag.
-
-**Rule:** A feature is not "done" until all four CI gates are green and the relevant
-scenario in [docs/scenarios.md](scenarios.md) passes end-to-end in SITL.
-
----
-
-### Python Test Conventions
+### Python test conventions
 
 - Framework: `pytest` (not `unittest`).
 - Location: `tests/` mirroring `src/fret/` (e.g., `tests/control/test_kinematics.py`).
+- Pure-Python simulation: `tests/simulation/` (no ROS runtime).
 - Integration tests: `tests/integration/` using `launch_testing`.
 - Mocks: use `unittest.mock` or `pytest-mock` to avoid ROS 2 runtime dependencies in
   unit tests. Integration tests may launch real nodes.
@@ -334,28 +258,28 @@ scenario in [docs/scenarios.md](scenarios.md) passes end-to-end in SITL.
   pytest tests/ --ignore=tests/integration --cov=src/fret --cov-fail-under=90
   ```
 
-### C++ Test Conventions
+### C++ test conventions
 
 - Framework: GTest for unit tests; `launch_testing` for integration tests.
 - Location: `src/fret/test/` for C++ unit tests.
 - Use `GTEST_SKIP()` with a descriptive message for not-yet-implemented tests.
 
-### Stub Marking Convention
+### Stub marking convention (Level 3 → Level 4)
 
 ```python
-# In the stub file (Level 3):
+# Level 3 — not yet implemented:
 @pytest.mark.xfail(strict=True, raises=NotImplementedError)
 def test_compute_jacobian_known_configuration():
     km = Kinematics(model="scara")
     result = km.compute_jacobian(np.array([0.0, 0.0, 0.1]))
     assert result.shape == (6, 3)
 
-# In the implementation file (Level 4), remove xfail when the method is filled:
+# Level 4 — remove xfail when implemented:
 def test_compute_jacobian_known_configuration():
     km = Kinematics(model="scara")
     result = km.compute_jacobian(np.array([0.0, 0.0, 0.1]))
     assert result.shape == (6, 3)
-    assert np.allclose(result[2, :], [0.0, 0.0, 1.0])  # known value
+    assert np.allclose(result[2, :], [0.0, 0.0, 1.0])
 ```
 
 ## 7. Configuration Parameters
@@ -486,86 +410,46 @@ Common corrections:
 
 ## 12. Pre-flight Checklist
 
-Before finishing **any** implementation task, all of the following must pass
-locally. This applies to both human contributors and AI agents.
+Before finishing **any** implementation task, run the consolidated gate script or
+equivalent steps from [CONTRIBUTING.md](../CONTRIBUTING.md):
 
 ```bash
-# 1. Build the workspace
-./scripts/build.sh
-
-# 2. Source the environment
-source /opt/ros/jazzy/setup.bash
-source install/setup.bash
-
-# 3. Python unit tests with coverage gate — all green, ≥ 90% coverage
-pytest tests/ --ignore=tests/integration -v --cov=src/fret --cov-fail-under=90
-
-# 4. Python type check — zero errors
-python -m mypy src/ --ignore-missing-imports --strict --exclude 'src/fret\.egg-info'
-
-# 5. Python formatting — zero issues
-python -m black --check --target-version py312 --line-length 79 src/
-python -m isort --check-only --line-length 79 src/
-
-# 6. C++ formatting — zero issues
-find src -name '*.cpp' -o -name '*.hpp' | xargs clang-format --dry-run --Werror
-
-# 7. Launch smoke tests — each launcher must start without errors
-timeout 10s ros2 launch fret view.py model:=scara
-timeout 10s ros2 launch fret sim.py model:=scara
+bash scripts/check/pre_push.sh
 ```
 
-All GitHub workflow checks (push **and** release) must also pass before
-opening or merging a pull request. The workflows are:
+With `--skip-ros`, smoke and integration gates are omitted (useful without a local
+ROS 2 install).
+
+Individual steps:
+
+```bash
+bash scripts/check/formatting.sh
+bash scripts/check/types.sh
+bash scripts/tests/unit.sh              # requires built workspace + ROS
+bash scripts/tests/smoke.sh             # requires ROS + xvfb
+bash scripts/tests/integration.sh       # requires ROS + xvfb
+```
+
+CI workflows (all required on pull requests):
 
 | Workflow | Trigger | Gate |
 |---|---|---|
 | `formatting.yml` | PR | Black, isort, clang-format |
 | `type_check.yml` | PR | mypy strict on `src/` |
-| `tests.yml` | PR | pytest ≥ 90% coverage + smoke tests |
-| `integration_tests.yml` | PR | launch_testing inter-node scenarios |
-| `release.yml` | Tag push | Full suite (all of the above) |
+| `tests.yml` | PR | pytest + smoke tests |
+| `integration.yml` | PR | `launch_testing` inter-node scenarios |
 
 ## 13. Git and Version Control
 
-### Commit Messages
+Commit messages, branch strategy, and pull request expectations are defined in
+[CONTRIBUTING.md](../CONTRIBUTING.md). Summary:
 
-Follow conventional commits format:
-
-```
-<type>(<scope>): <subject>
-
-<body>
-
-<footer>
-```
-
-Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
-
-Example:
-```
-feat(control): add Jacobian-based velocity control
-
-Implement numerical Jacobian computation and pseudoinverse-based
-inverse kinematics solver for real-time trajectory tracking.
-
-Closes #42
-```
-
-### Branch Strategy
-
-- `main` is protected; all changes via pull requests.
-- Feature branches: `feature/<name>`
-- Bugfix branches: `fix/<name>`
-- Keep branches focused and short-lived.
-
-### Pull Requests
-
-- Reference related issues.
-- Provide clear description of changes.
-- Ensure all CI checks pass.
-- Request review from maintainers.
+- Conventional Commits format (`feat`, `fix`, `docs`, `test`, …)
+- `main` is protected; changes via pull request
+- Focused branches; all CI checks must pass before merge
 
 ---
 
-These guidelines are mandatory for all development in FRET. When in doubt, refer to this document first, then ROS 2 official documentation.
+These guidelines are mandatory for all development in FRET. When in doubt, refer to
+[CONTRIBUTING.md](../CONTRIBUTING.md) for workflow, then this file for coding style,
+then ROS 2 official documentation.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -116,7 +116,7 @@ Kinematics engine.  This milestone validates the control stack in isolation.
 - `ControllerRosNode` subclasses `rclpy.node.Node` with full ROS wiring.
 - `StraightLineInjector` node reads `straight_line.yml` and publishes once.
 - `sitl.py` routes `scenario:=straight_line` to the injector (no planner).
-- **CI:** `bash scripts/simulate_milestone1.sh` passes (max EE error = 4.11 mm).
+- **CI:** `pytest tests/simulation/test_scenario_straight_line.py` passes.
 
 ### Key files
 
@@ -158,7 +158,7 @@ validation before wiring it to the control stack.
 - `PlannerNode` (L3) and `PlannerNodeRos` (L4 Action server) fully implemented.
 - `CSpaceChecker` (FK + KDTreeOccupancy) and `TrajectoryGenerator` implemented.
 - ARCO optional: linear-interpolation fallback when ARCO absent.
-- **CI:** `bash scripts/simulate_milestone2.sh` passes (EE error = 0.00 mm).
+- **CI:** `pytest tests/planning/` and integration tests for static reach pass.
 
 ### Key files
 
@@ -193,9 +193,8 @@ then tracked by the Jacobian controller.
 
 - `sitl.py` routes planner → controller via `/joint_trajectory` (no injector).
 - `PerceptionBridgeNode` feeds `/obstacle_cloud` → `SceneAcquisition` → `CSpaceChecker`.
-- **CI:** `python3 scripts/simulate_milestone3_pipeline.py` passes:
-  - Max EE error = **0.56 mm** (limit: 5 mm)
-  - No fault triggered
+- **CI:** `tests/integration/test_scenario_static_reach_full.py` and controller
+  tracking tests pass (max EE error **0.56 mm**, limit 5 mm).
 
 ### Key files
 
@@ -205,7 +204,7 @@ then tracked by the Jacobian controller.
 | `src/fret/config/scenarios/static_reach.yml` | Scenario config |
 | `tests/control/test_controller_node_tracking.py` | Tracking unit tests |
 | `tests/integration/test_scenario_static_reach_full.py` | End-to-end test |
-| `scripts/simulate_milestone3_pipeline.py` | CI simulation script |
+| `tests/integration/test_scenario_static_reach_full.py` | End-to-end integration test |
 
 ---
 
@@ -226,7 +225,7 @@ Total: **147 voxels**. Only voxels within `0.05 m ≤ r ≤ 0.60 m` are evaluate
 
 ### Acceptance criteria — ✅ All passed
 
-1. `scripts/validate_occupancy.py` runs without error.
+1. `pytest tests/scene/test_workspace_occupancy.py` passes.
 2. Matplotlib figure shows occupied (red) vs. free (grey) voxels as a 3-D scatter.
 3. `is_occupied(x, y, z)` returns correct values for known points.
 4. Unit test coverage for `WorkspaceOccupancyBuilder` ≥ 90 %.
@@ -234,18 +233,15 @@ Total: **147 voxels**. Only voxels within `0.05 m ≤ r ≤ 0.60 m` are evaluate
 ### Implementation summary
 
 - `WorkspaceOccupancyBuilder` pure-Python class in `src/fret/scene/workspace_occupancy.py`.
-- **CI:** `python3 scripts/simulate_milestone4_pipeline.py` passes:
-  - 19 occupied voxels, 59 free voxels
-  - `clearance(inside)` = −0.023 m, `clearance(free)` = +0.143 m
+- **CI:** `pytest tests/scene/test_workspace_occupancy.py` passes (19 occupied
+  voxels, 59 free voxels in golden configuration).
 
 ### Key files
 
 | File | Role |
 |---|---|
 | `src/fret/scene/workspace_occupancy.py` | WorkspaceOccupancyBuilder |
-| `scripts/validate_occupancy.py` | Standalone occupancy validation script |
-| `scripts/simulate_milestone4_pipeline.py` | CI simulation |
-| `tests/scene/test_workspace_occupancy.py` | 20 unit tests |
+| `tests/scene/test_workspace_occupancy.py` | Unit tests |
 
 ---
 
@@ -291,13 +287,9 @@ path at **constant z**, autonomously avoiding the pillars.
 - ✅ `src/fret/config/scenarios/pillar_avoidance.yml` — scenario YAML
 - ✅ `src/fret/config/perception.yaml` — cylinder obstacle entries added
 - ✅ `PerceptionBridgeNode` already supports cylinder surface sampling
-- ✅ `tests/scene/test_workspace_occupancy_pillars.py` — 13 unit tests
-- ✅ `tests/integration/test_scenario_pillar_avoidance.py` — 5 integration tests
-- ✅ `scripts/simulate_milestone5_pipeline.py` — CI pure-Python simulation
-- ✅ `scripts/simulate_milestone5.sh` — shell wrapper
-- ✅ `scripts/post_milestone5_report.sh` — PR report
-- ✅ MS-05 job added to `simulations_ci.yml`
-- ✅ MS-5 gate added to `pre_push.sh`
+- ✅ `tests/scene/test_workspace_occupancy_pillars.py` — pillar occupancy unit tests
+- ✅ `tests/integration/test_scenario_pillar_avoidance.py` — integration tests
+- ✅ MS-5 covered by `tests/integration/test_scenario_pillar_avoidance.py` in CI
 
 ---
 
@@ -338,6 +330,7 @@ MS-5  ✅  Pillar world + autonomous collision-aware motion at constant z
 - Interface contracts and QoS profiles: [`docs/interfaces.md`](docs/interfaces.md)
 - Architecture and data-flow diagrams: [`docs/architecture.md`](docs/architecture.md)
 - ARCO integration details and boundary: [`docs/arco.md`](docs/arco.md)
-- Coding standards and V-cycle: [`docs/guidelines.md`](docs/guidelines.md)
+- Coding standards: [`docs/guidelines.md`](docs/guidelines.md)
+- Development workflow (SDD, V-cycle): [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 - Simulation tutorial (A-Z): [`docs/simulation.md`](docs/simulation.md)
 

--- a/docs/modules/validation.md
+++ b/docs/modules/validation.md
@@ -10,7 +10,7 @@
 
 The validation module provides quantitative metrics and quality gates for evaluating
 the performance of FRET simulation runs. It is a pure-Python, ROS-independent layer
-used both in CI scripts and in post-processing analysis.
+used in pytest validation and post-processing analysis.
 
 ---
 
@@ -57,17 +57,12 @@ min_command_hz: 45.0
 
 ## CI Integration
 
-The validation module is used by all CI simulation scripts:
+Quality gates are evaluated in unit tests (`tests/test_quality_gates.py`) and
+in scenario/integration tests.
 
 ```bash
-python3 scripts/simulate_milestone3_pipeline.py --output /tmp/sim_ms3
-# Writes results.env with MAX_EE_ERROR_MM, RMS_EE_ERROR_MM, FAULT_TRIGGERED, ...
+pytest tests/test_metrics.py tests/test_quality_gates.py -v
 ```
-
-The `validate_quality_gates.py` script runs all gates against a completed run's
-`results.env` and exits non-zero if any gate fails.
-
----
 
 ## Tests
 
@@ -75,7 +70,6 @@ The `validate_quality_gates.py` script runs all gates against a completed run's
   smoothness, clearance, RMSE)
 - `tests/test_quality_gates.py` — unit tests for gate evaluation and report
   formatting
-- **Total: 71 tests**
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 This document lists the functional requirements for FRET at **Level 1** of the V-cycle.
 Requirements are traceable to scenarios in [docs/scenarios.md](scenarios.md) and validated
-by the integration test workflows in `.github/workflows/`.
+by integration tests in `tests/integration/` and `.github/workflows/integration.yml`.
 
 Format: `FR-<LAYER>-<NN>: The system shall...`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,8 +22,8 @@ The development was done on Ubuntu 24.04 under WSL on Windows 10.
 ### Phase 0 — Specification Completion ✅ *Complete*
 
 All items in this phase are prerequisites for writing any implementation code.
-They correspond to V-cycle Levels 1 and 2. See [docs/guidelines.md](guidelines.md)
-for the full V-cycle definition.
+They correspond to V-cycle Levels 1 and 2. See [CONTRIBUTING.md](../CONTRIBUTING.md)
+for the full SDD and V-cycle workflow.
 
 **Level 1 — Functional specifications and validation plan**
 
@@ -56,8 +56,7 @@ for the full V-cycle definition.
 - [x] `formatting.yml` — Black, isort, clang-format on every PR.
 - [x] `tests.yml` — build, unit tests (pytest, ≥ 90% coverage), smoke tests.
 - [x] `type_check.yml` — mypy strict mode on `src/`.
-- [x] `integration_tests.yml` — launch_testing inter-node scenario tests.
-- [x] `release.yml` — full suite on version tags.
+- [x] `integration.yml` — launch_testing inter-node scenario tests.
 
 ---
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -140,7 +140,7 @@ assertions using `launch_testing`. Each `test_scenario_<name>.py` file:
 3. Asserts quantitative pass criteria from the scenario definition above.
 4. Tears down the launch cleanly on pass or fail.
 
-The integration test workflow is defined in `.github/workflows/integration_tests.yml`.
+The integration test workflow is defined in `.github/workflows/integration.yml`.
 
 ---
 

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -77,100 +77,46 @@ source install/setup.bash
 
 ---
 
-## Step 5A — Pure-Python simulation (no Gazebo required)
+## Step 5A — Pure-Python validation (no Gazebo required)
 
-The pure-Python pipelines run all milestone algorithms end-to-end without Gazebo.
-They are the primary CI validation path.
+Milestone and scenario acceptance criteria are enforced by **pytest** under
+`tests/simulation/` and `tests/integration/` (the latter needs ROS; see Step 5B).
 
-### Milestone 1 — Straight-line tracking
-
-```bash
-bash scripts/simulate_milestone1.sh --output /tmp/sim_ms1
-```
-
-Expected output:
-```
-✅ Simulation PASSED — EE error ≤ 5 mm (max: 4.11 mm)
-```
-
-### Milestone 2 — Planning pipeline
+### Install the package
 
 ```bash
-bash scripts/simulate_milestone2.sh --output /tmp/sim_ms2
+pip install -e ".[dev]" --no-deps
 ```
 
-Expected output:
-```
-✅ Simulation PASSED - 2 waypoints, EE error = 0.00 mm
-```
-
-### Milestone 3 — Full end-to-end (planning + tracking)
-
-This is the primary A-to-B demonstration. The SCARA moves from
-`[0.0, 0.0, 0.0]` (home) to `[0.5, -0.3, 0.05]` over 20 seconds:
+### Milestone 1 — Straight-line tracking (MS-1)
 
 ```bash
-python3 scripts/simulate_milestone3_pipeline.py --output /tmp/sim_ms3
+pytest tests/simulation/test_scenario_straight_line.py -v
 ```
 
-Expected output:
-```
-=== Milestone 3 end-to-end simulation (planning + tracking) ===
-Start config  : [0.0, 0.0, 0.0]
-Goal  config  : [0.5, -0.3, 0.05]
-Sim duration  : 20 s  (1000 steps @ 50 Hz)
-Plot saved to /tmp/sim_ms3/tracking_plots.png
+Validates FR-CTL-02 (EE error ≤ 5 mm) and straight-line corridor constraints
+without a live ROS context.
 
---- Results ---
-  PLANNING_DURATION_S = 0.0001
-  N_WAYPOINTS = 2.0000
-  MAX_EE_ERROR_MM = 0.5594        ← well below 5 mm limit
-  RMS_EE_ERROR_MM = 0.5563
-  FAULT_TRIGGERED = 0.0000
+### Milestones 2–5 and scenarios
 
-✅ Simulation PASSED
-```
+| Milestone / scenario | Test location |
+|---|---|
+| MS-2 planning | `tests/planning/` |
+| MS-3 static reach | `tests/integration/test_scenario_static_reach_full.py` (ROS) |
+| MS-4 occupancy | `tests/scene/test_workspace_occupancy.py` |
+| MS-5 pillar avoidance | `tests/integration/test_scenario_pillar_avoidance.py` (ROS) |
+| SC-05 arc | `tests/planning/test_arc_injector.py` |
 
-The plot at `/tmp/sim_ms3/tracking_plots.png` shows:
-- EE path in Cartesian (x, y) — reference vs. executed
-- EE tracking error over time
-- Joint variables over time (q1, q2, q3)
-
-![MS-3 Tracking Plot](images/simulations/ms3_tracking.png)
-
-### Milestone 4 — Workspace occupancy map
+Run the full unit suite (no ROS):
 
 ```bash
-python3 scripts/simulate_milestone4_pipeline.py --output /tmp/sim_ms4
+pytest tests/ --ignore=tests/integration -v
 ```
 
-Expected output:
-```
-✅ [M4] PASSED — 19 occupied voxels, 59 free voxels
-```
-
-3-D scatter plot at `/tmp/sim_ms4/occupancy_map.png`.
-
-### SC-05 — Arc trajectory scenario
+Run integration scenarios (requires Steps 1–4 and `xvfb`):
 
 ```bash
-bash scripts/simulate_arc.sh --output /tmp/sim_arc
-```
-
-Expected output:
-```
-✅ Simulation PASSED — max EE error = 2.96 mm
-```
-
-### SC-01 — Static reach (full pipeline)
-
-```bash
-bash scripts/simulate_static_reach.sh --output /tmp/sim_sc01
-```
-
-Expected output:
-```
-✅ SC-01 static-reach PASSED — planning SUCCESS, no fault
+bash scripts/tests/integration.sh
 ```
 
 ---

--- a/scripts/check/pre_push.sh
+++ b/scripts/check/pre_push.sh
@@ -1,27 +1,21 @@
 #!/usr/bin/env bash
-# scripts/pre_push.sh
+# scripts/check/pre_push.sh
 #
 # Master pre-push validation — runs every required CI gate locally.
-# All AI agents and contributors MUST run this before pushing.
+# All contributors and AI agents should run this before pushing.
 #
-# Gates (all required unless --skip-ros is passed):
-#   1. check_formatting.sh        — black + isort + clang-format
-#   2. check_types.sh             — mypy strict
-#   3. simulate_milestone2.sh     — Milestone 2 pure-Python planning simulation (no ROS)
-#   4. simulate_milestone3.sh     — Milestone 3 pure-Python end-to-end simulation (no ROS)
-#   5. simulate_milestone4.sh     — Milestone 4 pure-Python workspace occupancy simulation (no ROS)
-#   6. simulate_milestone5.sh     — Milestone 5 pure-Python pillar-avoidance simulation (no ROS)
-#   7. simulate_arc.sh            — Arc scenario (SC-05) pure-Python simulation (no ROS)
-#   8. run_tests.sh               — pytest unit tests + quality gates  [requires ROS]
-#   9. run_smoke_tests.sh         — ROS 2 launch smoke tests            [requires ROS]
-#  10. simulate_static_reach.sh   — SC-01 full fretsim ROS 2 simulation [requires ROS]
+# Gates:
+#   1. scripts/check/formatting.sh   — black + isort + clang-format
+#   2. scripts/check/types.sh        — mypy strict
+#   3. scripts/tests/unit.sh         — pytest unit tests [requires ROS workspace]
+#   4. scripts/tests/smoke.sh        — ROS 2 launch smoke tests [requires ROS + xvfb]
+#   5. scripts/tests/integration.sh  — launch_testing scenarios [requires ROS + xvfb]
 #
 # Usage:
-#   bash scripts/pre_push.sh [--skip-ros]
+#   bash scripts/check/pre_push.sh [--skip-ros]
 #
 # Options:
-#   --skip-ros   Skip gates 7 and 8 that require a built ROS 2 workspace.
-#                Useful when running without a local ROS 2 install.
+#   --skip-ros   Skip gates 3–5 that require a built ROS 2 workspace.
 #
 # Exit code: 0 = all gates pass, 1 = at least one gate failed.
 
@@ -29,8 +23,8 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT_DIR="$(dirname "${SCRIPT_DIR}")"
-source "${SCRIPT_DIR}/common.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+source "${REPO_ROOT}/scripts/common.sh"
 
 SKIP_ROS=0
 
@@ -38,7 +32,7 @@ for arg in "$@"; do
     case "$arg" in
         --skip-ros) SKIP_ROS=1 ;;
         -h|--help)
-            sed -n '2,/^[^#]/{ /^#/{ s/^# \?//; p } }' "${BASH_SOURCE[0]}" | head -25
+            sed -n '2,/^[^#]/{ /^#/{ s/^# \?//; p } }' "${BASH_SOURCE[0]}" | head -20
             exit 0
             ;;
         *) fail "Unknown argument: ${arg}"; exit 1 ;;
@@ -67,24 +61,24 @@ run_gate() {
     fi
 }
 
-run_gate "Formatting (black + isort + clang-format)" "${SCRIPT_DIR}/check_formatting.sh"
-run_gate "Type check (mypy)"                          "${SCRIPT_DIR}/check_types.sh"
-run_gate "Milestone 2 simulation (no ROS)"            "${SCRIPT_DIR}/simulate_milestone2.sh"
-run_gate "Milestone 3 simulation (no ROS)"            "${SCRIPT_DIR}/simulate_milestone3.sh"
-run_gate "Milestone 4 simulation (no ROS)"            "${SCRIPT_DIR}/simulate_milestone4.sh"
-run_gate "Milestone 5 simulation (no ROS)"            "${SCRIPT_DIR}/simulate_milestone5.sh"
-run_gate "Arc scenario simulation (no ROS)"           "${SCRIPT_DIR}/simulate_arc.sh"
+run_gate "Formatting (black + isort + clang-format)" \
+    "${REPO_ROOT}/scripts/check/formatting.sh"
+run_gate "Type check (mypy)" \
+    "${REPO_ROOT}/scripts/check/types.sh"
 
 if [[ "${SKIP_ROS}" -eq 0 ]]; then
-    run_gate "Unit tests (pytest + coverage)"              "${SCRIPT_DIR}/run_tests.sh"
-    run_gate "Smoke tests (ROS 2 launch)"                  "${SCRIPT_DIR}/run_smoke_tests.sh"
-    run_gate "Static Reach SC-01 (full fretsim, ROS 2)"    "${SCRIPT_DIR}/simulate_static_reach.sh"
+    run_gate "Unit tests (pytest)" \
+        "${REPO_ROOT}/scripts/tests/unit.sh"
+    run_gate "Smoke tests (ROS 2 launch)" \
+        "${REPO_ROOT}/scripts/tests/smoke.sh"
+    run_gate "Integration tests (launch_testing)" \
+        "${REPO_ROOT}/scripts/tests/integration.sh"
 else
     warn "Skipping ROS-dependent gates (--skip-ros)."
-    warn "Run the following scripts manually once ROS 2 is available:"
-    warn "  ./scripts/run_tests.sh"
-    warn "  ./scripts/run_smoke_tests.sh"
-    warn "  ./scripts/simulate_static_reach.sh"
+    warn "Run manually when ROS 2 is available:"
+    warn "  bash scripts/tests/unit.sh"
+    warn "  bash scripts/tests/smoke.sh"
+    warn "  bash scripts/tests/integration.sh"
 fi
 
 echo ""

--- a/src/fret/config/benchmark.yaml
+++ b/src/fret/config/benchmark.yaml
@@ -4,7 +4,7 @@
 # against the quality gates.  All joint configurations use the SCARA RRP
 # convention: [joint_arm_0 (rad), joint_arm_1 (rad), joint_extension (m)].
 #
-# See scripts/validate_quality_gates.py for the runner and metric definitions.
+# See src/fret/validation/quality_gates.py and tests/test_quality_gates.py.
 
 benchmark:
   # Number of repeated runs per scenario.  3 is sufficient for deterministic

--- a/src/fret/config/scenarios/arc.yml
+++ b/src/fret/config/scenarios/arc.yml
@@ -19,7 +19,7 @@
 #   - /joint_commands published at >= 45 Hz for full duration.
 #   - No fault published on /controller_fault.
 #
-# See MILESTONES.md for full acceptance criteria.
+# See docs/milestones.md for full acceptance criteria.
 
 /**:
   ros__parameters:

--- a/src/fret/config/scenarios/pillar_avoidance.yml
+++ b/src/fret/config/scenarios/pillar_avoidance.yml
@@ -16,7 +16,7 @@
 #   - EE tracking error < 5 mm at all times.
 #   - No fault published on /controller_fault.
 #
-# See MILESTONES.md Milestone 5 for full acceptance criteria.
+# See docs/milestones.md Milestone 5 for full acceptance criteria.
 
 /**:
   ros__parameters:

--- a/src/fret/config/scenarios/straight_line.yml
+++ b/src/fret/config/scenarios/straight_line.yml
@@ -20,7 +20,7 @@
 #   - /joint_commands published at >= 45 Hz for full duration.
 #   - No fault published on /controller_fault.
 #
-# See MILESTONES.md — Milestone 1 for full acceptance criteria.
+# See docs/milestones.md — Milestone 1 for full acceptance criteria.
 
 /**:
   ros__parameters:

--- a/src/fret/control/controller_node.py
+++ b/src/fret/control/controller_node.py
@@ -114,7 +114,7 @@ class ControllerNode:
             path = path / "jacobian.yml"
         if not path.is_file():
             return
-        import yaml  # type: ignore[import-untyped]
+        import yaml
 
         try:
             with path.open() as fh:

--- a/src/fret/ros/perception_bridge.py
+++ b/src/fret/ros/perception_bridge.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import numpy as np
 import numpy.typing as npt
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 # ---------------------------------------------------------------------------
 # Pure-Python sampling helpers (no ROS dependency)

--- a/src/fret/ros/straight_line_injector.py
+++ b/src/fret/ros/straight_line_injector.py
@@ -180,7 +180,7 @@ def main(args: list[str] | None = None) -> None:  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------
-# Standalone helper (used by scripts/simulate_straight_line.py)
+# See tests/simulation/test_scenario_straight_line.py for pure-Python validation.
 # ---------------------------------------------------------------------------
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -6,5 +6,5 @@ standard unit test run via::
     pytest tests/ --ignore=tests/integration
 
 They are executed separately in the integration CI workflow
-(.github/workflows/integration_tests.yml).
+(.github/workflows/integration.yml).
 """

--- a/tests/simulation/test_scenario_straight_line.py
+++ b/tests/simulation/test_scenario_straight_line.py
@@ -8,7 +8,7 @@ tracking error ≤ 5 mm throughout the 3-second run.
 This test does NOT require a live ROS context — it runs the pure-Python
 logic layer only.
 
-Acceptance criteria checked here (MILESTONES.md Milestone 1):
+Acceptance criteria checked here (docs/milestones.md Milestone 1):
   AC-2 The EE moves from FK([0,0,0.10]) to FK([0.785,0,0.10]) in 3 s.
   AC-4 Maximum EE tracking error ≤ 5 mm at every timestep (FR-CTL-02).
   AC-5 No fault is triggered during the run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Rewrites `CONTRIBUTING.md` as the single development constitution for humans and AI agents, synthesizing the ecosystem methodology (website SDD article, luthier governance model, FRET 4-level V-cycle) with development stages, traceability, constraint layers, and quality gates.
- Slims `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` to entry points that point to `CONTRIBUTING.md` instead of duplicating V-cycle rules.
- Second commit removes fragmented/stale documentation: trims duplicated V-cycle content from `docs/guidelines.md`, fixes `scripts/check/pre_push.sh` to call existing scripts, and replaces references to removed `simulate_*` / `validate_*` scripts with actual pytest paths and correct CI workflow names.

## Ecosystem context documented

| Source | Contribution to this PR |
| --- | --- |
| [Website SDD article](https://alexandrelheinen.pages.dev/articles/2026-04-22-ai-agents-sdd/) | Three constraint layers, SDD V-cycle ↔ GitHub issues/PRs, agent local validation loop |
| [luthier](https://github.com/alexandrelheinen/luthier) | `CONTRIBUTING.md` as constitution, SDD + V-cycle + TDD ordering, DoR/DoD |
| [Freshy](https://freshy-25e.pages.dev/explore) | Listed as sibling project (private repo; portfolio on website) |
| FRET `docs/` | 4-level V-cycle mapped to `requirements.md`, `scenarios.md`, `architecture.md`, `interfaces.md` |

## Test plan

- [x] Verified no remaining references to `integration_tests.yml`, `simulations_ci.yml`, or deleted `scripts/simulate_*` paths
- [x] `scripts/check/pre_push.sh` paths resolve to existing files
- [ ] CI workflows (`formatting.yml`, `type_check.yml`, `tests.yml`, `integration.yml`) — pending on PR

## Commits

1. `docs: centralize SDD and V-cycle workflow in CONTRIBUTING.md`
2. `docs: remove stale references and fix validation tooling paths`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b57f9b9f-891c-4732-9b3c-0cacb90c8fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b57f9b9f-891c-4732-9b3c-0cacb90c8fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

