### PR TITLE
feat(control): PPP gantry kinematics module (T10-01)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,10 @@ jobs:
     env:
       ROS_DISTRO: jazzy
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,10 @@ jobs:
     env:
       ROS_DISTRO: jazzy
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "arco @ git+https://github.com/alexandrelheinen/arco.git@main",
 ]
 
+[project.optional-dependencies]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
@@ -16,6 +17,11 @@ dev = [
     "black>=24.0",
     "isort>=5.13",
     "mypy>=1.10",
+]
+sim = [
+    "mujoco>=3.2",
+    "imageio>=2.34",
+    "imageio-ffmpeg>=0.5",
 ]
 
 [project.scripts]

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Headless MuJoCo video renderer for FRET showcase scenarios.
+
+Renders an MP4 of the PPP gantry traversing a warehouse preview scene
+without requiring a ROS runtime.  Intended for README / article assets
+(releases.md V10-6, T10-07).
+
+Example::
+
+    python3 scripts/render_mujoco.py --scenario ppp_warehouse -o /tmp/v10.mp4
+    ./scripts/video.sh --model ppp --duration 30
+
+Dependencies (not required for core FRET algorithms)::
+
+    pip install mujoco imageio imageio-ffmpeg
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import numpy.typing as npt
+
+# PPP joint limits at 1:5 scale (see mjcf/ppp_warehouse.xml).
+_PPP_LIMITS = np.array(
+    [
+        [0.0, 12.0],
+        [0.0, 4.0],
+        [0.0, 3.0],
+    ],
+    dtype=np.float64,
+)
+
+# Pick-and-place preview path in joint space (x, y, z) [m].
+_PPP_WAREHOUSE_WAYPOINTS: list[npt.NDArray[np.float64]] = [
+    np.array([2.0, 1.0, 2.4]),
+    np.array([2.0, 1.0, 0.95]),
+    np.array([2.0, 1.0, 2.2]),
+    np.array([4.5, 1.0, 2.2]),
+    np.array([6.0, 2.6, 2.2]),
+    np.array([9.5, 3.2, 2.2]),
+    np.array([10.5, 3.2, 0.95]),
+    np.array([10.5, 3.2, 2.4]),
+]
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_mjcf_path(
+    model: str, scenario: str, mjcf_override: Path | None
+) -> Path:
+    """Return the MJCF file path for the requested model/scenario pair.
+
+    Args:
+        model: Robot model name (e.g. ``ppp``).
+        scenario: Scenario stem (e.g. ``ppp_warehouse``).
+        mjcf_override: Optional explicit MJCF path.
+
+    Returns:
+        Resolved path to an existing MJCF file.
+
+    Raises:
+        FileNotFoundError: If no MJCF file can be located.
+        ValueError: If model/scenario combination is unsupported.
+    """
+    if mjcf_override is not None:
+        if not mjcf_override.is_file():
+            raise FileNotFoundError(f"MJCF not found: {mjcf_override}")
+        return mjcf_override
+
+    if model == "ppp" and scenario in {"ppp_warehouse", "ppp"}:
+        candidate = _project_root() / "src/fret/mjcf/ppp_warehouse.xml"
+        if candidate.is_file():
+            return candidate
+
+    raise ValueError(
+        f"Unsupported model/scenario combination: model={model!r}, "
+        f"scenario={scenario!r}"
+    )
+
+
+def interpolate_waypoints(
+    waypoints: list[npt.NDArray[np.float64]],
+    duration_s: float,
+    fps: int,
+) -> npt.NDArray[np.float64]:
+    """Sample a smooth joint-space trajectory through waypoints.
+
+    Uses cubic ease-in-out segments between consecutive waypoints so the
+    gantry accelerates and decelerates at each segment boundary.
+
+    Args:
+        waypoints: List of joint configurations, each shape ``(3,)``.
+        duration_s: Total clip duration in seconds.
+        fps: Output frame rate.
+
+    Returns:
+        Array of shape ``(n_frames, 3)`` with joint positions per frame.
+    """
+    if len(waypoints) < 2:
+        raise ValueError("At least two waypoints are required")
+
+    n_frames = max(2, int(round(duration_s * fps)))
+    segment_count = len(waypoints) - 1
+    frames_per_segment = n_frames / segment_count
+    trajectory = np.zeros((n_frames, 3), dtype=np.float64)
+
+    for frame_idx in range(n_frames):
+        global_t = frame_idx / (n_frames - 1)
+        seg_float = global_t * segment_count
+        seg_idx = min(int(seg_float), segment_count - 1)
+        local_t = seg_float - seg_idx
+        # Smoothstep ease-in-out within each segment.
+        alpha = local_t * local_t * (3.0 - 2.0 * local_t)
+        q0 = waypoints[seg_idx]
+        q1 = waypoints[seg_idx + 1]
+        trajectory[frame_idx] = (1.0 - alpha) * q0 + alpha * q1
+
+    return np.clip(trajectory, _PPP_LIMITS[:, 0], _PPP_LIMITS[:, 1])
+
+
+def _require_mujoco() -> tuple[object, object]:
+    """Import MuJoCo and imageio, raising a clear error when missing."""
+    try:
+        import mujoco  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise SystemExit(
+            "MuJoCo is required for video rendering.\n"
+            "Install with: pip install mujoco imageio imageio-ffmpeg"
+        ) from exc
+    try:
+        import imageio.v3 as iio  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise SystemExit(
+            "imageio is required for MP4 export.\n"
+            "Install with: pip install imageio imageio-ffmpeg"
+        ) from exc
+    return mujoco, iio
+
+
+def _set_slide_joint(
+    mujoco: object,
+    model: object,
+    data: object,
+    joint_name: str,
+    value: float,
+) -> None:
+    """Write a scalar position into a slide joint's qpos slot."""
+    joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, joint_name)
+    if joint_id < 0:
+        raise ValueError(f"Joint not found in MJCF: {joint_name}")
+    qpos_adr = model.jnt_qposadr[joint_id]
+    data.qpos[qpos_adr] = value
+
+
+def render_video(
+    mjcf_path: Path,
+    output_path: Path,
+    *,
+    duration_s: float = 30.0,
+    fps: int = 30,
+    width: int = 1280,
+    height: int = 720,
+    camera: str = "overview",
+    waypoints: list[npt.NDArray[np.float64]] | None = None,
+) -> Path:
+    """Render a headless MuJoCo MP4 for the PPP warehouse preview.
+
+    Args:
+        mjcf_path: Path to the MJCF scene file.
+        output_path: Destination ``.mp4`` path.
+        duration_s: Clip length in seconds (default 30 for V10-6).
+        fps: Frame rate.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        camera: Named MuJoCo camera in the MJCF.
+        waypoints: Optional joint-space path; defaults to warehouse demo.
+
+    Returns:
+        The output path (created parent directories as needed).
+    """
+    mujoco, iio = _require_mujoco()
+    path_waypoints = (
+        waypoints if waypoints is not None else _PPP_WAREHOUSE_WAYPOINTS
+    )
+    trajectory = interpolate_waypoints(path_waypoints, duration_s, fps)
+
+    model = mujoco.MjModel.from_xml_path(str(mjcf_path))
+    data = mujoco.MjData(model)
+    renderer = mujoco.Renderer(model, height=height, width=width)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    frames: list[npt.NDArray[np.uint8]] = []
+
+    joint_names = ("joint_x", "joint_y", "joint_z")
+    for q in trajectory:
+        for idx, name in enumerate(joint_names):
+            _set_slide_joint(mujoco, model, data, name, float(q[idx]))
+        mujoco.mj_forward(model, data)
+        renderer.update_scene(data, camera=camera)
+        frames.append(renderer.render().copy())
+
+    renderer.close()
+    iio.imwrite(
+        output_path,
+        np.stack(frames, axis=0),
+        fps=fps,
+        codec="libx264",
+        pixelformat="yuv420p",
+    )
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Render a headless MuJoCo MP4 for FRET showcase scenarios.",
+    )
+    parser.add_argument(
+        "--model",
+        default="ppp",
+        help="Robot model name (default: ppp)",
+    )
+    parser.add_argument(
+        "--scenario",
+        default="ppp_warehouse",
+        help="Scenario stem (default: ppp_warehouse)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=Path("/tmp/fret_ppp_warehouse.mp4"),
+        help="Output MP4 path (default: /tmp/fret_ppp_warehouse.mp4)",
+    )
+    parser.add_argument(
+        "--mjcf",
+        type=Path,
+        default=None,
+        help="Override MJCF path (default: resolved from model/scenario)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=30.0,
+        help="Clip duration in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=30,
+        help="Frame rate (default: 30)",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=1280,
+        help="Frame width (default: 1280)",
+    )
+    parser.add_argument(
+        "--height",
+        type=int,
+        default=720,
+        help="Frame height (default: 720)",
+    )
+    parser.add_argument(
+        "--camera",
+        default="overview",
+        help="MJCF camera name (default: overview)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    mjcf_path = resolve_mjcf_path(args.model, args.scenario, args.mjcf)
+    output = render_video(
+        mjcf_path,
+        args.output,
+        duration_s=args.duration,
+        fps=args.fps,
+        width=args.width,
+        height=args.height,
+        camera=args.camera,
+    )
+    print(f"Wrote {output} ({args.duration:.1f}s @ {args.fps} fps)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/video.sh
+++ b/scripts/video.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Render a headless MuJoCo MP4 for FRET showcase scenarios (v1.0 PPP).
+#
+# Thin wrapper around scripts/render_mujoco.py.  Requires optional deps:
+#   pip install mujoco imageio imageio-ffmpeg
+#
+# Examples:
+#   ./scripts/video.sh
+#   ./scripts/video.sh --model ppp --scenario ppp_warehouse -o /tmp/v10.mp4
+#   ./scripts/video.sh --duration 15 --fps 24 --width 1920 --height 1080
+#
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "${SCRIPT_DIR}/render_mujoco.py" "$@"

--- a/src/fret/CMakeLists.txt
+++ b/src/fret/CMakeLists.txt
@@ -132,6 +132,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/worlds)
   )
 endif()
 
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/mjcf)
+  install(DIRECTORY mjcf
+    DESTINATION share/${PROJECT_NAME}
+  )
+endif()
+
 # ---------------------------------------------------------------------------
 # Environment hook (adds src/ to PYTHONPATH)
 # ---------------------------------------------------------------------------

--- a/src/fret/control/kinematics.py
+++ b/src/fret/control/kinematics.py
@@ -1,18 +1,22 @@
-"""Kinematics engine for the FRET SCARA RRP robot model.
+"""Per-model kinematics facade for FRET robot models.
 
-Provides closed-form forward kinematics (FK), analytical inverse kinematics
-(IK), and the geometric Jacobian for the SCARA RRP (3-DOF) manipulator.
-Parameters are extracted directly from ``src/fret/urdf/scara.xacro``.
+Dispatches to model-specific engines:
 
-Satisfies requirements FR-CTL-02 and FR-PLN-02.
+- ``"scara"`` — SCARA RRP (bootstrap, v0.9)
+- ``"ppp"`` — PPP gantry (v1.0)
+
+Satisfies requirements FR-SYS-01, FR-CTL-02, and FR-PLN-02.
 """
 
 from __future__ import annotations
 
 import math
+from typing import Protocol
 
 import numpy as np
 import numpy.typing as npt
+
+from fret.control.kinematics_ppp import PPPKinematics
 
 # ---------------------------------------------------------------------------
 # SCARA model constants (source: src/fret/urdf/scara.xacro)
@@ -44,25 +48,37 @@ _JOINT_NAMES: list[str] = [
 ]
 
 
-class Kinematics:
-    """Closed-form FK, IK, and Jacobian for the FRET SCARA RRP model.
+class _KinematicsBackend(Protocol):
+    """Structural protocol shared by per-model kinematics engines."""
 
-    A single ``Kinematics`` instance is shared between ``CSpaceChecker``
-    (planning layer) and ``StateEstimator`` (control layer) to avoid
-    redundant computation.
+    @property
+    def dof(self) -> int: ...
 
-    Args:
-        model: Robot model name.  Only ``"scara"`` is supported in Phase 1–2.
+    @property
+    def joint_names(self) -> list[str]: ...
 
-    Raises:
-        ValueError: If ``model`` is not ``"scara"``.
-    """
+    @property
+    def joint_limits(self) -> npt.NDArray[np.float64]: ...
 
-    def __init__(self, model: str) -> None:
-        if model != "scara":
-            raise ValueError(
-                f"Unsupported model '{model}'. Only 'scara' is supported."
-            )
+    def forward_kinematics(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]: ...
+
+    def inverse_kinematics(
+        self,
+        ee_pose: npt.NDArray[np.float64],
+        seed: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]: ...
+
+    def jacobian(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]: ...
+
+
+class _ScaraKinematics:
+    """Closed-form FK, IK, and Jacobian for the FRET SCARA RRP model."""
+
+    def __init__(self) -> None:
         self._l1: float = _L1
         self._l2: float = _L2
         self._z_base: float = _Z_BASE
@@ -284,3 +300,67 @@ class Kinematics:
             ],
             dtype=np.float64,
         )
+
+
+_SUPPORTED_MODELS: frozenset[str] = frozenset({"scara", "ppp"})
+
+
+class Kinematics:
+    """Facade for per-model kinematics engines (FR-SYS-01).
+
+    A single ``Kinematics`` instance is shared between ``CSpaceChecker``
+    (planning layer) and ``StateEstimator`` (control layer) to avoid
+    redundant computation.
+
+    Args:
+        model: Robot model name — ``"scara"`` or ``"ppp"``.
+
+    Raises:
+        ValueError: If ``model`` is not supported.
+    """
+
+    def __init__(self, model: str) -> None:
+        if model not in _SUPPORTED_MODELS:
+            supported = ", ".join(sorted(_SUPPORTED_MODELS))
+            raise ValueError(
+                f"Unsupported model '{model}'. Supported models: {supported}"
+            )
+        if model == "scara":
+            self._impl: _KinematicsBackend = _ScaraKinematics()
+        else:
+            self._impl = PPPKinematics()
+
+    @property
+    def dof(self) -> int:
+        """Number of degrees of freedom for the active model."""
+        return self._impl.dof
+
+    @property
+    def joint_names(self) -> list[str]:
+        """URDF joint names in kinematic-chain order (length ``DOF``)."""
+        return self._impl.joint_names
+
+    @property
+    def joint_limits(self) -> npt.NDArray[np.float64]:
+        """Joint limits array, shape ``(DOF, 2)`` — columns: lower, upper."""
+        return self._impl.joint_limits
+
+    def forward_kinematics(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Compute the homogeneous end-effector pose from joint positions."""
+        return self._impl.forward_kinematics(joint_positions)
+
+    def inverse_kinematics(
+        self,
+        ee_pose: npt.NDArray[np.float64],
+        seed: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Compute a joint configuration that achieves the given EE pose."""
+        return self._impl.inverse_kinematics(ee_pose, seed=seed)
+
+    def jacobian(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the geometric Jacobian at the given configuration."""
+        return self._impl.jacobian(joint_positions)

--- a/src/fret/control/kinematics_ppp.py
+++ b/src/fret/control/kinematics_ppp.py
@@ -1,0 +1,157 @@
+"""Kinematics engine for the FRET PPP gantry robot model (v1.0).
+
+The PPP gantry has three prismatic joints (X, Y, Z).  Configuration space is
+identical to Cartesian workspace position: ``q = (x, y, z)`` in metres.
+
+Parameters are defined in ``docs/robots/ppp.md``.
+
+Satisfies requirements FR-SYS-01, FR-CTL-02, and FR-PLN-02.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+#: Joint limits [lower, upper] in metres (source: docs/robots/ppp.md).
+_X_LIMITS: tuple[float, float] = (0.0, 60.0)
+_Y_LIMITS: tuple[float, float] = (0.0, 20.0)
+_Z_LIMITS: tuple[float, float] = (0.0, 6.0)
+
+#: URDF joint names in kinematic-chain order.
+_JOINT_NAMES: list[str] = ["joint_x", "joint_y", "joint_z"]
+
+
+class PPPKinematics:
+    """Identity-map FK, IK, and Jacobian for the PPP gantry model.
+
+    Forward kinematics maps joint configuration directly to end-effector
+    position in the ``world`` frame.  Inverse kinematics is the inverse map
+    with joint-limit enforcement.
+
+    A ``PPPKinematics`` instance is interchangeable with ``Kinematics(model="ppp")``.
+    """
+
+    def __init__(self) -> None:
+        self._limits: npt.NDArray[np.float64] = np.array(
+            [_X_LIMITS, _Y_LIMITS, _Z_LIMITS],
+            dtype=np.float64,
+        )
+
+    @property
+    def dof(self) -> int:
+        """Number of degrees of freedom (3 for the PPP gantry)."""
+        return 3
+
+    @property
+    def joint_names(self) -> list[str]:
+        """URDF joint names in kinematic-chain order (length ``DOF``)."""
+        return list(_JOINT_NAMES)
+
+    @property
+    def joint_limits(self) -> npt.NDArray[np.float64]:
+        """Joint limits array, shape ``(DOF, 2)`` — columns: lower, upper [m]."""
+        return self._limits.copy()
+
+    def forward_kinematics(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Compute the homogeneous end-effector pose from joint positions.
+
+        The PPP FK is the identity map: ``p_ee = q``.
+
+        Args:
+            joint_positions: Joint configuration, shape ``(DOF,)`` [m].
+
+        Returns:
+            4×4 homogeneous transformation matrix (dtype ``float64``).
+
+        Raises:
+            ValueError: If ``joint_positions.shape != (DOF,)``.
+        """
+        if joint_positions.shape != (self.dof,):
+            raise ValueError(
+                f"Expected shape ({self.dof},), got {joint_positions.shape}"
+            )
+        x = float(joint_positions[0])
+        y = float(joint_positions[1])
+        z = float(joint_positions[2])
+        return np.array(
+            [
+                [1.0, 0.0, 0.0, x],
+                [0.0, 1.0, 0.0, y],
+                [0.0, 0.0, 1.0, z],
+                [0.0, 0.0, 0.0, 1.0],
+            ],
+            dtype=np.float64,
+        )
+
+    def inverse_kinematics(
+        self,
+        ee_pose: npt.NDArray[np.float64],
+        seed: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Compute the joint configuration for the given EE pose.
+
+        The PPP IK is the inverse identity map: ``q = p_ee``.  Targets outside
+        the operational envelope raise ``RuntimeError``.
+
+        Args:
+            ee_pose: 4×4 homogeneous pose matrix in the ``world`` frame.
+            seed: Optional initial guess, shape ``(DOF,)``.  Unused.
+
+        Returns:
+            Joint configuration, shape ``(DOF,)`` [m].
+
+        Raises:
+            RuntimeError: If the target position is outside joint limits.
+        """
+        del seed  # unused — closed-form IK
+        x_t = float(ee_pose[0, 3])
+        y_t = float(ee_pose[1, 3])
+        z_t = float(ee_pose[2, 3])
+        limits = self._limits
+        coords = (x_t, y_t, z_t)
+        for idx, value in enumerate(coords):
+            lower = float(limits[idx, 0])
+            upper = float(limits[idx, 1])
+            if not (lower - 1e-9 <= value <= upper + 1e-9):
+                raise RuntimeError(
+                    f"Target axis {idx}={value:.4f} m outside limits "
+                    f"[{lower}, {upper}]"
+                )
+        return np.array([x_t, y_t, z_t], dtype=np.float64)
+
+    def jacobian(
+        self, joint_positions: npt.NDArray[np.float64]
+    ) -> npt.NDArray[np.float64]:
+        """Return the geometric Jacobian at the given configuration.
+
+        Prismatic joints aligned with world X, Y, Z produce a constant
+        identity linear block with zero angular rows.
+
+        Args:
+            joint_positions: Joint configuration, shape ``(DOF,)``.
+
+        Returns:
+            Geometric Jacobian, shape ``(6, DOF)``, dtype ``float64``.
+
+        Raises:
+            ValueError: If ``joint_positions.shape != (DOF,)``.
+        """
+        if joint_positions.shape != (self.dof,):
+            raise ValueError(
+                f"Expected shape ({self.dof},), got {joint_positions.shape}"
+            )
+        # Jacobian is configuration-independent for PPP prismatic axes.
+        return np.array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ],
+            dtype=np.float64,
+        )

--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -1,0 +1,70 @@
+<mujoco model="ppp_warehouse">
+  <!--
+    PPP gantry preview scene for MuJoCo headless video (SC-v10 / T10-02).
+
+    Uses a 1:5 scale of the v1.0 operational envelope for readable visuals:
+      X 0–12 m, Y 0–4 m, Z 0–3 m  (maps to joint_x/y/z limits in MJCF).
+
+    Joint names match fret.control.kinematics_ppp.PPPKinematics.
+  -->
+  <compiler angle="degree" coordinate="local"/>
+  <option timestep="0.002" gravity="0 0 -9.81" integrator="implicitfast"/>
+
+  <visual>
+    <headlight ambient="0.45 0.45 0.45" diffuse="0.85 0.85 0.85" specular="0.2 0.2 0.2"/>
+    <rgba haze="0.9 0.92 0.95 1"/>
+    <global azimuth="140" elevation="-25" offwidth="1920" offheight="1080"/>
+  </visual>
+
+  <asset>
+    <texture name="grid" type="2d" builtin="checker" rgb1="0.92 0.93 0.95" rgb2="0.78 0.80 0.84" width="512" height="512"/>
+    <material name="floor" texture="grid" texrepeat="6 6" reflectance="0.05"/>
+    <material name="gantry" rgba="0.25 0.45 0.75 1"/>
+    <material name="rail" rgba="0.35 0.35 0.40 1"/>
+    <material name="cargo" rgba="0.92 0.62 0.12 1"/>
+    <material name="obstacle" rgba="0.55 0.55 0.58 1"/>
+    <material name="goal" rgba="0.20 0.75 0.35 0.35"/>
+  </asset>
+
+  <worldbody>
+    <light pos="6 2 8" dir="-0.3 -0.2 -1" diffuse="1 1 1"/>
+    <light pos="-2 6 6" dir="0.5 -0.8 -1" diffuse="0.6 0.6 0.7"/>
+
+    <geom name="floor" type="plane" size="8 6 0.1" material="floor"/>
+
+    <!-- Static warehouse boxes (scaled layout inspired by ARCO ppp.yml). -->
+    <geom name="obs_a" type="box" pos="4.0 1.2 0.6" size="0.8 0.6 0.6" material="obstacle"/>
+    <geom name="obs_b" type="box" pos="6.5 2.8 0.5" size="0.7 0.7 0.5" material="obstacle"/>
+    <geom name="obs_c" type="box" pos="8.0 1.0 0.9" size="0.6 0.5 0.9" material="obstacle"/>
+    <geom name="goal_zone" type="box" pos="10.5 3.2 0.05" size="0.9 0.9 0.05" material="goal" contype="0" conaffinity="0"/>
+
+    <!-- PPP gantry: nested prismatic joints along world X, Y, Z. -->
+    <body name="gantry_base" pos="0 0 0">
+      <geom name="base_rail_y" type="box" pos="6 2 0.08" size="6.2 0.12 0.08" material="rail"/>
+
+      <body name="x_carriage" pos="0 0 0.2">
+        <joint name="joint_x" type="slide" axis="1 0 0" range="0 12" damping="80"/>
+        <geom name="x_rail" type="box" pos="0 0 0" size="0.12 2.2 0.08" material="rail"/>
+
+        <body name="y_carriage" pos="0 0 0.15">
+          <joint name="joint_y" type="slide" axis="0 1 0" range="0 4" damping="80"/>
+          <geom name="y_carriage_geom" type="box" size="0.18 0.18 0.06" material="gantry"/>
+
+          <body name="z_hoist" pos="0 0 0.12">
+            <joint name="joint_z" type="slide" axis="0 0 1" range="0 3" damping="120"/>
+            <geom name="z_column" type="box" size="0.08 0.08 0.5" pos="0 0 0.25" material="gantry"/>
+            <geom name="ee_plate" type="box" size="0.25 0.25 0.04" pos="0 0 0.55" material="gantry"/>
+
+            <!-- Cargo box welded to EE (magnetic grasp preview). -->
+            <body name="cargo" pos="0 0 0.75">
+              <geom name="cargo_box" type="box" size="0.25 0.25 0.25" material="cargo" mass="2.0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+
+    <!-- Fixed camera used by the headless renderer. -->
+    <camera name="overview" pos="13 6 7" xyaxes="-0.85 -0.52 0 0.25 -0.41 0.88" fovy="45"/>
+  </worldbody>
+</mujoco>

--- a/tests/control/test_kinematics_ppp.py
+++ b/tests/control/test_kinematics_ppp.py
@@ -1,0 +1,155 @@
+"""Tests for fret.control.Kinematics — PPP gantry model (v1.0).
+
+Acceptance criteria (T10-01, FR-SYS-01, FR-CTL-02, FR-PLN-02):
+  - ``Kinematics(model="ppp")`` constructs with DOF 3.
+  - ``joint_names`` returns PPP prismatic joint names.
+  - ``joint_limits`` match the v1.0 operational envelope.
+  - FK/IK implement the identity map ``q ≡ p_ee``.
+  - ``jacobian(q)`` has shape ``(6, 3)`` with prismatic columns.
+  - Wrong-shape input raises ``ValueError``.
+  - Out-of-envelope IK targets raise ``RuntimeError``.
+
+PPP model parameters (from docs/robots/ppp.md):
+  Workspace: X [0, 60], Y [0, 20], Z [0, 6] m
+  Joint names: joint_x, joint_y, joint_z
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fret.control.kinematics import Kinematics
+
+_DOF = 3
+_POS_TOL_M = 0.001  # 1 mm — identity map should be exact within float noise
+
+_X_LIMITS = (0.0, 60.0)
+_Y_LIMITS = (0.0, 20.0)
+_Z_LIMITS = (0.0, 6.0)
+
+
+def test_construction() -> None:
+    Kinematics(model="ppp")
+
+
+def test_dof_is_three() -> None:
+    k = Kinematics(model="ppp")
+    assert k.dof == _DOF
+
+
+def test_joint_names() -> None:
+    k = Kinematics(model="ppp")
+    assert k.joint_names == ["joint_x", "joint_y", "joint_z"]
+
+
+def test_joint_limits_shape() -> None:
+    k = Kinematics(model="ppp")
+    limits = k.joint_limits
+    assert limits.shape == (_DOF, 2)
+    assert np.all(limits[:, 0] < limits[:, 1])
+
+
+def test_joint_limits_values() -> None:
+    k = Kinematics(model="ppp")
+    lim = k.joint_limits
+    assert lim[0, 0] == pytest.approx(_X_LIMITS[0])
+    assert lim[0, 1] == pytest.approx(_X_LIMITS[1])
+    assert lim[1, 0] == pytest.approx(_Y_LIMITS[0])
+    assert lim[1, 1] == pytest.approx(_Y_LIMITS[1])
+    assert lim[2, 0] == pytest.approx(_Z_LIMITS[0])
+    assert lim[2, 1] == pytest.approx(_Z_LIMITS[1])
+
+
+def test_forward_kinematics_returns_4x4() -> None:
+    k = Kinematics(model="ppp")
+    T = k.forward_kinematics(np.array([1.0, 2.0, 3.0]))
+    assert T.shape == (4, 4)
+    np.testing.assert_array_almost_equal(T[3, :], [0.0, 0.0, 0.0, 1.0])
+
+
+def test_forward_kinematics_identity_position() -> None:
+    """FK maps joint positions directly to EE position (identity map)."""
+    k = Kinematics(model="ppp")
+    q = np.array([10.0, 5.0, 2.5])
+    T = k.forward_kinematics(q)
+    assert T[0, 3] == pytest.approx(10.0)
+    assert T[1, 3] == pytest.approx(5.0)
+    assert T[2, 3] == pytest.approx(2.5)
+
+
+def test_forward_kinematics_identity_rotation() -> None:
+    k = Kinematics(model="ppp")
+    T = k.forward_kinematics(np.array([1.0, 1.0, 1.0]))
+    np.testing.assert_array_almost_equal(T[:3, :3], np.eye(3))
+
+
+def test_jacobian_shape() -> None:
+    k = Kinematics(model="ppp")
+    J = k.jacobian(np.array([1.0, 2.0, 3.0]))
+    assert J.shape == (6, _DOF)
+
+
+def test_jacobian_prismatic_columns() -> None:
+    """Each prismatic joint maps unit joint velocity to a world-axis linear twist."""
+    k = Kinematics(model="ppp")
+    J = k.jacobian(np.array([5.0, 5.0, 3.0]))
+    expected = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    np.testing.assert_array_almost_equal(J, expected)
+
+
+def test_ik_round_trip() -> None:
+    k = Kinematics(model="ppp")
+    q_ref = np.array([15.0, 8.0, 4.0])
+    T_target = k.forward_kinematics(q_ref)
+    q_ik = k.inverse_kinematics(T_target)
+    T_recovered = k.forward_kinematics(q_ik)
+    position_error = np.linalg.norm(T_recovered[:3, 3] - T_target[:3, 3])
+    assert position_error < _POS_TOL_M
+
+
+def test_ik_multiple_configurations() -> None:
+    k = Kinematics(model="ppp")
+    configs = [
+        [0.0, 0.0, 0.0],
+        [30.0, 10.0, 3.0],
+        [60.0, 20.0, 6.0],
+        [5.5, 12.3, 1.7],
+    ]
+    for q_ref_list in configs:
+        q_ref = np.array(q_ref_list)
+        T_target = k.forward_kinematics(q_ref)
+        q_ik = k.inverse_kinematics(T_target)
+        T_recovered = k.forward_kinematics(q_ik)
+        err = np.linalg.norm(T_recovered[:3, 3] - T_target[:3, 3])
+        assert err < _POS_TOL_M, f"q={q_ref} → error {err:.4f} m"
+
+
+def test_ik_out_of_envelope_raises() -> None:
+    k = Kinematics(model="ppp")
+    pose = np.eye(4)
+    pose[0, 3] = 70.0  # beyond X limit
+    with pytest.raises(RuntimeError):
+        k.inverse_kinematics(pose)
+
+
+def test_forward_kinematics_wrong_shape_raises() -> None:
+    k = Kinematics(model="ppp")
+    with pytest.raises(ValueError):
+        k.forward_kinematics(np.zeros(5))
+
+
+def test_jacobian_wrong_shape_raises() -> None:
+    k = Kinematics(model="ppp")
+    with pytest.raises(ValueError):
+        k.jacobian(np.zeros(5))

--- a/tests/integration/test_scene_acquisition.py
+++ b/tests/integration/test_scene_acquisition.py
@@ -1,7 +1,7 @@
 """Integration tests: SceneAcquisition PointCloud2 → OccupancyUpdatePayload.
 
 Verifies the acquisition pipeline end-to-end with a real ROS 2 context:
-  - Publish a ``sensor_msgs/PointCloud2`` to ``/world_state``.
+  - Publish a ``sensor_msgs/PointCloud2`` to ``/obstacle_cloud``.
   - Assert that ``SceneAcquisition.get_latest_payload()`` returns the
     expected ``OccupancyUpdatePayload``.
 
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import PointCloud2  # type: ignore[import-untyped]
 from sensor_msgs_py.point_cloud2 import (
     create_cloud_xyz32,  # type: ignore[import-untyped]
@@ -22,6 +23,13 @@ from std_msgs.msg import Header  # type: ignore[import-untyped]
 
 from fret.interfaces import OccupancyUpdatePayload
 from fret.scene.acquisition import SceneAcquisition
+
+# Match SceneAcquisition subscription QoS (RELIABLE + TRANSIENT_LOCAL).
+_ACQ_QOS = QoSProfile(
+    reliability=ReliabilityPolicy.RELIABLE,
+    durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    depth=1,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,9 +81,9 @@ def test_scene_acquisition_raises_before_message(test_node: Node) -> None:
 
 @pytest.mark.timeout(30)
 def test_scene_acquisition_receives_cloud(test_node: Node) -> None:
-    """After publishing /world_state, get_latest_payload() returns a payload."""
+    """After publishing /obstacle_cloud, get_latest_payload() returns a payload."""
     acq = SceneAcquisition(node=test_node)
-    pub = test_node.create_publisher(PointCloud2, "/world_state", 1)
+    pub = test_node.create_publisher(PointCloud2, "/obstacle_cloud", _ACQ_QOS)
     cloud = _make_cloud(test_node, [(0.1, 0.2, 0.3), (0.4, 0.5, 0.6)])
     _publish_and_spin(test_node, pub, cloud)
     payload = acq.get_latest_payload()
@@ -89,7 +97,7 @@ def test_scene_acquisition_point_values(test_node: Node) -> None:
     """The extracted point coordinates must match those in the published cloud."""
     pts = [(0.1, 0.2, 0.3), (0.4, 0.5, 0.6)]
     acq = SceneAcquisition(node=test_node)
-    pub = test_node.create_publisher(PointCloud2, "/world_state", 1)
+    pub = test_node.create_publisher(PointCloud2, "/obstacle_cloud", _ACQ_QOS)
     _publish_and_spin(test_node, pub, _make_cloud(test_node, pts))
     payload = acq.get_latest_payload()
     expected = np.array(pts, dtype=np.float64)

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -1,0 +1,59 @@
+"""Tests for scripts/render_mujoco.py (pure-Python helpers).
+
+MuJoCo rendering is optional; these tests validate trajectory generation
+and MJCF path resolution without a MuJoCo runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# render_mujoco.py lives under scripts/, not src/
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))
+
+import render_mujoco as rm  # noqa: E402
+
+
+def test_resolve_mjcf_ppp_warehouse() -> None:
+    path = rm.resolve_mjcf_path("ppp", "ppp_warehouse", None)
+    assert path.name == "ppp_warehouse.xml"
+    assert path.is_file()
+
+
+def test_resolve_mjcf_override() -> None:
+    explicit = rm.resolve_mjcf_path("ppp", "ppp_warehouse", None)
+    resolved = rm.resolve_mjcf_path("ppp", "other", explicit)
+    assert resolved == explicit
+
+
+def test_resolve_mjcf_unsupported_raises() -> None:
+    with pytest.raises(ValueError, match="Unsupported"):
+        rm.resolve_mjcf_path("dubins", "dubins_race", None)
+
+
+def test_interpolate_waypoints_shape() -> None:
+    waypoints = [
+        np.array([0.0, 0.0, 1.0]),
+        np.array([1.0, 1.0, 1.0]),
+        np.array([2.0, 0.5, 2.0]),
+    ]
+    traj = rm.interpolate_waypoints(waypoints, duration_s=3.0, fps=10)
+    assert traj.shape == (30, 3)
+    assert traj[0, 0] == pytest.approx(0.0)
+    assert traj[-1, 0] == pytest.approx(2.0)
+
+
+def test_interpolate_waypoints_respects_limits() -> None:
+    waypoints = [
+        np.array([0.0, 0.0, 0.0]),
+        np.array([20.0, 10.0, 10.0]),
+    ]
+    traj = rm.interpolate_waypoints(waypoints, duration_s=1.0, fps=5)
+    assert np.all(traj[:, 0] <= rm._PPP_LIMITS[0, 1])
+    assert np.all(traj[:, 1] <= rm._PPP_LIMITS[1, 1])
+    assert np.all(traj[:, 2] <= rm._PPP_LIMITS[2, 1])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First v1.0 implementation slice: PPP gantry kinematics as a pure algorithm-layer foundation for SC-v10.

- Add `PPPKinematics` in `kinematics_ppp.py` — identity FK/IK, prismatic Jacobian, v1.0 joint limits (60×20×6 m).
- Route `Kinematics(model="ppp")` via facade delegation; SCARA behaviour unchanged.
- Add 15 unit tests in `tests/control/test_kinematics_ppp.py`.
- **CI fix:** set `defaults.run.shell: bash` in container workflows (fixes `setup.bash` under `sh`).
- **Integration fix:** publish to `/obstacle_cloud` with matching QoS in scene acquisition tests.
- **Video tooling:** `scripts/video.sh` + `scripts/render_mujoco.py`, MJCF preview scene, optional `sim` extras.

Closes #42

## Traceability

| ID | Description |
|---|---|
| T10-01 | PPP kinematics module |
| T10-02 | MJCF preview scene (`ppp_warehouse.xml`) |
| T10-07 | Headless video render script |
| FR-SYS-01 | `model:=ppp` via `Kinematics(model="ppp")` |
| FR-CTL-02 | v1.0 operational envelope |
| FR-PLN-02 | FK contract for C-space planning |
| V10-7 | PPP kinematics unit tests (partial) |

## Test plan

- [x] `pytest tests/control/test_kinematics_ppp.py -v` — 15 passed
- [x] `pytest tests/control/test_kinematics.py -v` — SCARA regression (19 passed)
- [x] `pytest tests/simulation/test_render_mujoco.py -v` — 5 passed
- [x] All CI workflows green on PR branch

## Video usage

```bash
pip install -e ".[sim]"
./scripts/video.sh --model ppp --scenario ppp_warehouse -o /tmp/v10.mp4
# or with custom settings:
./scripts/video.sh --duration 30 --fps 30 --width 1920 --height 1080 -o /tmp/v10.mp4
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

