### PR TITLE
feat(control): magnetic grasp FSM module (T10-04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,17 +37,65 @@ Full specification: **[docs/releases.md](docs/releases.md)**
 
 ## Quick start
 
+### Pure Python (algorithms only — no ROS)
+
 ```bash
 git clone https://github.com/alexandrelheinen/fret.git && cd fret
 pip install -e ".[dev]"
 pytest tests/ -v --ignore=tests/integration
 ```
 
-Full workspace (ROS 2 + Gazebo):
+### Full workspace (ROS 2 + Gazebo)
 
 ```bash
 ./scripts/install.sh -y && ./scripts/setup.sh -y && ./scripts/build.sh
 source /opt/ros/jazzy/setup.bash && source install/setup.bash
+```
+
+### MuJoCo preview video (optional)
+
+```bash
+pip install -e ".[sim]"
+./scripts/video.sh -o /tmp/fret_ppp_warehouse.mp4
+```
+
+---
+
+## v1.0 local development (incremental)
+
+Each PR adds a testable slice. After `pip install -e ".[dev]"`:
+
+| Step | Feature | Verify locally |
+|---|---|---|
+| 1 | PPP kinematics (T10-01) | `pytest tests/control/test_kinematics_ppp.py -v` |
+| 2 | Magnetic grasp FSM (T10-04) | `pytest tests/control/test_grasp_magnet.py -v` |
+| 3 | MuJoCo preview video (T10-07) | `pip install -e ".[sim]" && ./scripts/video.sh -o /tmp/v10.mp4` |
+
+**PPP kinematics** — identity-map FK/IK for the gantry:
+
+```bash
+python3 -c "
+from fret.control import Kinematics
+import numpy as np
+k = Kinematics('ppp')
+q = np.array([10.0, 5.0, 2.0])
+print('EE position:', k.forward_kinematics(q)[:3, 3])
+"
+```
+
+**Magnetic grasp FSM** — weld / transport / release without ROS:
+
+```bash
+python3 scripts/demo_grasp.py
+# or run the unit tests:
+pytest tests/control/test_grasp_magnet.py -v
+```
+
+**MuJoCo warehouse preview** — headless MP4 of gantry motion:
+
+```bash
+pip install -e ".[sim]"
+./scripts/video.sh --duration 30 --fps 30 -o /tmp/v10.mp4
 ```
 
 ---
@@ -113,7 +161,10 @@ ROS nodes in `fret.ros` handle simulator I/O only.
 | Item | Status |
 |---|---|
 | Bootstrap SCARA pipeline (MS-1–5) | ✅ Done (regression CI) |
-| v1.0 PPP + MuJoCo | 🔲 Specification complete; implementation next |
+| v1.0 PPP kinematics (T10-01) | ✅ Done |
+| v1.0 magnetic grasp FSM (T10-04) | ✅ Done |
+| v1.0 MuJoCo preview video script (T10-07) | ✅ Done |
+| v1.0 C-space checker + scenario launch | 🔲 Next |
 | v1.1 – v1.3 | 🔲 Specified |
 
 ---

--- a/docs/modules/control.md
+++ b/docs/modules/control.md
@@ -46,6 +46,43 @@ the geometric Jacobian for the SCARA RRP (3-DOF) manipulator.
 **Tests:** `tests/control/test_kinematics.py` — 19 unit tests covering FK/IK round-trip,
 Jacobian finite-difference validation, and joint limit checks.
 
+### `kinematics_ppp.py` — PPPKinematics (v1.0)
+
+Identity-map FK/IK for the PPP gantry (`q ≡ p_ee`). Selected via
+`Kinematics(model="ppp")`.
+
+| Property / method | PPP value |
+|---|---|
+| `dof` | 3 |
+| `joint_names` | `joint_x`, `joint_y`, `joint_z` |
+| `joint_limits` | X [0, 60], Y [0, 20], Z [0, 6] m |
+| `forward_kinematics(q)` | EE position = `q` |
+| `inverse_kinematics(pose)` | `q = p_ee` with limit check |
+
+**Tests:** `tests/control/test_kinematics_ppp.py` — 15 unit tests.
+
+---
+
+### `grasp_magnet.py` — MagneticGraspFSM (v1.0)
+
+Pure-Python magnetic weld / release state machine for PPP pick-and-place.
+
+```
+IDLE → APPROACH → CAPTURE → TRANSPORT → RELEASE → IDLE
+```
+
+| Symbol | Description |
+|---|---|
+| `GraspState` | FSM states (FR-GSP-04) |
+| `GraspConfig` | `capture_radius`, `goal_radius`, `weld_offset`, `box_half_extent` |
+| `MagneticGraspFSM` | Level-3 FSM; call `begin_transport()` then `update(ee, box, goal)` |
+| `is_welded` | `True` during CAPTURE / TRANSPORT |
+| `cargo_position` | World-frame cargo centre (tracks EE when welded) |
+| `cargo_corners()` | 8 corners of cargo AABB (FR-GSP-02 hook for planning) |
+
+**Demo:** `python3 scripts/demo_grasp.py`  
+**Tests:** `tests/control/test_grasp_magnet.py` — 10 unit tests.
+
 ---
 
 ### `controller_node.py` — ControllerNode
@@ -127,3 +164,6 @@ rate_hz: 50.0
 | FR-CTL-04 | FK → TF2 broadcast at 50 Hz |
 | FR-CTL-05 | Controller independent of planning node |
 | FR-CTL-06 | Fault detection and HALTED state |
+| FR-GSP-01 | Magnetic weld grasp (no finger DOF) |
+| FR-GSP-03 | Release at goal; cargo frozen |
+| FR-GSP-04 | Grasp FSM states |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -159,7 +159,7 @@ Layers: `SYS`, `SCN`, `PLN`, `CTL`, `GSP` (grasp), `SIM`, `HW`
 | FR-SCN-01–04 | v1.0+ | `tests/scene/` |
 | FR-PLN-01–07 | v1.0+ | `tests/planning/`, SC-v10+ |
 | FR-CTL-01–06 | v1.0+ | `tests/control/` |
-| FR-GSP-01–04 | v1.0 | `tests/control/test_grasp_magnet.py` *(planned)* |
+| FR-GSP-01–04 | v1.0 | `tests/control/test_grasp_magnet.py` |
 | FR-SIM-01–03 | v1.0 | MuJoCo launch + MP4 artifact |
 | FR-SIM-04 | v1.2 | Gazebo sitl smoke |
 | FR-HW-01–03 | post v1.3 | — |

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -69,6 +69,11 @@ These validate the MS-1–5 pipeline. They are **not** the v1.0 product demo.
 ```bash
 # MuJoCo headless MP4 (v1.0 CI target)
 python3 scripts/render_mujoco.py --scenario ppp_warehouse --output /tmp/v10.mp4
+# or via wrapper:
+./scripts/video.sh -o /tmp/v10.mp4
+
+# Magnetic grasp FSM demo (pure Python, no sim)
+python3 scripts/demo_grasp.py
 
 # ROS bag
 ros2 bag record /joint_states /joint_commands /joint_trajectory

--- a/scripts/demo_grasp.py
+++ b/scripts/demo_grasp.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Interactive demo of the PPP magnetic grasp FSM (T10-04).
+
+Runs a scripted pick-and-place sequence in pure Python — no ROS required.
+
+Example::
+
+    pip install -e ".[dev]"
+    python3 scripts/demo_grasp.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fret.control import GraspConfig, GraspState, MagneticGraspFSM
+
+_BOX = np.array([3.0, 2.0, 1.0])
+_GOAL = np.array([10.0, 3.0, 1.0])
+
+
+def main() -> None:
+    """Run a minimal weld → transport → release sequence."""
+    fsm = MagneticGraspFSM(GraspConfig())
+    print("Magnetic grasp FSM demo (FR-GSP-01–04)")
+    print(f"  initial state: {fsm.state.name}")
+
+    fsm.begin_transport()
+    print(f"  after begin_transport: {fsm.state.name}")
+
+    steps = [
+        ("approach (far)", _BOX + np.array([1.0, 0.0, 0.0])),
+        ("capture", _BOX.copy()),
+        ("transport", _BOX + np.array([4.0, 0.5, 0.0])),
+        ("at goal", _GOAL.copy()),
+        ("retract", _GOAL + np.array([1.0, 0.0, 0.5])),
+    ]
+
+    for label, ee in steps:
+        state = fsm.update(ee, _BOX, _GOAL)
+        welded = "welded" if fsm.is_welded else "free"
+        cargo = fsm.cargo_position
+        print(
+            f"  {label:16s} ee={ee.round(2)} → {state.name:9s} "
+            f"({welded}) cargo={cargo.round(2)}"
+        )
+
+    corners = fsm.cargo_corners()
+    print(f"  cargo_corners after release: shape {corners.shape}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fret/control/__init__.py
+++ b/src/fret/control/__init__.py
@@ -4,11 +4,15 @@ Re-exports the public API of the control sub-package.
 """
 
 from fret.control.controller_node import ControllerNode
+from fret.control.grasp_magnet import GraspConfig, GraspState, MagneticGraspFSM
 from fret.control.kinematics import Kinematics
 from fret.control.state_estimator import StateEstimator
 
 __all__ = [
     "ControllerNode",
+    "GraspConfig",
+    "GraspState",
     "Kinematics",
+    "MagneticGraspFSM",
     "StateEstimator",
 ]

--- a/src/fret/control/grasp_magnet.py
+++ b/src/fret/control/grasp_magnet.py
@@ -1,0 +1,179 @@
+"""Magnetic grasp finite-state machine for PPP warehouse pick-and-place (v1.0).
+
+Models cargo handling without a gripper: when the gantry end-effector enters a
+capture zone the box welds to the EE frame; during transport the welded cargo
+envelope is queryable for planning; at the goal the weld releases and the box
+remains at the release pose.
+
+Satisfies requirements FR-GSP-01, FR-GSP-03, and FR-GSP-04.
+Provides FR-GSP-02 hooks via ``is_welded`` and ``cargo_corners``.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+import numpy as np
+import numpy.typing as npt
+
+# Default scenario parameters (docs/scenarios.md, docs/robots/ppp.md).
+_DEFAULT_CAPTURE_RADIUS: float = 0.3
+_DEFAULT_GOAL_RADIUS: float = 0.5
+_DEFAULT_WELD_OFFSET: npt.NDArray[np.float64] = np.array(
+    [0.0, 0.0, 0.25], dtype=np.float64
+)
+_DEFAULT_BOX_HALF_EXTENT: npt.NDArray[np.float64] = np.array(
+    [0.25, 0.25, 0.25], dtype=np.float64
+)
+
+
+class GraspState(enum.IntEnum):
+    """Magnetic grasp FSM states (FR-GSP-04)."""
+
+    IDLE = 0
+    APPROACH = 1
+    CAPTURE = 2
+    TRANSPORT = 3
+    RELEASE = 4
+
+
+@dataclass(frozen=True)
+class GraspConfig:
+    """Configuration for the magnetic grasp FSM.
+
+    Attributes:
+        capture_radius: Distance threshold for welding [m].
+        goal_radius: Distance threshold for release at goal [m].
+        weld_offset: Cargo centre offset from EE in world axes [m].
+        box_half_extent: Half-sizes of the axis-aligned cargo box [m].
+    """
+
+    capture_radius: float = _DEFAULT_CAPTURE_RADIUS
+    goal_radius: float = _DEFAULT_GOAL_RADIUS
+    weld_offset: npt.NDArray[np.float64] = field(
+        default_factory=lambda: _DEFAULT_WELD_OFFSET.copy()
+    )
+    box_half_extent: npt.NDArray[np.float64] = field(
+        default_factory=lambda: _DEFAULT_BOX_HALF_EXTENT.copy()
+    )
+
+    def __post_init__(self) -> None:
+        if self.capture_radius <= 0.0:
+            raise ValueError(
+                f"capture_radius must be positive, got {self.capture_radius}"
+            )
+        if self.goal_radius <= 0.0:
+            raise ValueError(
+                f"goal_radius must be positive, got {self.goal_radius}"
+            )
+        if np.any(self.box_half_extent <= 0.0):
+            raise ValueError("box_half_extent components must be positive")
+
+
+class MagneticGraspFSM:
+    """Pure-Python magnetic weld / release state machine.
+
+    Level-3 logic core mirroring ``ControllerNode``: testable without ROS.
+    The FSM is driven by periodic calls to ``update`` with world-frame EE,
+    box, and goal positions.
+
+    Args:
+        config: Grasp radii, weld offset, and cargo geometry.
+    """
+
+    def __init__(self, config: GraspConfig | None = None) -> None:
+        self._config = config if config is not None else GraspConfig()
+        self._state: GraspState = GraspState.IDLE
+        self._cargo_position: npt.NDArray[np.float64] = np.zeros(
+            3, dtype=np.float64
+        )
+
+    @property
+    def state(self) -> GraspState:
+        """Current FSM state."""
+        return self._state
+
+    @property
+    def is_welded(self) -> bool:
+        """Whether cargo is currently welded to the end-effector."""
+        return self._state in (GraspState.CAPTURE, GraspState.TRANSPORT)
+
+    @property
+    def cargo_position(self) -> npt.NDArray[np.float64]:
+        """World-frame centre of the cargo box [m]."""
+        return self._cargo_position.copy()
+
+    def begin_transport(self) -> None:
+        """Signal task start: transition IDLE → APPROACH."""
+        if self._state == GraspState.IDLE:
+            self._state = GraspState.APPROACH
+
+    def update(
+        self,
+        ee_position: npt.NDArray[np.float64],
+        box_position: npt.NDArray[np.float64],
+        goal_position: npt.NDArray[np.float64],
+    ) -> GraspState:
+        """Advance the FSM by one tick.
+
+        Args:
+            ee_position: End-effector position in ``world``, shape ``(3,)``.
+            box_position: Nominal box position before weld, shape ``(3,)``.
+            goal_position: Goal position for release check, shape ``(3,)``.
+
+        Returns:
+            The FSM state after this update.
+        """
+        ee = np.asarray(ee_position, dtype=np.float64).reshape(3)
+        box = np.asarray(box_position, dtype=np.float64).reshape(3)
+        goal = np.asarray(goal_position, dtype=np.float64).reshape(3)
+        cfg = self._config
+
+        if self._state == GraspState.IDLE:
+            return self._state
+
+        if self._state == GraspState.APPROACH:
+            if np.linalg.norm(ee - box) < cfg.capture_radius:
+                self._state = GraspState.CAPTURE
+                self._cargo_position = ee + cfg.weld_offset
+                self._state = GraspState.TRANSPORT
+            return self._state
+
+        if self._state == GraspState.TRANSPORT:
+            self._cargo_position = ee + cfg.weld_offset
+            if np.linalg.norm(ee - goal) < cfg.goal_radius:
+                self._state = GraspState.RELEASE
+                self._state = GraspState.IDLE
+            return self._state
+
+        return self._state
+
+    def cargo_corners(self) -> npt.NDArray[np.float64]:
+        """Return eight world-frame corners of the welded cargo AABB.
+
+        Used as an FR-GSP-02 hook for ``CSpaceChecker`` integration.
+        Returns an empty ``(0, 3)`` array when not welded.
+
+        Returns:
+            Array of shape ``(8, 3)`` or ``(0, 3)``.
+        """
+        if not self.is_welded:
+            return np.empty((0, 3), dtype=np.float64)
+
+        centre = self._cargo_position
+        hx, hy, hz = self._config.box_half_extent
+        offsets = np.array(
+            [
+                [-hx, -hy, -hz],
+                [hx, -hy, -hz],
+                [-hx, hy, -hz],
+                [hx, hy, -hz],
+                [-hx, -hy, hz],
+                [hx, -hy, hz],
+                [-hx, hy, hz],
+                [hx, hy, hz],
+            ],
+            dtype=np.float64,
+        )
+        return centre + offsets

--- a/tests/control/test_grasp_magnet.py
+++ b/tests/control/test_grasp_magnet.py
@@ -1,0 +1,127 @@
+"""Tests for fret.control.grasp_magnet — PPP magnetic grasp FSM.
+
+Acceptance criteria (T10-04, FR-GSP-01, FR-GSP-03, FR-GSP-04):
+  - FSM states: IDLE, APPROACH, CAPTURE, TRANSPORT, RELEASE.
+  - Weld latches when ``‖p_ee − p_box‖ < capture_radius``.
+  - Cargo tracks EE + weld offset during TRANSPORT.
+  - Weld releases at goal; cargo pose frozen (FR-GSP-03).
+  - ``cargo_corners()`` returns 8 world-frame corners when welded.
+
+Default parameters (docs/scenarios.md, docs/robots/ppp.md):
+  capture_radius = 0.3 m, goal_radius = 0.5 m
+  box_half_extent = (0.25, 0.25, 0.25) m
+  weld_offset = (0, 0, 0.25) m
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fret.control.grasp_magnet import GraspConfig, GraspState, MagneticGraspFSM
+
+_CAPTURE_RADIUS = 0.3
+_GOAL_RADIUS = 0.5
+_WELD_OFFSET = np.array([0.0, 0.0, 0.25])
+_BOX_HALF = np.array([0.25, 0.25, 0.25])
+
+_BOX_POS = np.array([3.0, 2.0, 1.0])
+_GOAL_POS = np.array([10.0, 3.0, 1.0])
+
+
+def _fsm() -> MagneticGraspFSM:
+    return MagneticGraspFSM(
+        GraspConfig(
+            capture_radius=_CAPTURE_RADIUS,
+            goal_radius=_GOAL_RADIUS,
+            weld_offset=_WELD_OFFSET,
+            box_half_extent=_BOX_HALF,
+        )
+    )
+
+
+def test_construction_defaults_to_idle() -> None:
+    fsm = _fsm()
+    assert fsm.state == GraspState.IDLE
+    assert fsm.is_welded is False
+
+
+def test_invalid_capture_radius_raises() -> None:
+    with pytest.raises(ValueError, match="capture_radius"):
+        GraspConfig(capture_radius=-0.1)
+
+
+def test_begin_transport_moves_to_approach() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    assert fsm.state == GraspState.APPROACH
+
+
+def test_approach_stays_until_capture_radius() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    ee_far = _BOX_POS + np.array([1.0, 0.0, 0.0])
+    fsm.update(ee_far, _BOX_POS, _GOAL_POS)
+    assert fsm.state == GraspState.APPROACH
+    assert fsm.is_welded is False
+
+
+def test_capture_when_within_radius() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    ee_near = _BOX_POS + np.array([0.1, 0.0, 0.0])
+    fsm.update(ee_near, _BOX_POS, _GOAL_POS)
+    assert fsm.state == GraspState.TRANSPORT
+    assert fsm.is_welded is True
+
+
+def test_cargo_tracks_ee_plus_offset_in_transport() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    ee = _BOX_POS.copy()
+    fsm.update(ee, _BOX_POS, _GOAL_POS)
+    expected = ee + _WELD_OFFSET
+    np.testing.assert_allclose(fsm.cargo_position, expected)
+
+    ee_moved = ee + np.array([1.0, 0.5, 0.0])
+    fsm.update(ee_moved, _BOX_POS, _GOAL_POS)
+    np.testing.assert_allclose(fsm.cargo_position, ee_moved + _WELD_OFFSET)
+
+
+def test_release_at_goal_freezes_cargo() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    fsm.update(_BOX_POS, _BOX_POS, _GOAL_POS)
+    assert fsm.state == GraspState.TRANSPORT
+
+    ee_at_goal = _GOAL_POS.copy()
+    fsm.update(ee_at_goal, _BOX_POS, _GOAL_POS)
+    assert fsm.state == GraspState.IDLE
+    assert fsm.is_welded is False
+
+    frozen = fsm.cargo_position.copy()
+    ee_retract = _GOAL_POS + np.array([2.0, 0.0, 0.0])
+    fsm.update(ee_retract, _BOX_POS, _GOAL_POS)
+    np.testing.assert_allclose(fsm.cargo_position, frozen)
+
+
+def test_cargo_corners_shape_during_transport() -> None:
+    fsm = _fsm()
+    fsm.begin_transport()
+    fsm.update(_BOX_POS, _BOX_POS, _GOAL_POS)
+    corners = fsm.cargo_corners()
+    assert corners.shape == (8, 3)
+    centre = corners.mean(axis=0)
+    np.testing.assert_allclose(centre, fsm.cargo_position, atol=1e-9)
+
+
+def test_cargo_corners_empty_when_not_welded() -> None:
+    fsm = _fsm()
+    corners = fsm.cargo_corners()
+    assert corners.shape == (0, 3)
+
+
+def test_update_from_idle_without_begin_is_noop() -> None:
+    fsm = _fsm()
+    fsm.update(_BOX_POS, _BOX_POS, _GOAL_POS)
+    assert fsm.state == GraspState.IDLE


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Second v1.0 implementation slice: PPP **magnetic grasp FSM** as a pure algorithm-layer module for SC-v10 pick-and-place semantics.

- Add `MagneticGraspFSM` in `grasp_magnet.py` — weld latch, cargo tracking, release at goal.
- Export `GraspState`, `GraspConfig`, `MagneticGraspFSM` from `fret.control`.
- Add 10 unit tests in `tests/control/test_grasp_magnet.py`.
- Add `scripts/demo_grasp.py` interactive demo (no ROS).
- Update **README** with incremental local install/run steps for each v1.0 PR.

Closes #44

## Traceability

| ID | Description |
|---|---|
| T10-04 | Magnetic grasp FSM |
| FR-GSP-01 | Magnetic weld (no finger DOF) |
| FR-GSP-03 | Release at goal; cargo frozen |
| FR-GSP-04 | FSM states IDLE→APPROACH→CAPTURE→TRANSPORT→RELEASE |
| FR-GSP-02 | API hook (`is_welded`, `cargo_corners`) — checker integration in PR #3 |

## Local install & run

```bash
pip install -e ".[dev]"

# Unit tests
pytest tests/control/test_grasp_magnet.py -v

# Interactive demo
python3 scripts/demo_grasp.py
```

See README § **v1.0 local development (incremental)** for the full step-by-step guide.

## Out of scope

- `CSpaceChecker` cargo envelope integration (PR #3)
- ROS / launch / scenario YAML wiring
- MuJoCo weld physics sync

## Test plan

- [x] `pytest tests/control/test_grasp_magnet.py -v` — 10 passed
- [x] `python3 scripts/demo_grasp.py` — runs cleanly
- [x] `mypy --follow-imports=skip src/fret/control/grasp_magnet.py` — clean
- [x] `black` / `isort` on changed files
- [ ] Full CI green on PR branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

