### PR TITLE
feat(ros): MuJoCo backend adapter (T10-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Each PR adds a testable slice. After `pip install -e ".[dev]"`:
 | 3 | MuJoCo preview video (T10-07) | `pip install -e ".[sim]" && ./scripts/video.sh -o /tmp/v10.mp4` |
 | 4 | PPP C-space checker (T10-05, T10-08) | `pytest tests/planning/test_cspace_checker_ppp.py -v` |
 | 5 | PPP prismatic controller (T10-09) | `pytest tests/control/test_controller_ppp.py -v` |
+| 6 | MuJoCo ROS bridge (T10-03) | `pytest tests/ros/test_mujoco_bridge.py -v` |
 
 **PPP kinematics** — identity-map FK/IK for the gantry:
 
@@ -114,6 +115,14 @@ pytest tests/planning/test_cspace_checker_ppp.py tests/planning/test_ppp_obstacl
 python3 scripts/demo_ppp_controller.py
 # or run the unit tests:
 pytest tests/control/test_controller_ppp.py -v
+```
+
+**MuJoCo ROS bridge** — `/joint_commands` → `/joint_states` core:
+
+```bash
+python3 scripts/demo_mujoco_bridge.py
+# or run the unit tests:
+pytest tests/ros/test_mujoco_bridge.py -v
 ```
 
 ---
@@ -183,7 +192,9 @@ ROS nodes in `fret.ros` handle simulator I/O only.
 | v1.0 magnetic grasp FSM (T10-04) | ✅ Done |
 | v1.0 PPP C-space checker (T10-05, T10-08) | ✅ Done |
 | v1.0 MuJoCo preview video script (T10-07) | ✅ Done |
-| v1.0 MuJoCo bridge + scenario launch | 🔲 Next |
+| v1.0 PPP prismatic controller (T10-09) | ✅ Done |
+| v1.0 MuJoCo bridge (T10-03) | 🟡 PR open |
+| v1.0 scenario launch (T10-06) | 🔲 Next |
 | v1.1 – v1.3 | 🔲 Specified |
 
 ---

--- a/docs/modules/ros_nodes.md
+++ b/docs/modules/ros_nodes.md
@@ -17,6 +17,32 @@ FRET algorithm layers.
 
 ## Components
 
+### `mujoco_bridge.py` — MuJoCoBridgeNode (v1.0)
+
+Primary simulator I/O for the PPP MuJoCo backend.  Subscribes to velocity
+commands and publishes joint state at 50 Hz.
+
+| Symbol | Description |
+|---|---|
+| `MuJoCoBridgeCore` | Level-3 joint integration against MJCF limits |
+| `make_mujoco_bridge_core()` | Factory for model/scenario dispatch |
+| `integrate_joint_velocities()` | Clip + Euler integration helper |
+| `resolve_mjcf_path()` | Resolve `ppp_warehouse.xml` for PPP |
+
+**Topics:**
+
+| Topic | Type | Direction |
+|---|---|---|
+| `/joint_commands` | `std_msgs/Float64MultiArray` | Subscribe |
+| `/joint_states` | `sensor_msgs/JointState` | Publish |
+
+**Config:** `src/fret/config/simulation/mujoco.yml`
+
+**Demo:** `python3 scripts/demo_mujoco_bridge.py`  
+**Tests:** `tests/ros/test_mujoco_bridge.py` — 11 unit tests.
+
+---
+
 ### `perception_bridge.py` — PerceptionBridgeNode
 
 Reads obstacle definitions from `config/perception.yaml` and publishes a
@@ -89,6 +115,6 @@ else:                           # static_reach, obstacle_avoidance, ...
 |---|---|---|---|
 | `/obstacle_cloud` | `PointCloud2` | `PerceptionBridgeNode` | `SceneAcquisitionNode` |
 | `/joint_trajectory` | `JointTrajectory` | Injectors / `PlannerNodeRos` | `ControllerRosNode` |
-| `/joint_commands` | `Float64MultiArray` | `ControllerRosNode` | Gazebo / `BridgeNode` |
-| `/joint_states` | `JointState` | Gazebo | `StateEstimator`, `ControllerRosNode` |
+| `/joint_commands` | `Float64MultiArray` | `ControllerRosNode` | MuJoCo bridge / Gazebo |
+| `/joint_states` | `JointState` | MuJoCo bridge / Gazebo | `StateEstimator`, `ControllerRosNode` |
 | `/controller_fault` | `Bool` | `ControllerRosNode` | Operator / monitoring |

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -38,8 +38,12 @@ source /opt/ros/jazzy/setup.bash && source install/setup.bash
 ## v1.0 — PPP warehouse (planned)
 
 ```bash
-# Primary v1.0 entry point (not yet implemented)
+# Primary v1.0 entry point (launch wiring in T10-06)
 ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco
+
+# MuJoCo bridge core demo (pure Python, no ROS)
+python3 scripts/demo_mujoco_bridge.py
+pytest tests/ros/test_mujoco_bridge.py -v
 ```
 
 **Deliverables:**
@@ -47,7 +51,9 @@ ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco
 | Asset | Path |
 |---|---|
 | MJCF world | `src/fret/mjcf/ppp_warehouse.xml` |
-| Scenario | `src/fret/config/scenarios/ppp_warehouse.yml` |
+| MuJoCo bridge | `src/fret/ros/mujoco_bridge.py` |
+| Bridge config | `src/fret/config/simulation/mujoco.yml` |
+| Scenario | `src/fret/config/scenarios/ppp_warehouse.yml` *(T10-06)* |
 | Video script | `scripts/render_mujoco.py` |
 
 ---
@@ -96,5 +102,6 @@ ros2 bag record /joint_states /joint_commands /joint_trajectory
 
 ## Known limitations
 
-See [releases.md](releases.md) for current release status. v1.0 MuJoCo backend and
-PPP model are not yet implemented in code — specification only.
+See [releases.md](releases.md) for current release status. v1.0 scenario launch
+and full SITL wiring (T10-06) are not yet implemented — the MuJoCo bridge core
+is available for unit testing and incremental integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ arc_injector = "fret.ros.arc_injector:main"
 scene_acquisition_node = "fret.scene.acquisition_node:main"
 planner_node = "fret.planning.planner_node_ros:main"
 perception_bridge = "fret.ros.perception_bridge:main"
+mujoco_bridge = "fret.ros.mujoco_bridge:main"
 
 [build-system]
 requires = ["setuptools>=71", "wheel"]

--- a/scripts/demo_mujoco_bridge.py
+++ b/scripts/demo_mujoco_bridge.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Interactive demo of the MuJoCo bridge core (T10-03).
+
+Simulates a short velocity-command sequence in pure Python — no ROS required.
+
+Example::
+
+    pip install -e ".[dev]"
+    python3 scripts/demo_mujoco_bridge.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fret.ros.mujoco_bridge import make_mujoco_bridge_core
+
+
+def main() -> None:
+    """Step the PPP MuJoCo bridge with a simple pick-like motion."""
+    core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    print("MuJoCo bridge core demo (T10-03)")
+    print(f"  mjcf: {core.mjcf_path.name}")
+    print(f"  mujoco runtime: {core.has_mujoco_runtime}")
+    print(f"  joints: {core.joint_names}")
+    print(f"  start q: {core.get_positions().round(3)}")
+
+    dt = 0.02
+    segments = [
+        ("lower Z", np.array([0.0, 0.0, -0.5])),
+        ("raise Z", np.array([0.0, 0.0, 0.5])),
+        ("traverse +X", np.array([0.8, 0.0, 0.0])),
+        ("traverse +Y", np.array([0.0, 0.4, 0.0])),
+        ("stop", np.array([0.0, 0.0, 0.0])),
+    ]
+
+    for label, cmd in segments:
+        for _ in range(25):
+            core.step(cmd, dt)
+        q = core.get_positions()
+        print(f"  {label:12s} cmd={cmd} -> q={q.round(3)}")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fret/CMakeLists.txt
+++ b/src/fret/CMakeLists.txt
@@ -153,6 +153,7 @@ install(PROGRAMS
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/arc_injector
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/straight_line_injector
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/perception_bridge
+  ${CMAKE_CURRENT_SOURCE_DIR}/scripts/mujoco_bridge
   ${CMAKE_CURRENT_SOURCE_DIR}/scripts/viz_node
   DESTINATION lib/${PROJECT_NAME}
 )

--- a/src/fret/config/simulation/mujoco.yml
+++ b/src/fret/config/simulation/mujoco.yml
@@ -1,0 +1,10 @@
+# MuJoCo simulation bridge configuration (v1.0).
+#
+# Consumed by: MuJoCoBridgeNode (ros/mujoco_bridge.py)
+
+/**:
+  ros__parameters:
+    model: ppp
+    scenario: ppp_warehouse
+    update_rate: 50.0
+    initial_joint_positions: [0.0, 0.0, 0.0]

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -1,0 +1,445 @@
+"""MuJoCo backend adapter for FRET simulator I/O (v1.0).
+
+Level-3 ``MuJoCoBridgeCore`` integrates joint velocity commands against an
+MJCF scene without requiring a live ROS context.  When the optional
+``mujoco`` package is installed the core also keeps an ``MjModel`` /
+``MjData`` pair in sync for forward kinematics and future rendering hooks.
+
+Level-4 ``MuJoCoBridgeNode`` subscribes to ``/joint_commands`` and publishes
+``/joint_states`` at the configured rate (default 50 Hz).
+
+Satisfies requirements FR-SIM-01 and FR-SIM-02.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+from fret.control.kinematics_ppp import PPPKinematics
+
+# MJCF preview scale (1:5) limits for ppp_warehouse.xml.
+_PPP_MJCF_LIMITS: npt.NDArray[np.float64] = np.array(
+    [
+        [0.0, 12.0],
+        [0.0, 4.0],
+        [0.0, 3.0],
+    ],
+    dtype=np.float64,
+)
+
+_DEFAULT_UPDATE_RATE_HZ: float = 50.0
+
+
+def _project_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parents[1]
+
+
+def resolve_mjcf_path(
+    model: str,
+    scenario: str,
+    mjcf_override: str | pathlib.Path | None = None,
+) -> pathlib.Path:
+    """Return the MJCF file path for a model/scenario pair.
+
+    Args:
+        model: Robot model name (e.g. ``ppp``).
+        scenario: Scenario stem (e.g. ``ppp_warehouse``).
+        mjcf_override: Optional explicit MJCF path.
+
+    Returns:
+        Resolved path to an existing MJCF file.
+
+    Raises:
+        FileNotFoundError: If an override path does not exist.
+        ValueError: If the model/scenario combination is unsupported.
+    """
+    if mjcf_override is not None:
+        path = pathlib.Path(mjcf_override)
+        if not path.is_file():
+            raise FileNotFoundError(f"MJCF not found: {path}")
+        return path
+
+    if model == "ppp" and scenario in {"ppp_warehouse", "ppp"}:
+        candidate = _project_root() / "mjcf" / "ppp_warehouse.xml"
+        if candidate.is_file():
+            return candidate
+
+    raise ValueError(
+        f"Unsupported model/scenario combination: model={model!r}, "
+        f"scenario={scenario!r}"
+    )
+
+
+def integrate_joint_velocities(
+    positions: npt.NDArray[np.float64],
+    velocities: npt.NDArray[np.float64],
+    dt: float,
+    limits: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Integrate joint velocities and clip to per-axis limits.
+
+    Args:
+        positions: Current joint positions, shape ``(DOF,)``.
+        velocities: Commanded joint velocities [m/s or rad/s], shape ``(DOF,)``.
+        dt: Integration timestep [s].
+        limits: Joint limits array, shape ``(DOF, 2)`` with ``[lower, upper]``.
+
+    Returns:
+        Updated joint positions, shape ``(DOF,)``.
+    """
+    if positions.shape != velocities.shape:
+        raise ValueError("positions and velocities must have the same shape")
+    if limits.shape != (positions.shape[0], 2):
+        raise ValueError(
+            f"limits must have shape ({positions.shape[0]}, 2), got {limits.shape}"
+        )
+    updated = positions + velocities * dt
+    return np.clip(updated, limits[:, 0], limits[:, 1]).astype(np.float64)
+
+
+def make_mujoco_bridge_core(
+    model: str,
+    scenario: str,
+    *,
+    mjcf_path: str | pathlib.Path | None = None,
+    initial_positions: npt.NDArray[np.float64] | None = None,
+) -> MuJoCoBridgeCore:
+    """Build a model-appropriate MuJoCo bridge core (FR-SYS-01).
+
+    Args:
+        model: Robot model name (``ppp`` supported in v1.0).
+        scenario: Scenario stem used for MJCF resolution.
+        mjcf_path: Optional explicit MJCF path override.
+        initial_positions: Optional initial joint configuration.
+
+    Returns:
+        Configured ``MuJoCoBridgeCore`` instance.
+
+    Raises:
+        ValueError: If ``model`` is not recognised.
+    """
+    if model != "ppp":
+        raise ValueError(f"Unknown MuJoCo bridge model: {model!r}")
+
+    kin = PPPKinematics()
+    resolved = resolve_mjcf_path(model, scenario, mjcf_path)
+    q0 = (
+        np.zeros(kin.dof, dtype=np.float64)
+        if initial_positions is None
+        else np.asarray(initial_positions, dtype=np.float64)
+    )
+    if q0.shape != (kin.dof,):
+        raise ValueError(f"initial_positions must have shape ({kin.dof},)")
+
+    return MuJoCoBridgeCore(
+        mjcf_path=resolved,
+        joint_names=kin.joint_names,
+        limits=_PPP_MJCF_LIMITS,
+        initial_positions=q0,
+    )
+
+
+class MuJoCoBridgeCore:
+    """Level-3 MuJoCo joint I/O core.
+
+      Integrates velocity commands in joint space and optionally mirrors the
+    state into a MuJoCo model when the package is available.
+
+      Args:
+          mjcf_path: Path to the MJCF scene file.
+          joint_names: Ordered joint names matching command/state vectors.
+          limits: Joint limits array, shape ``(DOF, 2)``.
+          initial_positions: Starting joint configuration.
+    """
+
+    def __init__(
+        self,
+        mjcf_path: str | pathlib.Path,
+        joint_names: list[str],
+        limits: npt.NDArray[np.float64],
+        initial_positions: npt.NDArray[np.float64],
+    ) -> None:
+        self._mjcf_path = pathlib.Path(mjcf_path)
+        self._joint_names = list(joint_names)
+        self._limits = np.asarray(limits, dtype=np.float64)
+        self._positions = np.clip(
+            np.asarray(initial_positions, dtype=np.float64),
+            self._limits[:, 0],
+            self._limits[:, 1],
+        )
+        self._velocities = np.zeros_like(self._positions)
+        self._mujoco: Any | None = None
+        self._model: Any | None = None
+        self._data: Any | None = None
+        self._qpos_adrs: list[int] = []
+        self._load_mujoco_optional()
+        self._write_mujoco_state()
+
+    @property
+    def joint_names(self) -> list[str]:
+        """Ordered joint names."""
+        return list(self._joint_names)
+
+    @property
+    def limits(self) -> npt.NDArray[np.float64]:
+        """Joint limits array, shape ``(DOF, 2)``."""
+        return self._limits.copy()
+
+    @property
+    def mjcf_path(self) -> pathlib.Path:
+        """Loaded MJCF scene path."""
+        return self._mjcf_path
+
+    @property
+    def has_mujoco_runtime(self) -> bool:
+        """Return ``True`` when the optional MuJoCo package is active."""
+        return self._model is not None
+
+    def get_positions(self) -> npt.NDArray[np.float64]:
+        """Return a copy of the current joint positions."""
+        return self._positions.copy()
+
+    def get_velocities(self) -> npt.NDArray[np.float64]:
+        """Return a copy of the most recent joint velocities."""
+        return self._velocities.copy()
+
+    def set_positions(self, positions: npt.NDArray[np.float64]) -> None:
+        """Set joint positions directly (clipped to limits).
+
+        Args:
+            positions: Joint configuration, shape ``(DOF,)``.
+        """
+        q = np.asarray(positions, dtype=np.float64)
+        if q.shape != self._positions.shape:
+            raise ValueError(
+                f"Expected shape {self._positions.shape}, got {q.shape}"
+            )
+        self._positions = np.clip(q, self._limits[:, 0], self._limits[:, 1])
+        self._write_mujoco_state()
+
+    def step(
+        self,
+        velocities: npt.NDArray[np.float64],
+        dt: float,
+    ) -> npt.NDArray[np.float64]:
+        """Integrate one control timestep from a velocity command.
+
+        Args:
+            velocities: Commanded joint velocities, shape ``(DOF,)``.
+            dt: Integration period [s].
+
+        Returns:
+            Updated joint positions after integration.
+        """
+        v = np.asarray(velocities, dtype=np.float64)
+        if v.shape != self._positions.shape:
+            raise ValueError(
+                f"Expected velocity shape {self._positions.shape}, got {v.shape}"
+            )
+        self._velocities = v.copy()
+        self._positions = integrate_joint_velocities(
+            self._positions,
+            self._velocities,
+            dt,
+            self._limits,
+        )
+        self._write_mujoco_state()
+        return self._positions.copy()
+
+    def _load_mujoco_optional(self) -> None:
+        try:
+            import mujoco  # type: ignore[import-not-found]
+        except ImportError:
+            return
+
+        self._mujoco = mujoco
+        self._model = mujoco.MjModel.from_xml_path(str(self._mjcf_path))
+        self._data = mujoco.MjData(self._model)
+        adrs: list[int] = []
+        for name in self._joint_names:
+            joint_id = mujoco.mj_name2id(
+                self._model,
+                mujoco.mjtObj.mjOBJ_JOINT,
+                name,
+            )
+            if joint_id < 0:
+                raise ValueError(f"Joint not found in MJCF: {name}")
+            adrs.append(int(self._model.jnt_qposadr[joint_id]))
+        self._qpos_adrs = adrs
+
+    def _write_mujoco_state(self) -> None:
+        if self._model is None or self._data is None or self._mujoco is None:
+            return
+        for idx, adr in enumerate(self._qpos_adrs):
+            self._data.qpos[adr] = float(self._positions[idx])
+        self._mujoco.mj_forward(self._model, self._data)
+
+
+def _resolve_config_path(config_path: str | None) -> str:
+    if config_path is not None:
+        return config_path
+    try:
+        from ament_index_python.packages import get_package_share_directory
+
+        share = get_package_share_directory("fret")
+        return os.path.join(share, "config", "simulation", "mujoco.yml")
+    except Exception:
+        here = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(here, "..", "config", "simulation", "mujoco.yml")
+
+
+def _load_bridge_config(config_path: str) -> dict[str, Any]:
+    import yaml
+
+    with open(config_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        return {}
+    for section in data.values():
+        if isinstance(section, dict):
+            params = section.get("ros__parameters", {})
+            if isinstance(params, dict):
+                return params
+    return {}
+
+
+class MuJoCoBridgeNode:
+    """ROS 2 node bridging MuJoCo joint I/O to the FRET graph.
+
+    Subscribes:
+        /joint_commands  (``std_msgs/Float64MultiArray``, BEST_EFFORT)
+
+    Publishes:
+        /joint_states    (``sensor_msgs/JointState``, default 50 Hz)
+
+    Args:
+        config_path: Optional path to ``mujoco.yml``.
+        model: Robot model override.
+        scenario: Scenario stem override.
+        mjcf_path: Optional MJCF path override.
+    """
+
+    def __init__(
+        self,
+        config_path: str | None = None,
+        *,
+        model: str | None = None,
+        scenario: str | None = None,
+        mjcf_path: str | None = None,
+    ) -> None:
+        import rclpy
+        import rclpy.node
+        from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+        from sensor_msgs.msg import JointState
+        from std_msgs.msg import Float64MultiArray
+
+        self._rclpy = rclpy
+        resolved = _resolve_config_path(config_path)
+        cfg = _load_bridge_config(resolved)
+
+        model_name = model or str(cfg.get("model", "ppp"))
+        scenario_name = scenario or str(cfg.get("scenario", "ppp_warehouse"))
+        self._update_rate = float(
+            cfg.get("update_rate", _DEFAULT_UPDATE_RATE_HZ)
+        )
+        initial = cfg.get("initial_joint_positions", [0.0, 0.0, 0.0])
+        q0 = np.asarray(initial, dtype=np.float64)
+
+        self._core = make_mujoco_bridge_core(
+            model_name,
+            scenario_name,
+            mjcf_path=mjcf_path,
+            initial_positions=q0,
+        )
+        self._latest_cmd = np.zeros(
+            self._core.get_positions().shape, dtype=np.float64
+        )
+
+        class _Node(rclpy.node.Node):  # type: ignore[misc]
+            pass
+
+        self._node: rclpy.node.Node = _Node("mujoco_bridge_node")
+
+        cmd_qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            durability=DurabilityPolicy.VOLATILE,
+            depth=1,
+        )
+        self._node.create_subscription(
+            Float64MultiArray,
+            "/joint_commands",
+            self._command_callback,
+            cmd_qos,
+        )
+
+        self._state_pub = self._node.create_publisher(
+            JointState, "/joint_states", 10
+        )
+        self._timer = self._node.create_timer(
+            1.0 / self._update_rate,
+            self._timer_callback,
+        )
+        self._node.get_logger().info(
+            "MuJoCoBridgeNode ready: "
+            f"model={model_name}, scenario={scenario_name}, "
+            f"mjcf={self._core.mjcf_path.name}, "
+            f"rate={self._update_rate} Hz, "
+            f"mujoco_runtime={self._core.has_mujoco_runtime}"
+        )
+
+    def _command_callback(self, msg: Any) -> None:
+        data = list(getattr(msg, "data", []))
+        dof = self._latest_cmd.shape[0]
+        if len(data) < dof:
+            self._node.get_logger().warning(
+                f"Received /joint_commands with {len(data)} values; expected {dof}."
+            )
+            return
+        self._latest_cmd = np.asarray(data[:dof], dtype=np.float64)
+
+    def _timer_callback(self) -> None:
+        from sensor_msgs.msg import JointState
+
+        dt = 1.0 / self._update_rate
+        positions = self._core.step(self._latest_cmd, dt)
+        velocities = self._core.get_velocities()
+
+        msg = JointState()
+        msg.header.stamp = self._node.get_clock().now().to_msg()
+        msg.header.frame_id = "world"
+        msg.name = self._core.joint_names
+        msg.position = positions.tolist()
+        msg.velocity = velocities.tolist()
+        self._state_pub.publish(msg)
+
+    def spin(self) -> None:
+        """Spin the underlying ROS 2 node until shutdown."""
+        try:
+            self._rclpy.spin(self._node)
+        finally:
+            self._node.destroy_node()
+            if self._rclpy.ok():
+                self._rclpy.shutdown()
+
+
+def main(args: list[str] | None = None) -> None:  # pragma: no cover
+    """Entry point for the ``mujoco_bridge`` executable."""
+    import rclpy
+
+    rclpy.init(args=args)
+    node = MuJoCoBridgeNode()
+    node.spin()
+
+
+__all__ = [
+    "MuJoCoBridgeCore",
+    "MuJoCoBridgeNode",
+    "integrate_joint_velocities",
+    "make_mujoco_bridge_core",
+    "resolve_mjcf_path",
+]

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -253,7 +253,7 @@ class MuJoCoBridgeCore:
 
     def _load_mujoco_optional(self) -> None:
         try:
-            import mujoco  # type: ignore[import-not-found]
+            import mujoco
         except ImportError:
             return
 
@@ -394,7 +394,7 @@ class MuJoCoBridgeNode:
 
     def _command_callback(self, msg: Any) -> None:
         data = list(getattr(msg, "data", []))
-        dof = self._latest_cmd.shape[0]
+        dof = len(self._latest_cmd)
         if len(data) < dof:
             self._node.get_logger().warning(
                 f"Received /joint_commands with {len(data)} values; expected {dof}."

--- a/src/fret/scripts/mujoco_bridge
+++ b/src/fret/scripts/mujoco_bridge
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+from fret.ros.mujoco_bridge import main
+
+main()

--- a/tests/ros/test_mujoco_bridge.py
+++ b/tests/ros/test_mujoco_bridge.py
@@ -1,0 +1,125 @@
+"""Unit tests for MuJoCo bridge core (T10-03).
+
+Pure-Python tests — no ROS or MuJoCo runtime required for the core logic.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+
+from fret.ros.mujoco_bridge import (
+    MuJoCoBridgeCore,
+    integrate_joint_velocities,
+    make_mujoco_bridge_core,
+    resolve_mjcf_path,
+)
+
+
+def test_resolve_mjcf_ppp_warehouse() -> None:
+    """MJCF path resolution should find the PPP warehouse preview scene."""
+    path = resolve_mjcf_path("ppp", "ppp_warehouse", None)
+    assert path.name == "ppp_warehouse.xml"
+    assert path.is_file()
+
+
+def test_resolve_mjcf_override_missing_raises() -> None:
+    """Missing override path should raise FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        resolve_mjcf_path("ppp", "ppp_warehouse", "/nonexistent/scene.xml")
+
+
+def test_resolve_mjcf_unsupported_model_raises() -> None:
+    """Unsupported model/scenario pairs should raise ValueError."""
+    with pytest.raises(ValueError, match="Unsupported"):
+        resolve_mjcf_path("dubins", "dubins_race", None)
+
+
+def test_integrate_joint_velocities_clips_limits() -> None:
+    """Integration should clip positions to joint limits."""
+    limits = np.array([[0.0, 1.0], [0.0, 2.0]], dtype=np.float64)
+    q = np.array([0.5, 1.0])
+    q_dot = np.array([10.0, 10.0])
+    q_next = integrate_joint_velocities(q, q_dot, dt=1.0, limits=limits)
+    np.testing.assert_array_equal(q_next, np.array([1.0, 2.0]))
+
+
+def test_integrate_joint_velocities_shape_mismatch() -> None:
+    """Mismatched shapes should raise ValueError."""
+    limits = np.array([[0.0, 1.0], [0.0, 2.0]])
+    with pytest.raises(ValueError):
+        integrate_joint_velocities(
+            np.array([0.0, 0.0]),
+            np.array([1.0]),
+            dt=0.02,
+            limits=limits,
+        )
+
+
+def test_make_mujoco_bridge_core_ppp() -> None:
+    """Factory should build a PPP bridge core with three joints."""
+    core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    assert core.joint_names == ["joint_x", "joint_y", "joint_z"]
+    assert core.get_positions().shape == (3,)
+    assert core.mjcf_path.name == "ppp_warehouse.xml"
+
+
+def test_make_mujoco_bridge_core_unknown_model() -> None:
+    """Unknown models should raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown MuJoCo bridge model"):
+        make_mujoco_bridge_core("scara", "static_reach")
+
+
+def test_bridge_core_step_integrates_velocity() -> None:
+    """Velocity commands should advance joint positions."""
+    mjcf = resolve_mjcf_path("ppp", "ppp_warehouse", None)
+    limits = np.array(
+        [[0.0, 12.0], [0.0, 4.0], [0.0, 3.0]],
+        dtype=np.float64,
+    )
+    core = MuJoCoBridgeCore(
+        mjcf_path=mjcf,
+        joint_names=["joint_x", "joint_y", "joint_z"],
+        limits=limits,
+        initial_positions=np.zeros(3),
+    )
+    q_next = core.step(np.array([1.0, 0.5, 0.2]), dt=0.02)
+    np.testing.assert_allclose(q_next, np.array([0.02, 0.01, 0.004]))
+
+
+def test_bridge_core_respects_joint_limits() -> None:
+    """Repeated large velocity commands must not exceed MJCF limits."""
+    core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    for _ in range(1000):
+        core.step(np.array([10.0, 10.0, 10.0]), dt=0.02)
+    q = core.get_positions()
+    assert np.all(q >= core.limits[:, 0])
+    assert np.all(q <= core.limits[:, 1])
+
+
+def test_bridge_core_set_positions() -> None:
+    """Direct position writes should be clipped to limits."""
+    core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    core.set_positions(np.array([20.0, 5.0, 4.0]))
+    np.testing.assert_array_equal(
+        core.get_positions(),
+        np.array([12.0, 4.0, 3.0]),
+    )
+
+
+def test_load_mujoco_config_defaults() -> None:
+    """Default mujoco.yml should load PPP parameters."""
+    from fret.ros.mujoco_bridge import (
+        _load_bridge_config,
+        _resolve_config_path,
+    )
+
+    config_path = _resolve_config_path(None)
+    cfg = _load_bridge_config(config_path)
+    assert cfg["model"] == "ppp"
+    assert cfg["scenario"] == "ppp_warehouse"
+    assert cfg["update_rate"] == 50.0
+    assert cfg["initial_joint_positions"] == [0.0, 0.0, 0.0]
+    assert pathlib.Path(config_path).is_file()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal

Implements **T10-03** — MuJoCo ROS bridge for v1.0 PPP warehouse SITL.

Closes #50

## Changes

- **`MuJoCoBridgeCore`** — Level-3 joint velocity integration with MJCF limit clipping; optional MuJoCo runtime sync when `mujoco` is installed
- **`MuJoCoBridgeNode`** — Level-4 ROS node: `/joint_commands` → `/joint_states` at 50 Hz
- **`make_mujoco_bridge_core()`** factory + `resolve_mjcf_path()` for PPP warehouse MJCF
- **`config/simulation/mujoco.yml`** — model, scenario, rate, initial positions
- **11 unit tests** — pure Python, no ROS runtime required
- **Demo script** — `scripts/demo_mujoco_bridge.py`
- Build wiring: `mujoco_bridge` executable in CMakeLists + pyproject.toml

## Acceptance criteria

| Criterion | Status |
|---|---|
| Velocity integration with joint-limit clipping | ✅ |
| MJCF resolution for `ppp` / `ppp_warehouse` | ✅ |
| ROS topics wired per FR-SIM-02 | ✅ |
| Unit tests pass without MuJoCo (kinematic fallback) | ✅ |
| MuJoCo sync when package available | ✅ |

## Verify locally

```bash
pip install -e ".[dev]"
pytest tests/ros/test_mujoco_bridge.py -v
python3 scripts/demo_mujoco_bridge.py
bash scripts/check/types.sh
```

## Out of scope (next PR)

- `sitl.py backend:=mujoco` launch wiring (T10-06)
- `ppp_warehouse.yml` scenario YAML
- Magnetic grasp weld in MuJoCo physics
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13610780-8ac7-489b-becd-c58393166f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

