### PR TITLE
fix(ci): install EGL libs and repair MuJoCo showcase camera

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       MUJOCO_GL: egl
+      PYOPENGL_PLATFORM: egl
       R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
 
@@ -37,8 +38,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Python, sim deps, and AWS CLI
+      - name: Install EGL/Mesa and Python render deps
         run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            libegl1 \
+            libegl-mesa0 \
+            libgles2 \
+            libgl1 \
+            libgl1-mesa-dri \
+            libosmesa6
           python3 -m pip install --break-system-packages --upgrade pip
           python3 -m pip install --break-system-packages \
             awscli mujoco imageio imageio-ffmpeg

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -124,6 +124,12 @@ def interpolate_waypoints(
     return np.clip(trajectory, _PPP_LIMITS[:, 0], _PPP_LIMITS[:, 1])
 
 
+_EGL_APT_HINT = (
+    "sudo apt install libegl1 libegl-mesa0 libgles2 libgl1 "
+    "libgl1-mesa-dri libosmesa6"
+)
+
+
 def _require_mujoco() -> tuple[object, object]:
     """Import MuJoCo and imageio, raising a clear error when missing."""
     try:
@@ -133,6 +139,13 @@ def _require_mujoco() -> tuple[object, object]:
             "MuJoCo is required for video rendering.\n"
             "Install with: pip install mujoco imageio imageio-ffmpeg"
         ) from exc
+    except AttributeError as exc:
+        if "eglQueryString" in str(exc):
+            raise SystemExit(
+                "MuJoCo EGL rendering requires system OpenGL/EGL libraries.\n"
+                f"On Ubuntu 24.04: {_EGL_APT_HINT}"
+            ) from exc
+        raise
     try:
         import imageio.v3 as iio  # type: ignore[import-not-found]
     except ImportError as exc:

--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -64,7 +64,7 @@
       </body>
     </body>
 
-    <!-- Fixed camera used by the headless renderer. -->
-    <camera name="overview" pos="13 6 7" xyaxes="-0.85 -0.52 0 0.25 -0.41 0.88" fovy="45"/>
+    <!-- Fixed camera used by the headless renderer and interactive viewer. -->
+    <camera name="overview" mode="targetbody" target="gantry_base" pos="13 6 7" fovy="45"/>
   </worldbody>
 </mujoco>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing `showcase-video` release job (runs [#28905584875](https://github.com/alexandrelheinen/fret/actions/runs/28905584875)).

Two independent bugs caused the failure:

1. **Missing system EGL libraries** — `pip install mujoco` is not enough on Ubuntu 24.04 GitHub runners. MuJoCo's EGL backend needs `libegl1`, `libegl-mesa0`, `libgles2`, `libgl1`, `libgl1-mesa-dri`, and `libosmesa6`. Without them, import fails with `AttributeError: 'NoneType' object has no attribute 'eglQueryString'`.

2. **Broken MJCF fixed camera** — The `overview` camera used `xyaxes` orientation, which renders all-black frames with `mujoco.Renderer` on headless EGL (mean pixel value 0.0). Switching to `mode="targetbody"` produces valid frames (mean ≈ 84).

## Changes

- `.github/workflows/release.yml`: install EGL/Mesa apt packages; set `PYOPENGL_PLATFORM=egl`
- `src/fret/mjcf/ppp_warehouse.xml`: fix `overview` camera (`targetbody` mode)
- `scripts/render_mujoco.py`: clearer error when EGL system libs are missing

## Test plan

- [x] Local headless render with `MUJOCO_GL=egl` passes blank-frame check (`mean > 1.0`)
- [x] Release workflow on tag `v0.2.3`: [run #28905920282](https://github.com/alexandrelheinen/fret/actions/runs/28905920282) — all steps green including R2 upload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb9459d9-65c6-4839-8a02-9b6e2d6acd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb9459d9-65c6-4839-8a02-9b6e2d6acd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

