### PR TITLE
feat(showcase): export multi-POV warehouse videos on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
-# Renders the PPP warehouse MuJoCo showcase MP4 on version tags, verifies
-# pixels are non-blank, uploads to Cloudflare R2, and keeps a GitHub artifact.
+# Renders PPP warehouse MuJoCo showcase MP4s (multi-POV) on version tags,
+# verifies pixels are non-blank, uploads to Cloudflare R2, and keeps artifacts.
 
 on:
   push:
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   showcase-video:
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -52,29 +52,18 @@ jobs:
           python3 -m pip install --break-system-packages \
             awscli mujoco imageio imageio-ffmpeg
 
-      - name: Render PPP warehouse MP4
+      - name: Render PPP warehouse showcase clips (all POVs)
         run: |
           ./scripts/video.sh \
             --model ppp \
             --scenario ppp_warehouse \
+            --all-cameras \
+            --output-dir showcase_renders \
             --duration 30 \
             --fps 30 \
             --width 1280 \
-            --height 720 \
-            -o ppp_warehouse_showcase.mp4
-          test -s ppp_warehouse_showcase.mp4
-
-      - name: Verify render is not blank
-        run: |
-          python3 - <<'PY'
-          import imageio.v3 as iio
-
-          frame = iio.imread("ppp_warehouse_showcase.mp4", index=0)
-          mean = float(frame.mean())
-          print(f"frame mean={mean}")
-          if mean <= 1.0:
-              raise SystemExit("Render looks blank (frame mean <= 1.0)")
-          PY
+            --height 720
+          ls -la showcase_renders/
 
       - name: Write release metadata
         run: |
@@ -83,21 +72,58 @@ jobs:
           else
             TAG="${{ github.ref_name }}"
           fi
-          cat > meta.json <<EOF
-          {
-            "repo": "${{ github.repository }}",
-            "git_sha": "${{ github.sha }}",
-            "git_ref": "${TAG}",
-            "scenario": "ppp_warehouse",
-            "model": "ppp",
-            "duration_s": 30,
-            "fps": 30,
-            "width": 1280,
-            "height": 720,
-            "rendered_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
-            "workflow_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          tag = os.environ["TAG"]
+          renders = sorted(Path("showcase_renders").glob("*.mp4"))
+          if not renders:
+              raise SystemExit("No showcase MP4 files were produced")
+
+          videos = []
+          for path in renders:
+              camera = path.stem.removeprefix("ppp_warehouse_")
+              videos.append(
+                  {
+                      "camera": camera,
+                      "file": path.name,
+                      "bytes": path.stat().st_size,
+                  }
+              )
+
+          meta = {
+              "repo": "${{ github.repository }}",
+              "git_sha": "${{ github.sha }}",
+              "git_ref": tag,
+              "scenario": "ppp_warehouse",
+              "model": "ppp",
+              "duration_s": 30,
+              "fps": 30,
+              "width": 1280,
+              "height": 720,
+              "cameras": [video["camera"] for video in videos],
+              "videos": videos,
+              "primary_video": "ppp_warehouse_overview.mp4",
+              "rendered_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "workflow_run": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
           }
-          EOF
+          Path("meta.json").write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+          print(json.dumps(meta, indent=2))
+          PY
+        env:
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+
+      - name: Upload GitHub artifacts (backup)
+        uses: actions/upload-artifact@v6
+        with:
+          name: ppp-warehouse-showcase-${{ github.ref_name }}
+          path: |
+            showcase_renders/
+            meta.json
+          retention-days: 90
 
       - name: Upload to Cloudflare R2
         env:
@@ -111,24 +137,25 @@ jobs:
             TAG="${{ github.ref_name }}"
           fi
 
-          aws s3 cp ppp_warehouse_showcase.mp4 \
-            "s3://${R2_BUCKET}/releases/${TAG}/ppp_warehouse_showcase.mp4" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --content-type video/mp4
+          for mp4 in showcase_renders/*.mp4; do
+            base="$(basename "${mp4}")"
+            aws s3 cp "${mp4}" \
+              "s3://${R2_BUCKET}/releases/${TAG}/${base}" \
+              --endpoint-url "${R2_ENDPOINT}" \
+              --content-type video/mp4
+            aws s3 cp "${mp4}" \
+              "s3://${R2_BUCKET}/latest/${base}" \
+              --endpoint-url "${R2_ENDPOINT}" \
+              --content-type video/mp4
+          done
 
           aws s3 cp meta.json \
             "s3://${R2_BUCKET}/releases/${TAG}/meta.json" \
             --endpoint-url "${R2_ENDPOINT}" \
             --content-type application/json
 
-          aws s3 cp ppp_warehouse_showcase.mp4 \
+          # Backward-compatible primary pointer for README / download script.
+          aws s3 cp showcase_renders/ppp_warehouse_overview.mp4 \
             "s3://${R2_BUCKET}/latest/ppp_warehouse.mp4" \
             --endpoint-url "${R2_ENDPOINT}" \
             --content-type video/mp4
-
-      - name: Upload GitHub artifact (backup)
-        uses: actions/upload-artifact@v6
-        with:
-          name: ppp-warehouse-showcase-${{ github.ref_name }}
-          path: ppp_warehouse_showcase.mp4
-          retention-days: 90

--- a/scripts/download_showcase.sh
+++ b/scripts/download_showcase.sh
@@ -9,7 +9,9 @@
 #
 # Examples:
 #   ./scripts/download_showcase.sh
-#   ./scripts/download_showcase.sh --tag v0.2.0
+#   ./scripts/download_showcase.sh --tag v0.2.4
+#   ./scripts/download_showcase.sh --camera aisle --tag v0.2.4
+#   ./scripts/download_showcase.sh --all --tag v0.2.4
 #   ./scripts/download_showcase.sh -o /tmp/fret_demo.mp4
 #
 set -Eeuo pipefail
@@ -20,6 +22,8 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=scripts/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
+SHOWCASE_CAMERAS=(overview aisle topdown follow pick)
+
 usage() {
   cat <<'EOF'
 Usage: download_showcase.sh [OPTIONS]
@@ -27,9 +31,11 @@ Usage: download_showcase.sh [OPTIONS]
 Download MuJoCo showcase videos uploaded by the Release GitHub Actions workflow.
 
 Options:
-  --latest          Download latest/ppp_warehouse.mp4 (default)
-  --tag VERSION     Download releases/VERSION/ppp_warehouse_showcase.mp4
-  -o PATH           Output file path (default: artifacts/r2/<name>.mp4)
+  --latest          Download latest/ppp_warehouse_overview.mp4 (default)
+  --tag VERSION     Download from releases/VERSION/
+  --camera NAME     POV clip: overview, aisle, topdown, follow, pick
+  --all             Download every known POV for the selected tag/latest
+  -o PATH           Output file path (single download) or directory (--all)
   -h, --help        Show this help
 
 Environment (or .env at repo root):
@@ -66,8 +72,25 @@ require_r2_env() {
   fi
 }
 
+download_object() {
+  local object_key="$1"
+  local output_path="$2"
+  mkdir -p "$(dirname "${output_path}")"
+  info "Downloading s3://${R2_BUCKET}/${object_key}"
+  if ! aws s3 cp \
+    "s3://${R2_BUCKET}/${object_key}" \
+    "${output_path}" \
+    --endpoint-url "${R2_ENDPOINT}"; then
+    fail "Download failed for ${object_key}"
+    return 1
+  fi
+  ok "Saved ${output_path} ($(du -h "${output_path}" | cut -f1))"
+}
+
 MODE="latest"
 TAG=""
+CAMERA="overview"
+DOWNLOAD_ALL=0
 OUTPUT=""
 
 while [[ $# -gt 0 ]]; do
@@ -78,8 +101,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tag)
       MODE="tag"
-      TAG="${2:?--tag requires a version such as v0.2.0}"
+      TAG="${2:?--tag requires a version such as v0.2.4}"
       shift 2
+      ;;
+    --camera)
+      CAMERA="${2:?--camera requires a POV name}"
+      shift 2
+      ;;
+    --all)
+      DOWNLOAD_ALL=1
+      shift
       ;;
     -o)
       OUTPUT="${2:?-o requires a path}"
@@ -106,27 +137,32 @@ export AWS_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}"
 export AWS_DEFAULT_REGION="auto"
 
-if [[ "${MODE}" == "latest" ]]; then
-  OBJECT_KEY="latest/ppp_warehouse.mp4"
-  DEFAULT_NAME="ppp_warehouse_latest.mp4"
-else
-  OBJECT_KEY="releases/${TAG}/ppp_warehouse_showcase.mp4"
-  DEFAULT_NAME="ppp_warehouse_${TAG}.mp4"
+prefix="latest"
+if [[ "${MODE}" == "tag" ]]; then
+  prefix="releases/${TAG}"
 fi
 
-if [[ -z "${OUTPUT}" ]]; then
-  OUTPUT="${REPO_ROOT}/artifacts/r2/${DEFAULT_NAME}"
+if [[ "${DOWNLOAD_ALL}" -eq 1 ]]; then
+  out_dir="${OUTPUT:-${REPO_ROOT}/artifacts/r2/${prefix##*/}}"
+  mkdir -p "${out_dir}"
+  for cam in "${SHOWCASE_CAMERAS[@]}"; do
+    file_name="ppp_warehouse_${cam}.mp4"
+    download_object "${prefix}/${file_name}" "${out_dir}/${file_name}"
+  done
+  exit 0
 fi
 
-mkdir -p "$(dirname "${OUTPUT}")"
-
-info "Downloading s3://${R2_BUCKET}/${OBJECT_KEY}"
-if ! aws s3 cp \
-  "s3://${R2_BUCKET}/${OBJECT_KEY}" \
-  "${OUTPUT}" \
-  --endpoint-url "${R2_ENDPOINT}"; then
-  fail "Download failed. Check credentials, bucket name, and object path."
-  exit 1
+file_name="ppp_warehouse_${CAMERA}.mp4"
+if [[ "${MODE}" == "latest" && "${CAMERA}" == "overview" && -z "${OUTPUT}" ]]; then
+  # Prefer the explicit latest name, then fall back to the legacy alias.
+  default_out="${REPO_ROOT}/artifacts/r2/ppp_warehouse_latest.mp4"
+  if download_object "latest/${file_name}" "${default_out}"; then
+    exit 0
+  fi
+  warn "Falling back to legacy object latest/ppp_warehouse.mp4"
+  download_object "latest/ppp_warehouse.mp4" "${default_out}"
+  exit 0
 fi
 
-ok "Saved ${OUTPUT} ($(du -h "${OUTPUT}" | cut -f1))"
+OUTPUT="${OUTPUT:-${REPO_ROOT}/artifacts/r2/${file_name}}"
+download_object "${prefix}/${file_name}" "${OUTPUT}"

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Headless MuJoCo video renderer for FRET showcase scenarios.
 
-Renders an MP4 of the PPP gantry traversing a warehouse preview scene
+Renders MP4s of the PPP gantry traversing a warehouse preview scene
 without requiring a ROS runtime.  Intended for README / article assets
 (releases.md V10-6, T10-07).
 
@@ -9,6 +9,7 @@ Example::
 
     python3 scripts/render_mujoco.py --scenario ppp_warehouse -o /tmp/v10.mp4
     ./scripts/video.sh --model ppp --duration 30
+    ./scripts/video.sh --all-cameras --output-dir /tmp/showcase
 
 Dependencies (not required for core FRET algorithms)::
 
@@ -19,6 +20,8 @@ from __future__ import annotations
 
 import argparse
 import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -45,6 +48,29 @@ _PPP_WAREHOUSE_WAYPOINTS: list[npt.NDArray[np.float64]] = [
     np.array([10.5, 3.2, 0.95]),
     np.array([10.5, 3.2, 2.4]),
 ]
+
+# Default release export order (must match MJCF camera names).
+_PPP_WAREHOUSE_CAMERAS: tuple[str, ...] = (
+    "overview",
+    "aisle",
+    "topdown",
+    "follow",
+    "pick",
+)
+
+_EGL_APT_HINT = (
+    "sudo apt install libegl1 libegl-mesa0 libgles2 libgl1 "
+    "libgl1-mesa-dri libosmesa6"
+)
+
+
+@dataclass(frozen=True)
+class RenderResult:
+    """One rendered showcase clip."""
+
+    camera: str
+    path: Path
+    frame_mean: float
 
 
 def _project_root() -> Path:
@@ -84,6 +110,40 @@ def resolve_mjcf_path(
     )
 
 
+def list_showcase_cameras(
+    mjcf_path: Path,
+    *,
+    scenario: str = "ppp_warehouse",
+) -> list[str]:
+    """Return ordered showcase camera names for a scenario MJCF.
+
+    Args:
+        mjcf_path: Path to the MJCF scene file.
+        scenario: Scenario stem used for fallback defaults.
+
+    Returns:
+        Camera names in release-export order.
+    """
+    root = ET.parse(mjcf_path).getroot()
+    cameras = [
+        name
+        for node in root.iter("camera")
+        if (name := node.get("name")) is not None
+    ]
+    if cameras:
+        return cameras
+
+    if scenario in {"ppp_warehouse", "ppp"}:
+        return list(_PPP_WAREHOUSE_CAMERAS)
+
+    raise ValueError(f"No showcase cameras found in MJCF: {mjcf_path}")
+
+
+def showcase_output_name(scenario: str, camera: str) -> str:
+    """Build the canonical showcase MP4 filename for a scenario/camera pair."""
+    return f"{scenario}_{camera}.mp4"
+
+
 def interpolate_waypoints(
     waypoints: list[npt.NDArray[np.float64]],
     duration_s: float,
@@ -107,7 +167,6 @@ def interpolate_waypoints(
 
     n_frames = max(2, int(round(duration_s * fps)))
     segment_count = len(waypoints) - 1
-    frames_per_segment = n_frames / segment_count
     trajectory = np.zeros((n_frames, 3), dtype=np.float64)
 
     for frame_idx in range(n_frames):
@@ -122,12 +181,6 @@ def interpolate_waypoints(
         trajectory[frame_idx] = (1.0 - alpha) * q0 + alpha * q1
 
     return np.clip(trajectory, _PPP_LIMITS[:, 0], _PPP_LIMITS[:, 1])
-
-
-_EGL_APT_HINT = (
-    "sudo apt install libegl1 libegl-mesa0 libgles2 libgl1 "
-    "libgl1-mesa-dri libosmesa6"
-)
 
 
 def _require_mujoco() -> tuple[object, object]:
@@ -171,17 +224,42 @@ def _set_slide_joint(
     data.qpos[qpos_adr] = value
 
 
+def _open_video_writer(path: Path, fps: int) -> object:
+    """Open an incremental MP4 writer (low memory for multi-POV export)."""
+    import imageio
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return imageio.get_writer(
+        str(path),
+        fps=fps,
+        codec="libx264",
+        pixelformat="yuv420p",
+        macro_block_size=1,
+    )
+
+
+def _frame_mean(frame: npt.NDArray[np.uint8]) -> float:
+    return float(frame.mean())
+
+
+def _assert_camera_exists(mujoco: object, model: object, camera: str) -> None:
+    cam_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, camera)
+    if cam_id < 0:
+        raise ValueError(f"Camera not found in MJCF: {camera}")
+
+
 def render_video(
     mjcf_path: Path,
     output_path: Path,
     *,
+    scenario: str = "ppp_warehouse",
     duration_s: float = 30.0,
     fps: int = 30,
     width: int = 1280,
     height: int = 720,
     camera: str = "overview",
     waypoints: list[npt.NDArray[np.float64]] | None = None,
-) -> Path:
+) -> RenderResult:
     """Render a headless MuJoCo MP4 for the PPP warehouse preview.
 
     Args:
@@ -195,9 +273,63 @@ def render_video(
         waypoints: Optional joint-space path; defaults to warehouse demo.
 
     Returns:
-        The output path (created parent directories as needed).
+        Render metadata including the output path and first-frame mean.
     """
-    mujoco, iio = _require_mujoco()
+    results = render_showcase_videos(
+        mjcf_path,
+        output_path.parent,
+        scenario=scenario,
+        cameras=[camera],
+        output_names={camera: output_path.name},
+        duration_s=duration_s,
+        fps=fps,
+        width=width,
+        height=height,
+        waypoints=waypoints,
+    )
+    return results[0]
+
+
+def render_showcase_videos(
+    mjcf_path: Path,
+    output_dir: Path,
+    *,
+    scenario: str = "ppp_warehouse",
+    cameras: list[str] | None = None,
+    output_names: dict[str, str] | None = None,
+    duration_s: float = 30.0,
+    fps: int = 30,
+    width: int = 1280,
+    height: int = 720,
+    waypoints: list[npt.NDArray[np.float64]] | None = None,
+) -> list[RenderResult]:
+    """Render one MP4 per showcase camera in a single simulation pass.
+
+    Each frame updates the robot once, then renders every requested POV.
+    Frames stream directly to disk to keep memory bounded.
+
+    Args:
+        mjcf_path: Path to the MJCF scene file.
+        output_dir: Directory for output MP4 files.
+        scenario: Scenario stem used in default filenames.
+        cameras: Camera names to export; defaults to all MJCF cameras.
+        output_names: Optional per-camera filename overrides.
+        duration_s: Clip length in seconds.
+        fps: Frame rate.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+        waypoints: Optional joint-space path; defaults to warehouse demo.
+
+    Returns:
+        One :class:`RenderResult` per exported camera.
+    """
+    mujoco, _iio = _require_mujoco()
+    camera_names = cameras if cameras is not None else list_showcase_cameras(
+        mjcf_path, scenario=scenario
+    )
+    if not camera_names:
+        raise ValueError("At least one showcase camera is required")
+
     path_waypoints = (
         waypoints if waypoints is not None else _PPP_WAREHOUSE_WAYPOINTS
     )
@@ -207,32 +339,55 @@ def render_video(
     data = mujoco.MjData(model)
     renderer = mujoco.Renderer(model, height=height, width=width)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    frames: list[npt.NDArray[np.uint8]] = []
+    for camera in camera_names:
+        _assert_camera_exists(mujoco, model, camera)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    names = output_names or {
+        camera: showcase_output_name(scenario, camera) for camera in camera_names
+    }
+    paths = {
+        camera: output_dir / names[camera] for camera in camera_names
+    }
+    writers = {
+        camera: _open_video_writer(paths[camera], fps) for camera in camera_names
+    }
+    first_frames: dict[str, npt.NDArray[np.uint8]] = {}
 
     joint_names = ("joint_x", "joint_y", "joint_z")
-    for q in trajectory:
-        for idx, name in enumerate(joint_names):
-            _set_slide_joint(mujoco, model, data, name, float(q[idx]))
-        mujoco.mj_forward(model, data)
-        renderer.update_scene(data, camera=camera)
-        frames.append(renderer.render().copy())
+    try:
+        for q in trajectory:
+            for idx, name in enumerate(joint_names):
+                _set_slide_joint(mujoco, model, data, name, float(q[idx]))
+            mujoco.mj_forward(model, data)
+            for camera in camera_names:
+                renderer.update_scene(data, camera=camera)
+                frame = renderer.render()
+                writers[camera].append_data(frame)
+                if camera not in first_frames:
+                    first_frames[camera] = frame.copy()
+    finally:
+        for writer in writers.values():
+            writer.close()
+        renderer.close()
 
-    renderer.close()
-    iio.imwrite(
-        output_path,
-        np.stack(frames, axis=0),
-        fps=fps,
-        codec="libx264",
-        pixelformat="yuv420p",
-    )
-    return output_path
+    results: list[RenderResult] = []
+    for camera in camera_names:
+        frame = first_frames[camera]
+        mean = _frame_mean(frame)
+        if mean <= 1.0:
+            raise RuntimeError(
+                f"Camera {camera!r} render looks blank (frame mean={mean:.2f})"
+            )
+        results.append(RenderResult(camera=camera, path=paths[camera], frame_mean=mean))
+
+    return results
 
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser."""
     parser = argparse.ArgumentParser(
-        description="Render a headless MuJoCo MP4 for FRET showcase scenarios.",
+        description="Render headless MuJoCo MP4s for FRET showcase scenarios.",
     )
     parser.add_argument(
         "--model",
@@ -248,8 +403,14 @@ def build_parser() -> argparse.ArgumentParser:
         "-o",
         "--output",
         type=Path,
-        default=Path("/tmp/fret_ppp_warehouse.mp4"),
-        help="Output MP4 path (default: /tmp/fret_ppp_warehouse.mp4)",
+        default=None,
+        help="Output MP4 path for single-camera mode",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("/tmp/fret_showcase"),
+        help="Output directory for --all-cameras (default: /tmp/fret_showcase)",
     )
     parser.add_argument(
         "--mjcf",
@@ -283,8 +444,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--camera",
-        default="overview",
-        help="MJCF camera name (default: overview)",
+        action="append",
+        dest="cameras",
+        metavar="NAME",
+        help="MJCF camera name (repeatable; default: overview)",
+    )
+    parser.add_argument(
+        "--all-cameras",
+        action="store_true",
+        help="Export every showcase camera defined in the MJCF",
     )
     return parser
 
@@ -293,16 +461,63 @@ def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     args = build_parser().parse_args(argv)
     mjcf_path = resolve_mjcf_path(args.model, args.scenario, args.mjcf)
-    output = render_video(
+
+    if args.all_cameras:
+        cameras = list_showcase_cameras(mjcf_path, scenario=args.scenario)
+        results = render_showcase_videos(
+            mjcf_path,
+            args.output_dir,
+            scenario=args.scenario,
+            cameras=cameras,
+            duration_s=args.duration,
+            fps=args.fps,
+            width=args.width,
+            height=args.height,
+        )
+        for result in results:
+            print(
+                f"Wrote {result.path} "
+                f"(camera={result.camera}, mean={result.frame_mean:.1f}, "
+                f"{args.duration:.1f}s @ {args.fps} fps)"
+            )
+        return 0
+
+    cameras = args.cameras or ["overview"]
+    if len(cameras) == 1:
+        output = args.output or Path(
+            f"/tmp/{showcase_output_name(args.scenario, cameras[0])}"
+        )
+        result = render_video(
+            mjcf_path,
+            output,
+            scenario=args.scenario,
+            duration_s=args.duration,
+            fps=args.fps,
+            width=args.width,
+            height=args.height,
+            camera=cameras[0],
+        )
+        print(
+            f"Wrote {result.path} ({args.duration:.1f}s @ {args.fps} fps, "
+            f"mean={result.frame_mean:.1f})"
+        )
+        return 0
+
+    results = render_showcase_videos(
         mjcf_path,
-        args.output,
+        args.output_dir,
+        scenario=args.scenario,
+        cameras=cameras,
         duration_s=args.duration,
         fps=args.fps,
         width=args.width,
         height=args.height,
-        camera=args.camera,
     )
-    print(f"Wrote {output} ({args.duration:.1f}s @ {args.fps} fps)")
+    for result in results:
+        print(
+            f"Wrote {result.path} "
+            f"(camera={result.camera}, mean={result.frame_mean:.1f})"
+        )
     return 0
 
 

--- a/scripts/video.sh
+++ b/scripts/video.sh
@@ -7,6 +7,7 @@
 # Examples:
 #   ./scripts/video.sh
 #   ./scripts/video.sh --model ppp --scenario ppp_warehouse -o /tmp/v10.mp4
+#   ./scripts/video.sh --all-cameras --output-dir /tmp/showcase
 #   ./scripts/video.sh --duration 15 --fps 24 --width 1920 --height 1080
 #
 set -Eeuo pipefail

--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -64,7 +64,11 @@
       </body>
     </body>
 
-    <!-- Fixed camera used by the headless renderer and interactive viewer. -->
+    <!-- Showcase cameras for headless release renders and the interactive viewer. -->
     <camera name="overview" mode="targetbody" target="gantry_base" pos="13 6 7" fovy="45"/>
+    <camera name="aisle" mode="targetbody" target="gantry_base" pos="-2 2 1.5" fovy="55"/>
+    <camera name="topdown" mode="targetbody" target="gantry_base" pos="6 2 14" fovy="40"/>
+    <camera name="follow" mode="targetbody" target="z_hoist" pos="2.5 1.5 1.2" fovy="50"/>
+    <camera name="pick" mode="targetbody" target="cargo" pos="1.5 0.5 0.8" fovy="45"/>
   </worldbody>
 </mujoco>

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -57,3 +57,21 @@ def test_interpolate_waypoints_respects_limits() -> None:
     assert np.all(traj[:, 0] <= rm._PPP_LIMITS[0, 1])
     assert np.all(traj[:, 1] <= rm._PPP_LIMITS[1, 1])
     assert np.all(traj[:, 2] <= rm._PPP_LIMITS[2, 1])
+
+
+def test_list_showcase_cameras_reads_mjcf() -> None:
+    path = rm.resolve_mjcf_path("ppp", "ppp_warehouse", None)
+    cameras = rm.list_showcase_cameras(path)
+    assert cameras == [
+        "overview",
+        "aisle",
+        "topdown",
+        "follow",
+        "pick",
+    ]
+
+
+def test_showcase_output_name() -> None:
+    assert rm.showcase_output_name("ppp_warehouse", "aisle") == (
+        "ppp_warehouse_aisle.mp4"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Richer release exports: five POV clips per PPP warehouse showcase, rendered in a single simulation pass.

### Cameras

| POV | Purpose |
|-----|---------|
| `overview` | Wide diagonal shot of the full warehouse |
| `aisle` | Low aisle-level view along the gantry travel path |
| `topdown` | Bird's-eye layout / obstacle context |
| `follow` | Tracks the Z hoist during motion |
| `pick` | Close-up on cargo pick-and-place |

### Changes

- `ppp_warehouse.xml`: four new `targetbody` cameras
- `render_mujoco.py`: `--all-cameras`, streaming multi-POV export, blank-frame guard per camera
- `release.yml`: exports all POVs, rich `meta.json`, artifacts uploaded **before** R2
- `download_showcase.sh`: `--camera` and `--all` options

### Test plan

- [x] Unit tests (`list_showcase_cameras`, output naming)
- [x] Local multi-POV render (5 clips, all `mean > 1`)
- [x] Release workflow on tag `v0.2.4`: [run #28906154152](https://github.com/alexandrelheinen/fret/actions/runs/28906154152) — 9m05s, all 5 POVs uploaded to R2
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb9459d9-65c6-4839-8a02-9b6e2d6acd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb9459d9-65c6-4839-8a02-9b6e2d6acd8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

