### PR TITLE
test(v1.0): V10-1 PPP MuJoCo SITL launch smoke tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,7 @@ jobs:
             gnupg
           python3 -m pip install --break-system-packages \
             pytest pytest-timeout
+          python3 -m pip install --break-system-packages -e ".[sim]"
 
       - name: Configure Gazebo apt repository
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
             gnupg
           python3 -m pip install --break-system-packages \
             pytest pytest-cov pytest-timeout
+          python3 -m pip install --break-system-packages -e ".[sim]"
 
       - name: Configure Gazebo apt repository
         run: |

--- a/scripts/tests/smoke.sh
+++ b/scripts/tests/smoke.sh
@@ -56,11 +56,19 @@ require_command ros2 "ros2 not found. Source /opt/ros/jazzy/setup.bash first."
 run_smoke_test() {
     local test_name="$1"
     shift
+    local timeout_s=20
+    if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+        timeout_s="$1"
+        shift
+    fi
+    if [[ "${1:-}" == "--" ]]; then
+        shift
+    fi
     local log_file="/tmp/smoke_${test_name}.log"
 
-    info "Smoke test: ${test_name}"
+    info "Smoke test: ${test_name} (${timeout_s}s)"
     set +e
-    timeout 20s "$@" >"${log_file}" 2>&1
+    timeout "${timeout_s}s" "$@" >"${log_file}" 2>&1
     local exit_code=$?
     set -e
 
@@ -80,16 +88,23 @@ FAILED=0
 echo "=== ROS 2 launch smoke tests ==="
 
 # MuJoCo viewer dry-run (no ROS, no display required).
-run_smoke_test "mujoco_view_dry_run" python3 scripts/view_mujoco.py --dry-run \
+run_smoke_test "mujoco_view_dry_run" -- python3 scripts/view_mujoco.py --dry-run \
+    || FAILED=1
+
+# v1.0 V10-1: PPP warehouse MuJoCo SITL (no Gazebo dependency).
+run_smoke_test "sitl_ppp_warehouse_mujoco" 30 -- \
+    env MUJOCO_GL=egl PYOPENGL_PLATFORM=egl \
+    xvfb-run -a ros2 launch fret sitl.py \
+    scenario:=ppp_warehouse model:=ppp backend:=mujoco \
     || FAILED=1
 
 # Gazebo-dependent launches — skip gracefully when ros_gz_sim is not installed.
 if ros2 pkg prefix ros_gz_sim >/dev/null 2>&1; then
-    run_smoke_test "sim_launch"           xvfb-run -a ros2 launch fret sim.py model:=scara \
+    run_smoke_test "sim_launch" -- xvfb-run -a ros2 launch fret sim.py model:=scara \
         || FAILED=1
-    run_smoke_test "arco_scenario_launch" xvfb-run -a ros2 launch fret arco_scenario.py \
+    run_smoke_test "arco_scenario_launch" -- xvfb-run -a ros2 launch fret arco_scenario.py \
         || FAILED=1
-    run_smoke_test "sitl_launch"          xvfb-run -a ros2 launch fret sitl.py \
+    run_smoke_test "sitl_launch" -- xvfb-run -a ros2 launch fret sitl.py \
         || FAILED=1
 else
     info "ros_gz_sim not found — skipping Gazebo-dependent smoke tests (sim_launch, arco_scenario_launch, sitl_launch)."

--- a/tests/integration/test_sitl_ppp_warehouse_launch.py
+++ b/tests/integration/test_sitl_ppp_warehouse_launch.py
@@ -1,0 +1,143 @@
+"""V10-1 integration smoke: PPP warehouse MuJoCo SITL launch.
+
+Validates releases.md acceptance criterion V10-1:
+
+    ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco
+
+The launch must start all pipeline nodes and remain alive without fatal
+errors long enough for perception, planning, and control to initialise.
+
+Requires a built ROS 2 workspace and sourced overlay (see
+``scripts/tests/integration.sh``).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+from collections.abc import Iterator
+
+import pytest
+
+_REQUIRED_NODES: frozenset[str] = frozenset(
+    {
+        "/mujoco_bridge_node",
+        "/planner_node",
+        "/controller_node",
+        "/perception_bridge_node",
+        "/scene_acquisition_node",
+    }
+)
+
+_FATAL_PATTERNS: tuple[str, ...] = (
+    "process has died",
+    "process has finished",
+    "No executable found",
+    "package 'fret' not found",
+    "Failed to load",
+    "Traceback (most recent call last)",
+)
+
+
+def _ros2_node_names() -> set[str]:
+    """Return the current ROS 2 node name list."""
+    proc = subprocess.run(
+        ["ros2", "node", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=15,
+    )
+    return {line.strip() for line in proc.stdout.splitlines() if line.strip()}
+
+
+def _terminate_process_group(proc: subprocess.Popen[str]) -> None:
+    """Send SIGTERM to the launch process group and wait for exit."""
+    if proc.poll() is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+    except ProcessLookupError:
+        return
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        proc.wait(timeout=10)
+
+
+@pytest.fixture()
+def ppp_warehouse_sitl_launch() -> Iterator[subprocess.Popen[str]]:
+    """Launch SC-v10 SITL and tear it down after the test."""
+    env = os.environ.copy()
+    env.setdefault("MUJOCO_GL", "egl")
+    env.setdefault("PYOPENGL_PLATFORM", "egl")
+
+    proc = subprocess.Popen(
+        [
+            "ros2",
+            "launch",
+            "fret",
+            "sitl.py",
+            "scenario:=ppp_warehouse",
+            "model:=ppp",
+            "backend:=mujoco",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        yield proc
+    finally:
+        _terminate_process_group(proc)
+        if proc.stdout is not None:
+            proc.stdout.close()
+
+
+@pytest.mark.timeout(120)
+def test_v10_1_ppp_warehouse_mujoco_sitl_starts(
+    ros_context: None,
+    ppp_warehouse_sitl_launch: subprocess.Popen[str],
+) -> None:
+    """V10-1: MuJoCo PPP SITL launch stays up with all core nodes present."""
+    del ros_context  # fixture ensures rclpy is initialised for ros2 CLI
+    proc = ppp_warehouse_sitl_launch
+
+    deadline = time.monotonic() + 45.0
+    nodes_ok = False
+    log_lines: list[str] = []
+
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            break
+        if proc.stdout is not None and proc.stdout.readable():
+            line = proc.stdout.readline()
+            if line:
+                log_lines.append(line.rstrip())
+        nodes = _ros2_node_names()
+        if _REQUIRED_NODES.issubset(nodes):
+            nodes_ok = True
+            break
+        time.sleep(0.5)
+
+    log_tail = "\n".join(log_lines[-40:])
+    assert proc.poll() is None, (
+        "SITL launch exited before all nodes were ready.\n" f"{log_tail}"
+    )
+    assert nodes_ok, (
+        "Timed out waiting for PPP warehouse SITL nodes.\n"
+        f"Expected: {sorted(_REQUIRED_NODES)}\n"
+        f"Seen: {sorted(_ros2_node_names())}\n"
+        f"{log_tail}"
+    )
+
+    combined_log = "\n".join(log_lines)
+    for pattern in _FATAL_PATTERNS:
+        assert (
+            pattern not in combined_log
+        ), f"Launch log contains fatal pattern {pattern!r}.\n{log_tail}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **V10-1** acceptance testing: `ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco` must start cleanly and keep all pipeline nodes alive.

## Changes

- **`scripts/tests/smoke.sh`**: new `sitl_ppp_warehouse_mujoco` case (30 s timeout, MuJoCo EGL env)
- **`tests/integration/test_sitl_ppp_warehouse_launch.py`**: pytest integration test verifying core nodes start and stay alive
- **CI**: install `-e ".[sim]"` in `tests.yml` and `integration.yml`

## Test plan

```bash
./scripts/build.sh
bash scripts/tests/smoke.sh
bash scripts/tests/integration.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71fe2f9d-1086-47a4-94b3-7e0370cf2dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71fe2f9d-1086-47a4-94b3-7e0370cf2dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

