### PR TITLE
feat(v1.0): cargo-inclusive planning, doc sync, release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Full specification: **[docs/releases.md](docs/releases.md)**
 
 | Layer | Technology |
 |---|---|
-| Planning | ARCO (SST, KDTree, pruner) |
+| Planning | ARCO (RRT*, SST, KDTree, pruner) |
 | Middleware | ROS 2 Jazzy |
 | Visual simulation | MuJoCo |
 | Engineering SITL | Gazebo Harmonic (v1.2+) |
@@ -65,7 +65,16 @@ source /opt/ros/jazzy/setup.bash && source install/setup.bash
 
 ```bash
 pip install -e ".[sim]"
-./scripts/video.sh -o /tmp/fret_ppp_warehouse.mp4
+./scripts/video.sh --collision-backend mujoco --planner-algorithm rrt_star -o /tmp/fret_ppp_warehouse.mp4
+```
+
+**Release showcase (v1.0.0+):** after tagging, CI uploads multi-POV warehouse clips to
+Cloudflare R2. Download locally:
+
+```bash
+./scripts/download_showcase.sh --tag v1.0.0 --all
+# or latest overview:
+./scripts/download_showcase.sh --latest
 ```
 
 ---
@@ -222,7 +231,10 @@ ROS nodes in `fret.ros` handle simulator I/O only.
 | v1.0 MuJoCo bridge (T10-03) | ✅ Done |
 | v1.0 scenario launch (T10-06) | ✅ Done |
 | v1.0 E2E acceptance V10-2…5 | ✅ Done |
+| v1.0 ROS SITL smoke V10-1 | ✅ Done |
 | v1.0 release video CI (V10-6) | ✅ Done |
+| v1.0 cargo-inclusive transit planning (FR-GSP-02) | ✅ Done |
+| v1.0.0 git tag + R2 showcase | 🔲 Pending tag |
 | v1.1 – v1.3 | 🔲 Specified |
 
 ---

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -23,7 +23,7 @@ robot class, one showcase scenario, and one article-ready visual demo.
 
 **Platform stack (all releases):**
 
-- **Planning:** ARCO (SST, KDTree occupancy, trajectory pruner)
+- **Planning:** ARCO (RRT*, SST, KDTree occupancy, trajectory pruner)
 - **Middleware:** ROS 2 Jazzy
 - **Engineering SITL:** Gazebo Harmonic (where applicable)
 - **Showcase visuals:** MuJoCo
@@ -89,7 +89,7 @@ boxes and width-crossing barriers create detours (see ARCO PPP scene for referen
 | # | Criterion |
 |---|---|
 | V10-1 | `ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco` runs without error |
-| V10-2 | ARCO SST finds collision-free path within 30 s (EE + welded box) |
+| V10-2 | ARCO RRT* finds collision-free path within 30 s (EE + welded box, MuJoCo contacts) |
 | V10-3 | Gantry tracks trajectory; EE position error ≤ 10 mm in MuJoCo |
 | V10-4 | Cargo box picked at start zone, released at goal zone |
 | V10-5 | No collision between welded box and static obstacles along executed path |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -120,9 +120,9 @@ Layers: `SYS`, `SCN`, `PLN`, `CTL`, `GSP` (grasp), `SIM`, `HW`
 | Parameter | Value |
 |---|---|
 | Joints | 3 prismatic (x, y, z) |
-| Workspace | [0,60] × [0,20] × [0,6] m |
+| Workspace | [0,60] × [0,20] × [0,6] m (full); 12×4×3 m MJCF preview |
 | Cargo | 0.5 m box, magnetic weld |
-| Planner | ARCO SST |
+| Planner | ARCO RRT* (MuJoCo collision) |
 
 ### v1.1 — Dubins
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
 v0.9  ✅  Bootstrap SCARA pipeline (MS-1–5, pure-Python CI)
   │
   ▼
-v1.0  🔲  PPP gantry — warehouse box pick-and-place (magnetic grasp, MuJoCo)
+v1.0  ✅  PPP gantry — warehouse box pick-and-place (magnetic grasp, MuJoCo)
   │
   ▼
 v1.1  🔲  Dubins dual-robot race A→B through column forest
@@ -61,17 +61,18 @@ Validated on SCARA (RRP, 3-DOF):
 
 ---
 
-## Phase 2 — v1.0 PPP warehouse 🔲 *Current*
+## Phase 2 — v1.0 PPP warehouse ✅ *Complete*
 
 **Robot:** PPP gantry (3 prismatic). **Scenario:** SC-v10 magnetic box transport.
 
-- [ ] PPP kinematics and joint-space controller
-- [ ] Magnetic grasp FSM (weld / release)
-- [ ] PPP C-space collision checker (EE + cargo envelope)
-- [ ] MuJoCo MJCF: gantry + warehouse obstacles
-- [ ] MuJoCo backend adapter (`backend:=mujoco`)
-- [ ] Scenario `ppp_warehouse.yml` + launch
-- [ ] Headless MP4 render for README / article
+- [x] PPP kinematics and joint-space controller
+- [x] Magnetic grasp FSM (weld / release)
+- [x] PPP C-space collision checker (EE + cargo envelope, MuJoCo contacts)
+- [x] MuJoCo MJCF: gantry + warehouse obstacles
+- [x] MuJoCo backend adapter (`backend:=mujoco`)
+- [x] Scenario `ppp_warehouse.yml` + launch
+- [x] Headless MP4 render for README / article (RRT* + prune + tracking)
+- [x] V10-1 ROS SITL smoke test
 - [ ] Tag `v1.0.0`
 
 ---

--- a/docs/robots/README.md
+++ b/docs/robots/README.md
@@ -4,7 +4,7 @@ Each FRET release targets one robot class. Models are selectable via `model:=` a
 
 | Model | Release | Doc | Status |
 |---|---|---|---|
-| `ppp` | v1.0 | [ppp.md](ppp.md) | 🔲 Planned |
+| `ppp` | v1.0 | [ppp.md](ppp.md) | ✅ Shipped |
 | `dubins` | v1.1 | [dubins.md](dubins.md) | 🔲 Planned |
 | `rrp` / `scara` | v1.2 | [rrp.md](rrp.md) | 🟡 Bootstrap exists |
 | `six_dof` | v1.3 | [six_dof.md](six_dof.md) | 🔲 Planned |

--- a/docs/robots/ppp.md
+++ b/docs/robots/ppp.md
@@ -90,7 +90,9 @@ FRET v1.0 PPP scenarios derive obstacle layouts from ARCO:
 - `arco/map/ppp.yml`
 - `arco/simulator/scenes/ppp.py`
 
-Planning uses ARCO `SSTPlanner` with `KDTreeOccupancy` in 3-D C-space.
+Planning uses ARCO `RRTPlanner` with MuJoCo MJCF contact checks (or analytic
+PPP envelopes). Transit planning includes the welded cargo box when
+``plan_include_cargo:=true`` (FR-GSP-02).
 
 ---
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -25,10 +25,11 @@ using magnetic grasp.
 
 | Parameter | Value |
 |---|---|
-| Workspace | 60 × 20 × 6 m |
-| Obstacles | Static boxes (ARCO `ppp.yml` layout) |
+| Workspace | 12 × 4 × 3 m (1:5 MJCF preview; full ARCO layout in `ppp_warehouse_obstacles.yml`) |
+| Obstacles | Static boxes + shelf racks (ARCO `ppp.yml` preview layout) |
 | Grasp | Magnetic weld |
-| Planner | ARCO SST |
+| Planner | ARCO RRT* (MuJoCo collision contacts) |
+| Collision | `collision_backend:=mujoco`, `plan_include_cargo:=true` |
 | Timeout | 30 s |
 
 **Pass criteria:** See [releases.md § v1.0](releases.md#v10--ppp-gantry-warehouse-pick-and-place).

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -180,6 +180,7 @@ def plan_ppp_warehouse_path(
     """
     _ensure_fret_importable()
     from fret.interfaces import PlanningRequest, PlanningStatus
+    from fret.control.grasp_magnet import parse_grasp_config
     from fret.planning.planner_node import PlannerNode
     from fret.planning.ppp_obstacles import load_preview_workspace_bounds
     from fret.scenario.ppp_warehouse_runner import _build_occupancy_adapter
@@ -194,6 +195,8 @@ def plan_ppp_warehouse_path(
     resolved_collision = str(
         params.get("collision_backend", collision_backend)
     )
+    grasp_cfg = parse_grasp_config(dict(params.get("grasp", {})))
+    plan_include_cargo = bool(params.get("plan_include_cargo", True))
 
     planner = PlannerNode(
         model="ppp",
@@ -201,6 +204,8 @@ def plan_ppp_warehouse_path(
         occupancy=box_occ,
         collision_backend=resolved_collision,  # type: ignore[arg-type]
         planner_algorithm=resolved_planner,  # type: ignore[arg-type]
+        include_cargo=plan_include_cargo,
+        grasp_config=grasp_cfg,
         scenario=str(params.get("scenario_id", scenario)),
         workspace_bounds=preview_bounds,
         mjcf_path=resolved_mjcf,
@@ -278,22 +283,32 @@ def resolve_showcase_waypoints(
 
 def build_pruned_dense_waypoints(
     path: list[npt.NDArray[np.float64]],
+    *,
+    scenario: str = "ppp_warehouse",
 ) -> list[npt.NDArray[np.float64]]:
     """Prune and densify a planner path for controller tracking."""
     _ensure_fret_importable()
+    from fret.control.grasp_magnet import parse_grasp_config
     from fret.control.kinematics import Kinematics
     from fret.planning.cspace_checker import make_cspace_checker
     from fret.planning.planner_node import _CSpaceOccupancy
     from fret.planning.ppp_obstacles import build_box_obstacle_occupancy
     from fret.planning.trajectory_generator import TrajectoryGenerator
+    from fret.sitl_config import load_scenario_parameters
+
+    params = load_scenario_parameters(_scenario_config_path(scenario))
+    grasp_cfg = parse_grasp_config(dict(params.get("grasp", {})))
+    plan_include_cargo = bool(params.get("plan_include_cargo", True))
 
     kin = Kinematics("ppp")
     occ = build_box_obstacle_occupancy([])
     checker = make_cspace_checker(
         kin,
         occ,
+        include_cargo=plan_include_cargo,
+        grasp_config=grasp_cfg,
         collision_backend="mujoco",
-        scenario="ppp_warehouse",
+        scenario=scenario,
     )
     traj_gen = TrajectoryGenerator(kin)
     traj_gen.set_collision_context(
@@ -593,7 +608,10 @@ def render_showcase_videos(
         waypoints=waypoints,
     )
     if collision_backend is not None and use_tracking:
-        dense = build_pruned_dense_waypoints(path_waypoints)
+        dense = build_pruned_dense_waypoints(
+            path_waypoints,
+            scenario=scenario,
+        )
         trajectory = simulate_tracked_trajectory(
             dense,
             duration_s=duration_s,

--- a/src/fret/config/scenarios/ppp_warehouse.yml
+++ b/src/fret/config/scenarios/ppp_warehouse.yml
@@ -24,6 +24,7 @@
     # Collision checking: analytic (AABB + occupancy) or mujoco (MJCF contacts).
     collision_backend: mujoco
     planner_algorithm: rrt_star
+    plan_include_cargo: true
 
     grasp:
       capture_radius: 0.3

--- a/src/fret/control/grasp_magnet.py
+++ b/src/fret/control/grasp_magnet.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass, field
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -69,6 +70,34 @@ class GraspConfig:
             )
         if np.any(self.box_half_extent <= 0.0):
             raise ValueError("box_half_extent components must be positive")
+
+
+def parse_grasp_config(grasp: dict[str, Any] | None) -> GraspConfig:
+    """Build ``GraspConfig`` from scenario ``grasp`` parameters."""
+    params = dict(grasp) if grasp is not None else {}
+    capture_radius = float(
+        params.get("capture_radius", _DEFAULT_CAPTURE_RADIUS)
+    )
+    goal_radius = float(params.get("goal_radius", _DEFAULT_GOAL_RADIUS))
+
+    weld_raw = params.get("weld_offset", _DEFAULT_WELD_OFFSET.tolist())
+    if isinstance(weld_raw, (int, float)):
+        weld_offset = np.array([0.0, 0.0, float(weld_raw)], dtype=np.float64)
+    else:
+        weld_offset = np.asarray(weld_raw, dtype=np.float64).reshape(3)
+
+    half_raw = params.get("box_half_extent", 0.25)
+    if isinstance(half_raw, (int, float)):
+        box_half = np.full(3, float(half_raw), dtype=np.float64)
+    else:
+        box_half = np.asarray(half_raw, dtype=np.float64).reshape(3)
+
+    return GraspConfig(
+        capture_radius=capture_radius,
+        goal_radius=goal_radius,
+        weld_offset=weld_offset,
+        box_half_extent=box_half,
+    )
 
 
 class MagneticGraspFSM:

--- a/src/fret/planning/cspace_checker_mujoco.py
+++ b/src/fret/planning/cspace_checker_mujoco.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from fret.control.kinematics import Kinematics
 
 _OBSTACLE_GEOM_PREFIXES: tuple[str, ...] = ("obs_", "rack_")
+_CARGO_GEOM_NAMES: frozenset[str] = frozenset({"cargo_box"})
 _FREE_CLEARANCE_M: float = 0.01
 _COLLISION_CLEARANCE_M: float = -0.01
 
@@ -67,7 +68,11 @@ class MujocoPPPCollisionChecker:
         self._dof = kinematics.dof
         self._mujoco, self._model, self._data = self._load_runtime()
         self._qpos_adrs = self._resolve_qpos_addresses()
-        self._robot_geom_ids, self._obstacle_geom_ids = self._classify_geoms()
+        (
+            self._base_robot_geom_ids,
+            self._cargo_geom_ids,
+            self._obstacle_geom_ids,
+        ) = self._classify_geoms()
 
     @property
     def include_cargo(self) -> bool:
@@ -107,10 +112,13 @@ class MujocoPPPCollisionChecker:
             adrs.append(adr)
         return adrs
 
-    def _classify_geoms(self) -> tuple[set[int], set[int]]:
+    def _classify_geoms(
+        self,
+    ) -> tuple[set[int], set[int], set[int]]:
         mujoco = self._mujoco
         model = self._model
         robot_ids: set[int] = set()
+        cargo_ids: set[int] = set()
         obstacle_ids: set[int] = set()
         for gid in range(model.ngeom):
             if int(model.geom_contype[gid]) == 0:
@@ -121,13 +129,21 @@ class MujocoPPPCollisionChecker:
                 continue
             if name.startswith(_OBSTACLE_GEOM_PREFIXES):
                 obstacle_ids.add(gid)
+            elif name in _CARGO_GEOM_NAMES:
+                cargo_ids.add(gid)
             elif name == "goal_zone":
                 continue
             else:
                 robot_ids.add(gid)
         if not obstacle_ids:
             raise ValueError("MJCF contains no obstacle collision geoms")
-        return robot_ids, obstacle_ids
+        return robot_ids, cargo_ids, obstacle_ids
+
+    def _active_robot_geom_ids(self) -> set[int]:
+        """Robot geoms used for collision queries (cargo optional, FR-GSP-02)."""
+        if self._config.include_cargo:
+            return self._base_robot_geom_ids | self._cargo_geom_ids
+        return set(self._base_robot_geom_ids)
 
     def _set_configuration(
         self, configuration: npt.NDArray[np.float64]
@@ -141,13 +157,12 @@ class MujocoPPPCollisionChecker:
         model = self._model
         data = self._data
         mujoco.mj_collision(model, data)
+        robot_ids = self._active_robot_geom_ids()
         for i in range(int(data.ncon)):
             con = data.contact[i]
             g1, g2 = int(con.geom1), int(con.geom2)
-            if (
-                g1 in self._robot_geom_ids and g2 in self._obstacle_geom_ids
-            ) or (
-                g2 in self._robot_geom_ids and g1 in self._obstacle_geom_ids
+            if (g1 in robot_ids and g2 in self._obstacle_geom_ids) or (
+                g2 in robot_ids and g1 in self._obstacle_geom_ids
             ):
                 return True
         return False

--- a/src/fret/planning/planner_node.py
+++ b/src/fret/planning/planner_node.py
@@ -29,6 +29,7 @@ from typing import Any, Literal
 import numpy as np
 import numpy.typing as npt
 
+from fret.control.grasp_magnet import GraspConfig
 from fret.interfaces import (
     ErrorCode,
     PlanningRequest,
@@ -90,6 +91,8 @@ class PlannerNode:
             occupancy model.
         collision_backend: PPP collision backend (``analytic`` or ``mujoco``).
         planner_algorithm: ARCO planner (``rrt_star`` or ``sst``).
+        include_cargo: When True, PPP planning includes welded cargo (FR-GSP-02).
+        grasp_config: Cargo geometry for PPP cargo-inclusive checks.
         scenario: Scenario stem for MJCF resolution (MuJoCo backend).
         mjcf_path: Optional MJCF override for MuJoCo collision checks.
     """
@@ -102,6 +105,8 @@ class PlannerNode:
         occupancy: Any | None = None,
         collision_backend: CollisionBackend = "analytic",
         planner_algorithm: PlannerAlgorithm = "rrt_star",
+        include_cargo: bool = False,
+        grasp_config: GraspConfig | None = None,
         scenario: str = "ppp_warehouse",
         mjcf_path: str | pathlib.Path | None = None,
         workspace_bounds: (
@@ -121,6 +126,8 @@ class PlannerNode:
         self._traj_gen = TrajectoryGenerator(self._kin)
         self._collision_backend = collision_backend
         self._planner_algorithm = planner_algorithm
+        self._include_cargo = include_cargo
+        self._grasp_config = grasp_config
         self._scenario = scenario
         self._mjcf_path = mjcf_path
         self._workspace_bounds = workspace_bounds
@@ -166,6 +173,8 @@ class PlannerNode:
             checker = make_cspace_checker(
                 self._kin,
                 occ,
+                include_cargo=self._include_cargo,
+                grasp_config=self._grasp_config,
                 collision_backend=self._collision_backend,
                 scenario=self._scenario,
                 mjcf_path=self._mjcf_path,

--- a/src/fret/planning/planner_node_ros.py
+++ b/src/fret/planning/planner_node_ros.py
@@ -75,6 +75,11 @@ class PlannerRosNode:  # pragma: no cover
         self.declare_parameter("start_configuration", [])  # type: ignore[attr-defined]
         self.declare_parameter("collision_backend", "analytic")  # type: ignore[attr-defined]
         self.declare_parameter("planner_algorithm", "rrt_star")  # type: ignore[attr-defined]
+        self.declare_parameter("plan_include_cargo", False)  # type: ignore[attr-defined]
+        self.declare_parameter("grasp.capture_radius", 0.3)  # type: ignore[attr-defined]
+        self.declare_parameter("grasp.goal_radius", 0.5)  # type: ignore[attr-defined]
+        self.declare_parameter("grasp.weld_offset", [0.0, 0.0, 0.0])  # type: ignore[attr-defined]
+        self.declare_parameter("grasp.box_half_extent", 0.25)  # type: ignore[attr-defined]
 
         self._model = str(
             self.get_parameter("model").get_parameter_value().string_value  # type: ignore[attr-defined]
@@ -113,6 +118,12 @@ class PlannerRosNode:  # pragma: no cover
             .get_parameter_value()
             .string_value
         )
+        self._plan_include_cargo = bool(
+            self.get_parameter("plan_include_cargo")  # type: ignore[attr-defined]
+            .get_parameter_value()
+            .bool_value
+        )
+        self._grasp_config = self._read_grasp_config()
 
         # ------------------------------------------------------------------
         # Publisher — TRANSIENT_LOCAL so late-joining controller receives it
@@ -175,6 +186,35 @@ class PlannerRosNode:  # pragma: no cover
                 self._joint_states_callback,
                 be_qos,
             )
+
+    def _read_grasp_config(self) -> Any:
+        """Read PPP grasp geometry from ROS parameters."""
+        from fret.control.grasp_magnet import parse_grasp_config
+
+        return parse_grasp_config(
+            {
+                "capture_radius": self.get_parameter(  # type: ignore[attr-defined]
+                    "grasp.capture_radius"
+                )
+                .get_parameter_value()
+                .double_value,
+                "goal_radius": self.get_parameter(  # type: ignore[attr-defined]
+                    "grasp.goal_radius"
+                )
+                .get_parameter_value()
+                .double_value,
+                "weld_offset": list(
+                    self.get_parameter("grasp.weld_offset")  # type: ignore[attr-defined]
+                    .get_parameter_value()
+                    .double_array_value
+                ),
+                "box_half_extent": self.get_parameter(  # type: ignore[attr-defined]
+                    "grasp.box_half_extent"
+                )
+                .get_parameter_value()
+                .double_value,
+            }
+        )
 
     # ------------------------------------------------------------------
     # Callbacks
@@ -296,6 +336,10 @@ class PlannerRosNode:  # pragma: no cover
             occupancy_adapter=self._occ_adapter,
             collision_backend=self._collision_backend,  # type: ignore[arg-type]
             planner_algorithm=self._planner_algorithm,  # type: ignore[arg-type]
+            include_cargo=self._plan_include_cargo,
+            grasp_config=(
+                self._grasp_config if self._model == "ppp" else None
+            ),
             scenario=self._scenario_id,
         )
         request = PlanningRequest(

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -19,7 +19,12 @@ import numpy as np
 import numpy.typing as npt
 
 from fret.control.controller_ppp import PPPControllerNode
-from fret.control.grasp_magnet import GraspConfig, GraspState, MagneticGraspFSM
+from fret.control.grasp_magnet import (
+    GraspConfig,
+    GraspState,
+    MagneticGraspFSM,
+    parse_grasp_config,
+)
 from fret.control.kinematics import Kinematics
 from fret.interfaces import (
     OccupancyUpdatePayload,
@@ -71,27 +76,7 @@ class PPPWarehouseRunResult:
 
 def _parse_grasp_config(grasp: dict[str, Any]) -> GraspConfig:
     """Build ``GraspConfig`` from scenario ``grasp`` parameters."""
-    capture_radius = float(grasp.get("capture_radius", 0.3))
-    goal_radius = float(grasp.get("goal_radius", 0.5))
-
-    weld_raw = grasp.get("weld_offset", [0.0, 0.0, 0.25])
-    if isinstance(weld_raw, (int, float)):
-        weld_offset = np.array([0.0, 0.0, float(weld_raw)], dtype=np.float64)
-    else:
-        weld_offset = np.asarray(weld_raw, dtype=np.float64).reshape(3)
-
-    half_raw = grasp.get("box_half_extent", 0.25)
-    if isinstance(half_raw, (int, float)):
-        box_half = np.full(3, float(half_raw), dtype=np.float64)
-    else:
-        box_half = np.asarray(half_raw, dtype=np.float64).reshape(3)
-
-    return GraspConfig(
-        capture_radius=capture_radius,
-        goal_radius=goal_radius,
-        weld_offset=weld_offset,
-        box_half_extent=box_half,
-    )
+    return parse_grasp_config(grasp)
 
 
 def _build_occupancy_adapter(
@@ -248,6 +233,7 @@ class PPPWarehouseRunner:
         goal = np.asarray(params["goal_configuration"], dtype=np.float64)
         timeout = float(params.get("planning_timeout", _PLANNING_TIMEOUT_S))
         grasp_cfg = _parse_grasp_config(dict(params.get("grasp", {})))
+        plan_include_cargo = bool(params.get("plan_include_cargo", True))
 
         occ_adapter, box_occ = _build_occupancy_adapter(self._obstacle_path)
         preview_bounds = load_preview_workspace_bounds(self._obstacle_path)
@@ -261,6 +247,8 @@ class PPPWarehouseRunner:
             occupancy=box_occ,
             collision_backend=collision_backend,  # type: ignore[arg-type]
             planner_algorithm=planner_algorithm,  # type: ignore[arg-type]
+            include_cargo=plan_include_cargo,
+            grasp_config=grasp_cfg,
             scenario=scenario_id,
             workspace_bounds=preview_bounds,
         )
@@ -292,7 +280,7 @@ class PPPWarehouseRunner:
             kin,
             box_occ,
             plan_result.path,
-            include_cargo=False,
+            include_cargo=plan_include_cargo,
             grasp_config=grasp_cfg,
             collision_backend=collision_backend,
             scenario=scenario_id,

--- a/tests/planning/test_cspace_checker_mujoco.py
+++ b/tests/planning/test_cspace_checker_mujoco.py
@@ -47,3 +47,24 @@ def test_mujoco_detects_shelf_penetration(mujoco_available: None) -> None:
     q = np.array([9.0, 3.56, 1.0])
     assert checker.is_collision_free(q) is False
     assert checker.clearance(q) < 0.0
+
+
+def test_mujoco_include_cargo_flag(mujoco_available: None) -> None:
+    """Cargo geom is optional in MuJoCo contact checks (FR-GSP-02)."""
+    kin = Kinematics("ppp")
+    checker_ee = make_cspace_checker(
+        kin,
+        build_box_obstacle_occupancy([]),
+        collision_backend="mujoco",
+        include_cargo=False,
+    )
+    checker_cargo = make_cspace_checker(
+        kin,
+        build_box_obstacle_occupancy([]),
+        collision_backend="mujoco",
+        include_cargo=True,
+    )
+    assert isinstance(checker_ee, MujocoPPPCollisionChecker)
+    assert checker_ee.include_cargo is False
+    assert checker_cargo.include_cargo is True
+    assert len(checker_cargo._cargo_geom_ids) > 0

--- a/tests/planning/test_planner_node_ros.py
+++ b/tests/planning/test_planner_node_ros.py
@@ -198,6 +198,7 @@ def _new_node(
         "start_configuration": start_cfg if start_cfg is not None else [],
         "collision_backend": "analytic",
         "planner_algorithm": "rrt_star",
+        "plan_include_cargo": False,
     }
 
     mock_trigger = MagicMock()
@@ -376,6 +377,8 @@ class TestTriggerPlanning:
         inst._planning_timeout = 10.0  # type: ignore[attr-defined]
         inst._collision_backend = "analytic"  # type: ignore[attr-defined]
         inst._planner_algorithm = "rrt_star"  # type: ignore[attr-defined]
+        inst._plan_include_cargo = False  # type: ignore[attr-defined]
+        inst._grasp_config = None  # type: ignore[attr-defined]
         inst._start_cfg = [0.0, 0.0, 0.0]  # type: ignore[attr-defined]
         inst._planned = False  # type: ignore[attr-defined]
         inst._occ_adapter = OccupancyAdapter()  # type: ignore[attr-defined]

--- a/tests/test_sitl_config.py
+++ b/tests/test_sitl_config.py
@@ -71,6 +71,7 @@ def test_load_ppp_warehouse_scenario() -> None:
     assert params["goal_configuration"] == [10.5, 2.8, 2.65]
     assert params["collision_backend"] == "mujoco"
     assert params["planner_algorithm"] == "rrt_star"
+    assert params["plan_include_cargo"] is True
     assert params["planning_timeout"] == 30.0
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the remaining v1.0 checklist items after PR #62 (MuJoCo + RRT*) and PR #63 (V10-1 SITL smoke).

## Changes

### FR-GSP-02 — cargo-inclusive transit planning
- `plan_include_cargo: true` in `ppp_warehouse.yml`
- `PlannerNode` passes `include_cargo` + `GraspConfig` into `make_cspace_checker`
- `MujocoPPPCollisionChecker` toggles `cargo_box` geom contacts based on `include_cargo`
- Runner, ROS planner node, and release video script use the same settings

### Documentation sync
- `releases.md`, `scenarios.md`, `requirements.md`, `roadmap.md`, `robots/ppp.md` updated for **RRT*** + MuJoCo collision + 1:5 preview workspace
- README: R2 showcase download instructions for `v1.0.0`

## Test plan

```bash
pip install -e ".[dev,sim]"
python3 -m pytest tests/planning/test_cspace_checker_mujoco.py tests/test_sitl_config.py -v
python3 -c "from fret.scenario.ppp_warehouse_runner import PPPWarehouseRunner; r=PPPWarehouseRunner().run(); assert r.path_collision_free"
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71fe2f9d-1086-47a4-94b3-7e0370cf2dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71fe2f9d-1086-47a4-94b3-7e0370cf2dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

