### PR TITLE
Set up FRET development environment (ROS 2 Jazzy + MuJoCo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,40 @@ conflict, resolve in this order:
 
 An imperative order (implement, add, fix…) always implies the full V-cycle
 described in [CONTRIBUTING.md](CONTRIBUTING.md), not code alone.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for cloud agents. The base VM snapshot already has
+ROS 2 Jazzy Desktop + Gazebo Harmonic, headless-GL libraries, `xvfb`, and a
+complete C/C++ toolchain installed system-wide. The startup update script only
+refreshes Python deps (`pip install -e ".[dev,sim]"`, installed to `~/.local`;
+this also reinstalls the `arco` git dependency from its `main` branch, so it
+needs network access). Standard build/test/run commands live in
+[README.md](README.md), [CONTRIBUTING.md](CONTRIBUTING.md), and `scripts/`.
+
+- **Sourcing:** ROS is not sourced by default. Run
+  `source /opt/ros/jazzy/setup.bash` and, after building,
+  `source install/setup.bash`. `scripts/build.sh`, `scripts/tests/*.sh` source
+  these themselves.
+- **pytest vs ROS plugins (important):** The pip `pytest` (>=8, currently 9.x)
+  is incompatible with ROS Jazzy's `launch_testing` / `launch_ros` pytest
+  plugins (they use the removed `path` hook arg). With the ROS overlay sourced,
+  plain `pytest` — and thus `scripts/tests/unit.sh` as written — aborts with a
+  `PluginValidationError`. Run unit tests with those plugins disabled:
+  `python3 -m pytest tests/ --ignore=tests/integration -p no:launch_testing -p no:launch_ros`.
+  The same incompatibility blocks `tests/integration/` (launch_testing based)
+  under pytest 9.
+- **Headless MuJoCo:** viewer/render scripts need EGL. Export
+  `MUJOCO_GL=egl PYOPENGL_PLATFORM=egl` (the system EGL libs are in the
+  snapshot), e.g. `scripts/render_mujoco.py` / `scripts/video.sh`.
+- **render_mujoco motion:** the default controller-tracked showcase path
+  (`simulate_tracked_trajectory`) barely advances with the current controller
+  config and renders a near-static clip; pass `--no-tracking` to render visible
+  planned-path (ARCO RRT*) motion.
+- **Known pre-existing breakages (not environment issues):** the pinned
+  `arco @ main` has drifted so its `KDTreeOccupancy` now rejects empty point
+  sets, which breaks a few occupancy/tracking tests; `mypy` reports a missing
+  `Any` import in `planner_node_ros.py`; and the ROS `planner_node` crashes at
+  launch because `declare_parameter("start_configuration", [])` is inferred as
+  `BYTE_ARRAY` under rclpy Jazzy. Other nodes (mujoco_bridge, controller,
+  perception, scene) launch cleanly.

--- a/src/fret/planning/planner_node_ros.py
+++ b/src/fret/planning/planner_node_ros.py
@@ -39,6 +39,8 @@ Satisfies requirements FR-PLN-01 through FR-PLN-07 at the ROS level.
 
 from __future__ import annotations
 
+from typing import Any
+
 # Nanoseconds per second — used when splitting a float timestamp into
 # (sec, nanosec) fields required by builtin_interfaces/Duration.
 _NS_PER_SEC: int = 1_000_000_000
@@ -57,6 +59,7 @@ class PlannerRosNode:  # pragma: no cover
 
     def __init__(self, model: str = "scara") -> None:
         import rclpy.node
+        from rcl_interfaces.msg import ParameterDescriptor
         from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
         from sensor_msgs.msg import JointState
         from trajectory_msgs.msg import JointTrajectory
@@ -72,13 +75,28 @@ class PlannerRosNode:  # pragma: no cover
             "goal_configuration", [0.3272, 0.4712, 0.05]
         )
         self.declare_parameter("planning_timeout", 10.0)  # type: ignore[attr-defined]
-        self.declare_parameter("start_configuration", [])  # type: ignore[attr-defined]
+        # An empty-list default would be inferred as BYTE_ARRAY by rclpy and
+        # then reject the DOUBLE_ARRAY override from the scenario YAML, so use
+        # a dynamically typed descriptor to keep the "empty = use /joint_states"
+        # default while accepting a float[] override.
+        self.declare_parameter(  # type: ignore[attr-defined]
+            "start_configuration",
+            [],
+            ParameterDescriptor(dynamic_typing=True),
+        )
         self.declare_parameter("collision_backend", "analytic")  # type: ignore[attr-defined]
         self.declare_parameter("planner_algorithm", "rrt_star")  # type: ignore[attr-defined]
         self.declare_parameter("plan_include_cargo", False)  # type: ignore[attr-defined]
         self.declare_parameter("grasp.capture_radius", 0.3)  # type: ignore[attr-defined]
         self.declare_parameter("grasp.goal_radius", 0.5)  # type: ignore[attr-defined]
-        self.declare_parameter("grasp.weld_offset", [0.0, 0.0, 0.0])  # type: ignore[attr-defined]
+        # weld_offset may be given as a scalar (interpreted as a Z offset) or a
+        # 3-vector in scenario YAML; parse_grasp_config accepts both, so declare
+        # it with dynamic typing to avoid a DOUBLE/DOUBLE_ARRAY type clash.
+        self.declare_parameter(  # type: ignore[attr-defined]
+            "grasp.weld_offset",
+            [0.0, 0.0, 0.0],
+            ParameterDescriptor(dynamic_typing=True),
+        )
         self.declare_parameter("grasp.box_half_extent", 0.25)  # type: ignore[attr-defined]
 
         self._model = str(
@@ -203,11 +221,11 @@ class PlannerRosNode:  # pragma: no cover
                 )
                 .get_parameter_value()
                 .double_value,
-                "weld_offset": list(
-                    self.get_parameter("grasp.weld_offset")  # type: ignore[attr-defined]
-                    .get_parameter_value()
-                    .double_array_value
-                ),
+                # .value returns the native scalar or list; parse_grasp_config
+                # normalizes both to a 3-vector.
+                "weld_offset": self.get_parameter(  # type: ignore[attr-defined]
+                    "grasp.weld_offset"
+                ).value,
                 "box_half_extent": self.get_parameter(  # type: ignore[attr-defined]
                     "grasp.box_half_extent"
                 )

--- a/src/fret/scene/occupancy_adapter.py
+++ b/src/fret/scene/occupancy_adapter.py
@@ -81,7 +81,10 @@ class OccupancyAdapter:
         Args:
             payload: Latest obstacle geometry in the ``world`` frame.
         """
-        if KDTreeOccupancy is not None:  # pragma: no cover
+        # ARCO's KDTreeOccupancy requires at least one obstacle point, so an
+        # empty payload (obstacle-free scene) falls back to _SimpleOccupancy,
+        # which reports infinite clearance everywhere.
+        if KDTreeOccupancy is not None and len(payload.obstacle_points) > 0:
             # Use a 5 cm clearance radius — matches the 6 cm column width
             # with a small buffer while keeping most of the workspace reachable.
             self._occupancy = KDTreeOccupancy(

--- a/tests/planning/test_planner_node_ros.py
+++ b/tests/planning/test_planner_node_ros.py
@@ -54,9 +54,12 @@ def _build_rclpy_stub() -> ModuleType:
             self.create_publisher = MagicMock(return_value=MagicMock())
             self.create_subscription = MagicMock(return_value=MagicMock())
 
-        def declare_parameter(self, name: str, value: object) -> None:
+        def declare_parameter(
+            self, name: str, value: object, descriptor: object = None
+        ) -> None:
             # Only store the default if not already present (caller may have
-            # pre-populated with a test-specific value).
+            # pre-populated with a test-specific value).  ``descriptor`` mirrors
+            # the real rclpy signature and is ignored by the stub.
             self._params.setdefault(name, value)
 
         def get_parameter(self, name: str) -> MagicMock:
@@ -78,6 +81,9 @@ def _build_rclpy_stub() -> ModuleType:
                 pv.double_value = 0.0
                 pv.integer_value = 0
             param.get_parameter_value.return_value = pv
+            # ``.value`` returns the native stored value (used for dynamically
+            # typed parameters such as grasp.weld_offset).
+            param.value = value
             return param
 
     class _FakeQoSProfile:
@@ -105,6 +111,8 @@ def _install_ros_msg_stubs() -> None:
         ("trajectory_msgs.msg", ["JointTrajectory", "JointTrajectoryPoint"]),
         ("builtin_interfaces", ["Duration"]),
         ("builtin_interfaces.msg", ["Duration"]),
+        ("rcl_interfaces", ["ParameterDescriptor"]),
+        ("rcl_interfaces.msg", ["ParameterDescriptor"]),
     ]:
         if pkg in sys.modules:
             continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and validated the FRET development environment for cloud agents, documented durable startup notes in `AGENTS.md`, and fixed the failing CI checks.

### Environment setup
- Installed the Python stack (`pip install -e ".[dev,sim]"`), ROS 2 Jazzy Desktop + Gazebo Harmonic, headless-GL/EGL libraries, `xvfb`, and completed the C/C++ toolchain (`libstdc++-14-dev`).
- Added `## Cursor Cloud specific instructions` to `AGENTS.md` (ROS sourcing, the pytest 9 vs `launch_testing`/`launch_ros` plugin conflict, headless MuJoCo `MUJOCO_GL=egl`, `render_mujoco --no-tracking`).
- Update script (per-session dep refresh): `pip install --break-system-packages -e ".[dev,sim]"`.

### CI fixes
- `type_check`: import `Any` in `planner_node_ros.py` (used in an annotation).
- `integration` (empty occupancy): `arco@main`'s `KDTreeOccupancy` now rejects empty point clouds; `OccupancyAdapter.update()` falls back to `_SimpleOccupancy` for obstacle-free scenes (infinite clearance).
- `integration` (SITL launch): `planner_node` crashed because `start_configuration` (`[]`) and `grasp.weld_offset` (scalar YAML) were inferred as `BYTE_ARRAY`/`DOUBLE` and rejected the scenario overrides. Declared both with `ParameterDescriptor(dynamic_typing=True)` and read `grasp.weld_offset` via `.value` (`parse_grasp_config` already normalizes scalar or vector). Updated the rclpy test stub accordingly.

## Hello-world demonstration

v1.0 PPP warehouse pick-and-place: ARCO RRT* plans a collision-free path and the gantry follows it across the warehouse (headless MuJoCo).

[fret_ppp_warehouse_planned.mp4](https://cursor.com/agents/bc-2ede71a1-2166-4a6d-a391-e869bec40f16/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffret_ppp_warehouse_planned.mp4)

ROS 2 SITL node graph (`ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp backend:=mujoco`): all 5 nodes up, planner SUCCESS (23 waypoints) → trajectory published (2494 waypoints) → controller loads it.
[ros_sitl_launch.log](https://cursor.com/artifacts/c/art-d18ed967-6c87-48dd-aba2-b997fe22afb2)

## Testing

- ✅ `black --check` / `isort --check-only` on `src/`
- ✅ `mypy --strict src/` (CI-equivalent, no ROS on path)
- ✅ `pytest tests/integration/` — 32 passed (was 10 failed)
- ✅ `pytest tests/ --ignore=tests/integration -p no:launch_testing -p no:launch_ros` — 384 passed, 2 pre-existing `TestCSpaceCheckerWithPillars` failures (deterministic `_SimpleOccupancy` clearance, unrelated to CI and present before this PR)
- ✅ `bash scripts/build.sh`, `bash scripts/tests/smoke.sh`
- ✅ All 4 PR checks green: `formatting`, `type_check`, `integration`, `validate`

Note: unit tests run with `-p no:launch_testing -p no:launch_ros` locally because ROS's launch pytest plugins are incompatible with pytest 9 (documented in `AGENTS.md`); CI uses the container's pytest 7.4.4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ede71a1-2166-4a6d-a391-e869bec40f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ede71a1-2166-4a6d-a391-e869bec40f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

