### PR TITLE
fix(showcase): restore release CLI flag and add regression gates

### DIFF
--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -1498,6 +1498,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Write per-clip sim/render timing JSON (for release CI)",
     )
+    parser.add_argument(
+        "--no-realtime-postprocess",
+        action="store_true",
+        help="Skip ffmpeg speedup to match simulation time",
+    )
     return parser
 
 

--- a/scripts/tests/smoke.sh
+++ b/scripts/tests/smoke.sh
@@ -91,6 +91,16 @@ echo "=== ROS 2 launch smoke tests ==="
 run_smoke_test "mujoco_view_dry_run" -- python3 scripts/view_mujoco.py --dry-run \
     || FAILED=1
 
+# Release workflow CLI must parse before tag builds render showcase MP4s.
+info "Showcase release CLI smoke"
+if python3 -m pytest tests/simulation/test_render_mujoco.py \
+    -k "release_workflow_cli_args_parse or main_accepts_release" -q; then
+    ok "showcase_release_cli: PASSED"
+else
+    fail "showcase_release_cli: FAILED"
+    FAILED=1
+fi
+
 # v1.0 V10-1: PPP warehouse MuJoCo SITL (no Gazebo dependency).
 run_smoke_test "sitl_ppp_warehouse_mujoco" 30 -- \
     env MUJOCO_GL=egl PYOPENGL_PLATFORM=egl \

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -211,3 +211,108 @@ def test_showcase_timing_real_time_factor() -> None:
 def test_resolve_scenario_duration_reads_yaml() -> None:
     assert rm.resolve_scenario_duration("ppp_warehouse") == pytest.approx(60.0)
     assert rm.resolve_scenario_duration("dubins_race") == pytest.approx(35.0)
+
+
+# Mirrors .github/workflows/release.yml showcase render invocations.
+_RELEASE_PPP_CLI: list[str] = [
+    "--model",
+    "ppp",
+    "--scenario",
+    "ppp_warehouse",
+    "--all-cameras",
+    "--collision-backend",
+    "mujoco",
+    "--planner-algorithm",
+    "rrt_star",
+    "--no-tracking",
+    "--output-dir",
+    "showcase_renders",
+    "--timing-json",
+    "showcase_renders/ppp_timing.json",
+    "--fps",
+    "30",
+    "--width",
+    "1280",
+    "--height",
+    "720",
+]
+
+_RELEASE_DUBINS_CLI: list[str] = [
+    "--model",
+    "dubins",
+    "--scenario",
+    "dubins_race",
+    "--all-cameras",
+    "--output-dir",
+    "showcase_renders",
+    "--timing-json",
+    "showcase_renders/dubins_timing.json",
+    "--fps",
+    "30",
+    "--width",
+    "1280",
+    "--height",
+    "720",
+]
+
+
+def test_release_workflow_cli_args_parse() -> None:
+    """Release workflow flags must parse without missing Namespace attributes."""
+    parser = rm.build_parser()
+    ppp_args = parser.parse_args(_RELEASE_PPP_CLI)
+    dubins_args = parser.parse_args(_RELEASE_DUBINS_CLI)
+
+    assert ppp_args.model == "ppp"
+    assert ppp_args.scenario == "ppp_warehouse"
+    assert ppp_args.all_cameras is True
+    assert ppp_args.no_tracking is True
+    assert ppp_args.timing_json == Path("showcase_renders/ppp_timing.json")
+    assert ppp_args.no_realtime_postprocess is False
+
+    assert dubins_args.model == "dubins"
+    assert dubins_args.scenario == "dubins_race"
+    assert dubins_args.all_cameras is True
+    assert dubins_args.timing_json == Path("showcase_renders/dubins_timing.json")
+    assert dubins_args.no_realtime_postprocess is False
+
+
+def test_main_accepts_release_ppp_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() must accept the exact release.yml PPP invocation."""
+    timing = rm.ShowcaseTiming(sim_time_s=12.0, render_duration_s=12.0)
+
+    def _fake_render(*_args: object, **_kwargs: object) -> list[rm.RenderResult]:
+        return [
+            rm.RenderResult(
+                camera="overview",
+                path=Path("/tmp/ppp_warehouse_overview.mp4"),
+                frame_mean=42.0,
+                timing=timing,
+            )
+        ]
+
+    monkeypatch.setattr(rm, "render_showcase_videos", _fake_render)
+    monkeypatch.setattr(rm, "postprocess_showcase_results", lambda r, **k: r)
+    monkeypatch.setattr(rm, "write_showcase_timing_json", lambda *_a, **_k: None)
+
+    assert rm.main(_RELEASE_PPP_CLI) == 0
+
+
+def test_main_accepts_release_dubins_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() must accept the exact release.yml Dubins invocation."""
+    timing = rm.ShowcaseTiming(sim_time_s=34.0, render_duration_s=34.0)
+
+    def _fake_render(*_args: object, **_kwargs: object) -> list[rm.RenderResult]:
+        return [
+            rm.RenderResult(
+                camera="overview",
+                path=Path("/tmp/dubins_race_overview.mp4"),
+                frame_mean=42.0,
+                timing=timing,
+            )
+        ]
+
+    monkeypatch.setattr(rm, "render_showcase_videos", _fake_render)
+    monkeypatch.setattr(rm, "postprocess_showcase_results", lambda r, **k: r)
+    monkeypatch.setattr(rm, "write_showcase_timing_json", lambda *_a, **_k: None)
+
+    assert rm.main(_RELEASE_DUBINS_CLI) == 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Release workflow [run 28969317137](https://github.com/alexandrelheinen/fret/actions/runs/28969317137) failed on the PPP showcase render step:

```
AttributeError: 'Namespace' object has no attribute 'no_realtime_postprocess'
```

`main()` referenced `args.no_realtime_postprocess` after the real-time post-process work landed, but `build_parser()` never registered `--no-realtime-postprocess`. The Release workflow only runs on version tags, so PR CI did not execute this code path.

## Fix

- Register `--no-realtime-postprocess` in `build_parser()`.

## Regression gates (V-cycle Level 3–4)

| Test | Purpose |
|---|---|
| `test_release_workflow_cli_args_parse` | Parses the exact argv from `.github/workflows/release.yml` for PPP and Dubins |
| `test_main_accepts_release_ppp_cli` | `main()` smoke with mocked render (PPP release invocation) |
| `test_main_accepts_release_dubins_cli` | `main()` smoke with mocked render (Dubins release invocation) |
| `showcase_release_cli` in `scripts/tests/smoke.sh` | Runs the above on every PR via `tests.yml` |

## Quality gates

- [x] `bash scripts/check/formatting.sh`
- [x] `bash scripts/check/types.sh`
- [x] `pytest tests/simulation/test_render_mujoco.py` (21 passed)

## Traceability

- Unblocks release showcase upload (V10-6 / V11-2) after tagging `v1.1.0`.
- No `FR-*` / `SC-*` behavior change — CLI wiring fix only.

## Follow-up

Re-run the Release workflow (or tag `v1.1.0`) after merge to confirm full EGL + ffmpeg render succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14e06924-9e38-46fe-a6fc-3a37b0499f03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14e06924-9e38-46fe-a6fc-3a37b0499f03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

