### PR TITLE
Fix download_showcase.sh to list R2 bucket contents

### DIFF
--- a/scripts/download_showcase.sh
+++ b/scripts/download_showcase.sh
@@ -2,6 +2,8 @@
 # Download FRET showcase MP4s from a private Cloudflare R2 bucket.
 #
 # Release CI uploads two POVs per scenario: overview (whole scene) + follow.
+# This script lists objects under latest/ or releases/<tag>/ and downloads
+# only files that actually exist in the bucket (no hard-coded manifest).
 #
 # Credentials (pick one):
 #   1. Copy .env.example → .env at repo root (recommended; .env is gitignored)
@@ -11,6 +13,7 @@
 #
 # Examples:
 #   ./scripts/download_showcase.sh
+#   ./scripts/download_showcase.sh --list
 #   ./scripts/download_showcase.sh --scenario dubins_race
 #   ./scripts/download_showcase.sh --tag v1.1.0 --scenario dubins_race --camera follow
 #   ./scripts/download_showcase.sh --all --tag v1.1.0
@@ -24,21 +27,21 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # shellcheck source=scripts/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
-RELEASE_SCENARIOS=(ppp_warehouse dubins_race)
-RELEASE_CAMERAS=(overview follow)
-
 usage() {
   cat <<'EOF'
 Usage: download_showcase.sh [OPTIONS]
 
 Download MuJoCo showcase videos uploaded by the Release GitHub Actions workflow.
+Objects are discovered by listing the R2 prefix; missing files are skipped with
+--all or reported with a clear error for a single-file download.
 
 Options:
-  --latest              Download latest/<scenario>_overview.mp4 (default)
+  --latest              Download from latest/ (default)
   --tag VERSION         Download from releases/VERSION/
-  --scenario NAME       ppp_warehouse (default) or dubins_race
+  --list                List available MP4 objects and exit
+  --scenario NAME       Filter by scenario prefix (e.g. ppp_warehouse, dubins_race)
   --camera NAME         POV clip: overview or follow (default: overview)
-  --all                 Download every release POV (both scenarios, or one with --scenario)
+  --all                 Download every MP4 in the prefix (optionally filtered)
   -o PATH               Output file path (single download) or directory (--all)
   -h, --help            Show this help
 
@@ -103,12 +106,152 @@ legacy_primary_object() {
   esac
 }
 
+list_r2_mp4_objects() {
+  local prefix="$1"
+  local listing=""
+  if ! listing="$(
+    aws s3 ls "s3://${R2_BUCKET}/${prefix}/" --endpoint-url "${R2_ENDPOINT}" 2>&1
+  )"; then
+    fail "Cannot list s3://${R2_BUCKET}/${prefix}/"
+    echo "${listing}" >&2
+    return 1
+  fi
+
+  local object_name=""
+  local -a objects=()
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    object_name="${line##* }"
+    if [[ "${object_name}" == *.mp4 ]]; then
+      objects+=("${object_name}")
+    fi
+  done <<<"${listing}"
+
+  if ((${#objects[@]} == 0)); then
+    fail "No MP4 objects found under s3://${R2_BUCKET}/${prefix}/"
+    return 1
+  fi
+
+  printf '%s\n' "${objects[@]}"
+}
+
+object_matches_scenario() {
+  local object_name="$1"
+  local scenario="$2"
+  [[ "${object_name}" == "${scenario}.mp4" || "${object_name}" == "${scenario}_"* ]]
+}
+
+object_matches_camera() {
+  local object_name="$1"
+  local scenario="$2"
+  local camera="$3"
+  if [[ "${object_name}" == "${scenario}_${camera}.mp4" ]]; then
+    return 0
+  fi
+  if [[ "${camera}" == "overview" && "${object_name}" == "$(legacy_primary_object "${scenario}")" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+filter_objects() {
+  local scenario="${1:-}"
+  local camera="${2:-}"
+  shift 2 || true
+  local objects=("$@")
+  local filtered=()
+  local object_name=""
+
+  for object_name in "${objects[@]}"; do
+    if [[ -n "${scenario}" ]] && ! object_matches_scenario "${object_name}" "${scenario}"; then
+      continue
+    fi
+    if [[ -n "${camera}" ]] && ! object_matches_camera "${object_name}" "${scenario}" "${camera}"; then
+      continue
+    fi
+    filtered+=("${object_name}")
+  done
+
+  if ((${#filtered[@]} > 0)); then
+    printf '%s\n' "${filtered[@]}"
+  fi
+}
+
+# Populated by load_collected_objects on success.
+COLLECTED_OBJECTS=()
+
+load_collected_objects() {
+  local prefix="$1"
+  local scenario="${2:-}"
+  local camera="${3:-}"
+  local -a objects=()
+  local listed=""
+
+  COLLECTED_OBJECTS=()
+  if ! listed="$(list_r2_mp4_objects "${prefix}")"; then
+    return 1
+  fi
+  mapfile -t objects <<<"${listed}"
+
+  if [[ -n "${scenario}" || -n "${camera}" ]]; then
+    mapfile -t COLLECTED_OBJECTS < <(
+      filter_objects "${scenario}" "${camera}" "${objects[@]}"
+    )
+    if ((${#COLLECTED_OBJECTS[@]} == 0)); then
+      fail "No matching MP4 objects under s3://${R2_BUCKET}/${prefix}/"
+      info "Available objects:"
+      printf '  %s\n' "${objects[@]}"
+      return 1
+    fi
+    return 0
+  fi
+
+  COLLECTED_OBJECTS=("${objects[@]}")
+  return 0
+}
+
+print_object_list() {
+  local prefix="$1"
+  local scenario="${2:-}"
+
+  if ! load_collected_objects "${prefix}" "${scenario}" ""; then
+    exit 1
+  fi
+  info "Objects under s3://${R2_BUCKET}/${prefix}/:"
+  printf '  %s\n' "${COLLECTED_OBJECTS[@]}"
+}
+
+select_single_object() {
+  local prefix="$1"
+  local scenario="$2"
+  local camera="$3"
+  local canonical="${scenario}_${camera}.mp4"
+  local object_name=""
+
+  if ! load_collected_objects "${prefix}" "${scenario}" "${camera}"; then
+    return 1
+  fi
+
+  for object_name in "${COLLECTED_OBJECTS[@]}"; do
+    if [[ "${object_name}" == "${canonical}" ]]; then
+      echo "${object_name}"
+      return 0
+    fi
+  done
+
+  if ((${#COLLECTED_OBJECTS[@]} > 1)); then
+    warn "Multiple matches for ${scenario}/${camera}; using ${COLLECTED_OBJECTS[0]}"
+  fi
+  echo "${COLLECTED_OBJECTS[0]}"
+}
+
 MODE="latest"
 TAG=""
 SCENARIO=""
 SCENARIO_EXPLICIT=0
 CAMERA="overview"
 DOWNLOAD_ALL=0
+LIST_ONLY=0
 OUTPUT=""
 
 while [[ $# -gt 0 ]]; do
@@ -122,8 +265,12 @@ while [[ $# -gt 0 ]]; do
       TAG="${2:?--tag requires a version such as v1.1.0}"
       shift 2
       ;;
+    --list)
+      LIST_ONLY=1
+      shift
+      ;;
     --scenario)
-      SCENARIO="${2:?--scenario requires ppp_warehouse or dubins_race}"
+      SCENARIO="${2:?--scenario requires a scenario name such as ppp_warehouse}"
       SCENARIO_EXPLICIT=1
       shift 2
       ;;
@@ -169,34 +316,40 @@ if [[ -z "${SCENARIO}" ]]; then
   SCENARIO="ppp_warehouse"
 fi
 
-if [[ "${DOWNLOAD_ALL}" -eq 1 ]]; then
+if [[ "${LIST_ONLY}" -eq 1 ]]; then
   if [[ "${SCENARIO_EXPLICIT}" -eq 1 ]]; then
-    scenarios=("${SCENARIO}")
+    print_object_list "${prefix}" "${SCENARIO}"
   else
-    scenarios=("${RELEASE_SCENARIOS[@]}")
+    print_object_list "${prefix}"
   fi
+  exit 0
+fi
+
+if [[ "${DOWNLOAD_ALL}" -eq 1 ]]; then
   out_dir="${OUTPUT:-${REPO_ROOT}/artifacts/r2/${prefix##*/}}"
   mkdir -p "${out_dir}"
-  for scenario in "${scenarios[@]}"; do
-    for cam in "${RELEASE_CAMERAS[@]}"; do
-      file_name="${scenario}_${cam}.mp4"
-      download_object "${prefix}/${file_name}" "${out_dir}/${file_name}"
-    done
-  done
-  exit 0
-fi
-
-file_name="${SCENARIO}_${CAMERA}.mp4"
-if [[ "${MODE}" == "latest" && "${CAMERA}" == "overview" && -z "${OUTPUT}" ]]; then
-  default_out="${REPO_ROOT}/artifacts/r2/${SCENARIO}_latest.mp4"
-  if download_object "latest/${file_name}" "${default_out}"; then
-    exit 0
+  if [[ "${SCENARIO_EXPLICIT}" -eq 1 ]]; then
+    load_collected_objects "${prefix}" "${SCENARIO}" "" || exit 1
+  else
+    load_collected_objects "${prefix}" "" "" || exit 1
   fi
-  legacy="$(legacy_primary_object "${SCENARIO}")"
-  warn "Falling back to legacy object latest/${legacy}"
-  download_object "latest/${legacy}" "${default_out}"
+  for object_name in "${COLLECTED_OBJECTS[@]}"; do
+    download_object "${prefix}/${object_name}" "${out_dir}/${object_name}"
+  done
+  ok "Downloaded ${#COLLECTED_OBJECTS[@]} file(s) to ${out_dir}"
   exit 0
 fi
 
-OUTPUT="${OUTPUT:-${REPO_ROOT}/artifacts/r2/${file_name}}"
-download_object "${prefix}/${file_name}" "${OUTPUT}"
+object_name="$(select_single_object "${prefix}" "${SCENARIO}" "${CAMERA}")"
+if [[ -z "${object_name}" ]]; then
+  fail "No MP4 found for scenario=${SCENARIO} camera=${CAMERA} under ${prefix}/"
+  print_object_list "${prefix}" "${SCENARIO}" || print_object_list "${prefix}"
+  exit 1
+fi
+
+if [[ "${MODE}" == "latest" && "${CAMERA}" == "overview" && -z "${OUTPUT}" ]]; then
+  OUTPUT="${REPO_ROOT}/artifacts/r2/${SCENARIO}_latest.mp4"
+fi
+
+OUTPUT="${OUTPUT:-${REPO_ROOT}/artifacts/r2/${object_name}}"
+download_object "${prefix}/${object_name}" "${OUTPUT}"

--- a/scripts/tests/test_download_showcase.sh
+++ b/scripts/tests/test_download_showcase.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Unit-style checks for scripts/download_showcase.sh (mock aws, no R2 credentials).
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MOCK_BIN="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${MOCK_BIN}"
+}
+trap cleanup EXIT
+
+cat >"${MOCK_BIN}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "s3" && "$2" == "ls" ]]; then
+  prefix="${3#s3://fret-renders/}"
+  prefix="${prefix%/}/"
+  case "${prefix}" in
+    latest/)
+      echo "2026-01-01 00:00:00    1000000 ppp_warehouse_overview.mp4"
+      echo "2026-01-01 00:00:00     900000 ppp_warehouse_follow.mp4"
+      echo "2026-01-01 00:00:00     800000 ppp_warehouse.mp4"
+      ;;
+    releases/v1.0.0/)
+      echo "2026-01-01 00:00:00    1000000 ppp_warehouse_overview.mp4"
+      echo "2026-01-01 00:00:00     900000 ppp_warehouse_follow.mp4"
+      ;;
+    releases/v1.1.0/)
+      echo "2026-01-01 00:00:00    1100000 ppp_warehouse_overview.mp4"
+      echo "2026-01-01 00:00:00    1000000 ppp_warehouse_follow.mp4"
+      echo "2026-01-01 00:00:00    1200000 dubins_race_overview.mp4"
+      echo "2026-01-01 00:00:00    1050000 dubins_race_follow.mp4"
+      ;;
+    *)
+      echo "An error occurred (NoSuchKey)" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "$1" == "s3" && "$2" == "cp" ]]; then
+  dest=""
+  skip_next=0
+  for arg in "$@"; do
+    if ((skip_next)); then
+      skip_next=0
+      continue
+    fi
+    if [[ "${arg}" == --endpoint-url ]]; then
+      skip_next=1
+      continue
+    fi
+    if [[ "${arg}" != s3 && "${arg}" != cp && "${arg}" != s3://* ]]; then
+      dest="${arg}"
+    fi
+  done
+  mkdir -p "$(dirname "${dest}")"
+  echo "mock video" >"${dest}"
+  exit 0
+fi
+
+echo "unsupported aws invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${MOCK_BIN}/aws"
+
+export PATH="${MOCK_BIN}:${PATH}"
+export R2_ACCESS_KEY_ID=test
+export R2_SECRET_ACCESS_KEY=test
+export R2_ACCOUNT_ID=testaccount
+export R2_BUCKET=fret-renders
+
+DOWNLOAD="${REPO_ROOT}/scripts/download_showcase.sh"
+OUT_DIR="$(mktemp -d)"
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    echo "FAIL: ${label} — expected output to contain '${needle}'"
+    echo "${haystack}"
+    exit 1
+  fi
+}
+
+assert_file_count() {
+  local dir="$1"
+  local expected="$2"
+  local label="$3"
+  local actual
+  actual="$(find "${dir}" -maxdepth 1 -name '*.mp4' | wc -l | tr -d ' ')"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL: ${label} — expected ${expected} mp4 files, got ${actual}"
+    ls -la "${dir}"
+    exit 1
+  fi
+}
+
+echo "=== download_showcase.sh mock tests ==="
+
+list_out="$("${DOWNLOAD}" --list 2>&1)"
+assert_contains "${list_out}" "ppp_warehouse_overview.mp4" "--list latest"
+assert_contains "${list_out}" "ppp_warehouse.mp4" "--list includes legacy alias"
+
+all_out_dir="${OUT_DIR}/all_latest"
+"${DOWNLOAD}" --all -o "${all_out_dir}" >/dev/null
+assert_file_count "${all_out_dir}" 3 " --all on latest downloads only listed objects"
+
+tag_out_dir="${OUT_DIR}/all_v1_0"
+"${DOWNLOAD}" --all --tag v1.0.0 -o "${tag_out_dir}" >/dev/null
+assert_file_count "${tag_out_dir}" 2 " --all on v1.0.0 skips missing dubins clips"
+
+v11_out_dir="${OUT_DIR}/all_v1_1"
+"${DOWNLOAD}" --all --tag v1.1.0 -o "${v11_out_dir}" >/dev/null
+assert_file_count "${v11_out_dir}" 4 " --all on v1.1.0 downloads every listed clip"
+
+single_out="${OUT_DIR}/ppp_overview.mp4"
+"${DOWNLOAD}" --scenario ppp_warehouse --camera overview -o "${single_out}" >/dev/null
+if [[ ! -s "${single_out}" ]]; then
+  echo "FAIL: single download did not create output file"
+  exit 1
+fi
+
+if "${DOWNLOAD}" --tag v9.9.9 --list >/dev/null 2>&1; then
+  echo "FAIL: expected missing prefix to fail"
+  exit 1
+fi
+
+echo "PASS: download_showcase.sh mock tests"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`download_showcase.sh` assumed a fixed manifest of showcase MP4s (`ppp_warehouse_overview`, `dubins_race_follow`, etc.) and failed when any expected file was missing from R2 — for example downloading `--all` before Dubins race clips existed, or fetching a partial release.

## Changes

- **List before download:** use `aws s3 ls` on `latest/` or `releases/<tag>/` to discover MP4 objects
- **`--all`:** download only files that actually exist (no hard-coded scenario/camera matrix)
- **`--list`:** new flag to inspect available objects without downloading
- **Single download:** resolve `{scenario}_{camera}.mp4` from the listing; prefer canonical names over legacy aliases like `ppp_warehouse.mp4`
- **Errors:** missing prefixes or unmatched filters fail with the available object list
- **Tests:** mock-aws harness in `scripts/tests/test_download_showcase.sh`

## Verification

```bash
bash scripts/tests/test_download_showcase.sh
bash -n scripts/download_showcase.sh
```

## Usage

```bash
./scripts/download_showcase.sh --list
./scripts/download_showcase.sh --all --tag v1.0.0   # skips missing dubins clips
./scripts/download_showcase.sh --all --tag v1.1.0     # downloads whatever is in the bucket
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1611dfd-cb13-4641-8f86-d1c8bbcfd6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1611dfd-cb13-4641-8f86-d1c8bbcfd6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

