### PR TITLE
Prepare documentation for v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ bash scripts/check/pre_push.sh
 
 | Topic | Document |
 |---|---|
+| **v1.2 physics implementation spec** | [docs/mujoco_physics_v1.2.md](docs/mujoco_physics_v1.2.md) |
+| Configuration reference | [docs/config.md](docs/config.md) |
 | Scenario catalogue | [docs/scenarios.md](docs/scenarios.md) |
 | Robot models | [docs/robots/README.md](docs/robots/README.md) |
 | PPP gantry | [docs/robots/ppp.md](docs/robots/ppp.md) |

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,132 @@
+# FRET configuration reference
+
+Runtime parameters live in YAML under `src/fret/config/`. Tunable algorithm and
+simulation values must not be hardcoded in Python or MJCF (see
+[docs/guidelines.md](guidelines.md#yaml-configuration-files)).
+
+| Directory | Purpose |
+| --- | --- |
+| `config/scenarios/` | Per-run definitions (start/goal, timeouts, physics flags) |
+| `config/controllers/` | Closed-loop gains (`ros__parameters` format) |
+| `config/worlds/` | Static obstacle layouts, Dubins vehicle/planner tuning |
+| `config/simulation/` | MuJoCo bridge and physics SITL (v1.2+) |
+
+Scenario schema: [scenarios.md](scenarios.md#scenario-yaml-schema).
+
+---
+
+## Simulation / physics (v1.2)
+
+**Spec:** [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md) · **Overview:**
+[mujoco.md](mujoco.md)
+
+### Parameter precedence
+
+| Priority | Source | Example |
+| --- | --- | --- |
+| 1 (highest) | Launch argument | `physics_mode:=true` |
+| 2 | Scenario YAML | `physics_mode: true` under `ros__parameters` |
+| 3 | Bridge config file | `config/simulation/mujoco.yml` |
+| 4 (lowest) | Code defaults | **Forbidden** for tunables — missing keys fail at load |
+
+Launch and scenario values merge into `MuJoCoBridgeNode` parameters at startup.
+
+### `physics_mode`
+
+| Value | Behaviour |
+| --- | --- |
+| `false` | Kinematic mirror (v1.0–v1.1): Python integration → `qpos` write → `mj_forward` |
+| `true` | Physics SITL (v1.2): `/joint_commands` → actuators → `mj_step` → `/joint_states` from sim |
+
+Declared in:
+
+- **Launch:** `ros2 launch fret sitl.py … physics_mode:=true`
+- **Scenario:** `physics_mode: true` in `config/scenarios/<name>.yml`
+
+Satisfies FR-SIM-09. SC-v12 runs SC-v10 and SC-v11 scenarios with
+`physics_mode: true`.
+
+### `config/simulation/mujoco.yml` schema (v1.2 target)
+
+Consumed by `MuJoCoBridgeNode` / `MuJoCoBridgeCore`. All fields required when
+`physics_mode: true`; bridge raises on missing keys.
+
+```yaml
+/**:
+  ros__parameters:
+    # Identity (v1.0)
+    model: ppp
+    scenario: ppp_warehouse
+    update_rate: 50.0
+    initial_joint_positions: [0.0, 0.0, 0.0]
+    collision_backend: mujoco
+
+    # v1.2 physics
+    physics_mode: false
+    mjcf_timestep: 0.002          # must match MJCF <option timestep>
+    substeps_per_tick: 25         # floor(1 / (mjcf_timestep * update_rate))
+
+    # Contact / regression logging (v1.2)
+    contact_log_enabled: true
+    contact_log_path: ""          # empty → /tmp/fret_physics/<scenario_id>/contacts.jsonl
+    metrics_path: ""              # empty → /tmp/fret_physics/<scenario_id>/metrics.json
+
+    # Per-model actuator tables (one block active per model)
+    actuators:
+      ppp:
+        names: [act_joint_x, act_joint_y, act_joint_z]
+        kv: [120.0, 120.0, 180.0]
+        forcerange: [[-5000, 5000], [-5000, 5000], [-8000, 8000]]
+      dubins:
+        names: [act_rrt_x, act_rrt_y, act_rrt_yaw, act_sst_x, act_sst_y, act_sst_yaw]
+        kv: [80.0, 80.0, 40.0, 80.0, 80.0, 40.0]
+        forcerange: [[-2000, 2000], [-2000, 2000], [-500, 500],
+                     [-2000, 2000], [-2000, 2000], [-500, 500]]
+
+    # PPP cargo weld (T12-04)
+    cargo_weld:
+      equality_name: cargo_weld
+      body_parent: z_hoist
+      body_child: cargo
+```
+
+**MJCF vs YAML rule:** XML declares actuator *existence* and joint binding with
+placeholder `kv="1"`. Runtime applies `actuators.<model>.kv` and `forcerange` via
+MuJoCo API (`model.actuator_gainprm`, `model.actuator_forcerange`).
+
+### Scenario YAML fields for physics (v1.2)
+
+Add to release scenarios when enabling SC-v12:
+
+```yaml
+/**:
+  ros__parameters:
+    scenario_id: "ppp_warehouse"
+    model: "ppp"
+    backend: "mujoco"
+
+    physics_mode: false            # set true for SC-v12 / physics SITL
+
+    # Optional Dubins-only override (default true)
+    inter_agent_contact: true
+
+    simulation_config: simulation/mujoco.yml   # bridge parameter file
+```
+
+Existing v1.0/v1.1 fields (`start_configuration`, `planning_timeout`, `grasp`,
+`recording`, …) are unchanged. See [scenarios.md](scenarios.md) for the full
+schema.
+
+### Controller configs (unchanged)
+
+PPP and Dubins closed-loop gains remain in `config/controllers/ppp.yml` and
+`config/controllers/dubins.yml`. Physics mode does **not** duplicate controller
+gains — it only adds actuator execution layer tuning in `simulation/mujoco.yml`.
+
+### Tuning workflow
+
+1. Run kinematic baseline; record EE / pose error from existing tests.
+2. Set `physics_mode: true`; start with default `kv` values above.
+3. Increase `kv` until tracking error meets FR-CTL-02 limits without actuator saturation.
+4. Inspect contact log (§4 in [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md)).
+5. Commit tuned values to `simulation/mujoco.yml` only — not Python.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -278,6 +278,23 @@ use exactly these profiles to ensure correct publisher/subscriber matching.
 
 ---
 
+## Simulation launch parameters (v1.2)
+
+Passed to `ros2 launch fret sitl.py` or declared in scenario YAML under
+`ros__parameters`. Full schema: [config.md](config.md#simulation-physics-v12).
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `model` | string | `scara` | Robot model (`ppp`, `dubins`, …) |
+| `scenario` | string | `static_reach` | Scenario YAML stem |
+| `physics_mode` | bool | `false` | Enable MuJoCo actuator + `mj_step` SITL (FR-SIM-09) |
+
+When `physics_mode:=true`, `/joint_states` must reflect simulated `qpos`/`qvel`
+only — no open-loop pose injection (FR-SIM-07). See
+[mujoco_physics_v1.2.md](mujoco_physics_v1.2.md).
+
+---
+
 ## ARCO Dependency Contract
 
 **Integration mechanism:** editable local install.

--- a/docs/modules/ros_nodes.md
+++ b/docs/modules/ros_nodes.md
@@ -39,6 +39,17 @@ publishes joint state at 50 Hz.
 
 **Config:** `src/fret/config/simulation/mujoco.yml`
 
+**Parameters (v1.2):**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `physics_mode` | bool | `false` | Kinematic mirror vs `mj_step` physics SITL |
+| `update_rate` | float | `50.0` | `/joint_states` publish rate [Hz] |
+| `substeps_per_tick` | int | `25` | MuJoCo steps per control callback |
+| `simulation_config` | string | — | Loaded from scenario or launch |
+
+Spec: [mujoco_physics_v1.2.md](../mujoco_physics_v1.2.md) · [config.md](../config.md).
+
 **Demo:** `python3 scripts/demo_mujoco_bridge.py`  
 **Tests:** `tests/ros/test_mujoco_bridge.py` — 11 unit tests.
 

--- a/docs/mujoco.md
+++ b/docs/mujoco.md
@@ -4,7 +4,8 @@
 > engine for physics, contacts, rendering, and SITL validation.
 >
 > **Related:** [simulation.md](simulation.md) · [requirements.md](requirements.md) ·
-> [releases.md](releases.md) · [modules/ros_nodes.md](modules/ros_nodes.md)
+> [releases.md](releases.md) · [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md) ·
+> [modules/ros_nodes.md](modules/ros_nodes.md)
 
 ---
 
@@ -292,6 +293,11 @@ Optional asset import tools: `trimesh`, `pycollada`.
 ## v1.2 physics deliverables (summary)
 
 Full acceptance criteria: [releases.md § v1.2](releases.md#v12--mujoco-physics-sitl).
+
+**Implementation specification:** [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md)
+(actuators, cargo weld, contact logs, regression tests).
+
+Configuration schema: [config.md § Simulation](config.md#simulation-physics-v12).
 
 | Robot | Physics work |
 |---|---|

--- a/docs/mujoco_physics_v1.2.md
+++ b/docs/mujoco_physics_v1.2.md
@@ -221,3 +221,90 @@ from FSM, ignore equality weld. Showcase scripts (`render_mujoco.py`) default to
 kinematic mode until `--physics-mode` is passed (T12-07).
 
 ---
+
+## 4. Contact logging and regression test contract
+
+### Contact log format (T12-05)
+
+When `contact_log_enabled: true`, the bridge appends one JSON object per line
+(JSONL) after each control tick that reports `data.ncon > 0`.
+
+**Default path:** `/tmp/fret_physics/<scenario_id>/contacts.jsonl`
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `sim_time` | float | MuJoCo simulation time [s] |
+| `wall_time` | float | Unix timestamp [s] |
+| `geom1` | string | First geom name |
+| `geom2` | string | Second geom name |
+| `force_norm` | float | Contact force magnitude [N] |
+| `pos` | [float×3] | Contact position in world frame [m] |
+
+Example line:
+
+```json
+{"sim_time": 12.04, "wall_time": 1710000000.12, "geom1": "cargo_box", "geom2": "obs_a", "force_norm": 42.3, "pos": [4.01, 1.18, 0.52]}
+```
+
+CI uploads this file as artifact `physics-contacts-<scenario_id>` (V12-5).
+
+### Sim-time metrics file
+
+Written once at scenario shutdown to `metrics_path` (default:
+`/tmp/fret_physics/<scenario_id>/metrics.json`):
+
+```json
+{
+  "scenario_id": "ppp_warehouse",
+  "physics_mode": true,
+  "sim_time_final": 58.2,
+  "wall_time_elapsed": 61.4,
+  "max_tracking_error_m": 0.008,
+  "contact_event_count": 127,
+  "max_contact_force_n": 156.0,
+  "penetration_violations": 0
+}
+```
+
+`penetration_violations` counts timesteps where any contact distance <
+`-0.001` m (1 mm tolerance).
+
+### Regression test files (T12-06, V12-7)
+
+| Test file | Scenario | Minimum assertions |
+| --- | --- | --- |
+| `tests/integration/test_mujoco_physics_ppp.py` | SC-v10 + `physics_mode` | SITL completes; weld engage/release; `max_tracking_error_m ≤ 0.010`; `penetration_violations == 0`; contact log exists |
+| `tests/integration/test_mujoco_physics_dubins.py` | SC-v11 + `physics_mode` | Both agents reach goal; `penetration_violations == 0`; column contacts logged (`force_norm > 0`); optional inter-agent test |
+
+Tests run under `launch_testing` in `.github/workflows/integration.yml` when
+physics implementation lands. Until then, mark `@pytest.mark.xfail` with reason
+`T12-01 not implemented`.
+
+### Kinematic vs physics regression clip (T12-07)
+
+Showcase scripts accept `--physics-mode` (off by default):
+
+```bash
+./scripts/video.sh --model ppp --scenario ppp_warehouse … --physics-mode
+```
+
+Post-run comparison (manual or CI optional job):
+
+| Metric | Threshold | Action if exceeded |
+| --- | --- | --- |
+| Path length ratio (physics / kinematic) | ≤ 1.15 | Review actuator gains |
+| Goal position error | ≤ FR-CTL-02 limit | Fail V12-2 / V12-3 |
+| MP4 frame SSIM | ≥ 0.85 | Warning only (visual regression) |
+
+Store side-by-side clips under `/tmp/fret_physics/<scenario_id>/regression/`.
+
+### Smoke extension
+
+`scripts/tests/smoke.sh` gains a physics stanza (after T12-01):
+
+```bash
+timeout 30 ros2 launch fret sitl.py scenario:=ppp_warehouse model:=ppp physics_mode:=true
+timeout 30 ros2 launch fret sitl.py scenario:=dubins_race model:=dubins physics_mode:=true
+```
+
+Exit 0 within timeout satisfies V12-1 launch criterion.

--- a/docs/mujoco_physics_v1.2.md
+++ b/docs/mujoco_physics_v1.2.md
@@ -143,3 +143,81 @@ Implementation lives in `src/fret/ros/mujoco_bridge.py`. No open-loop
 `set_positions()` calls are permitted while `physics_mode` is active (FR-SIM-07).
 
 ---
+
+## 2. Cargo weld physics (PPP)
+
+### Problem
+
+v1.0 magnetic grasp is **logical**: `MagneticGraspFSM` sets cargo pose relative to
+the EE during TRANSPORT, and the bridge writes `cargo` body `qpos` directly
+(kinematic mirror). Planning uses the welded AABB via `cargo_corners()`.
+
+v1.2 requires the cargo to follow the EE through **physical coupling** while
+contacts with obstacles produce forces (V12-2).
+
+### Chosen approach: toggled MJCF equality weld
+
+| Alternative | Verdict |
+| --- | --- |
+| Fixed weld for entire episode | Cannot release at goal |
+| Mocap `cargo_floor` body | Mocap bodies do not participate in contact dynamics the same way as free bodies |
+| Manual per-step pose sync in physics mode | Pose teleportation — violates FR-SIM-07 |
+| **`<equality type="weld">` toggled by bridge** | **Selected** — native MuJoCo constraint, release by deactivating constraint |
+
+### MJCF changes (`ppp_warehouse.xml`)
+
+1. **Cargo body** — add a `freejoint` on the `cargo` body so it can settle after
+   release (remove fixed child offset-only placement during physics episodes):
+
+```xml
+<body name="cargo" pos="0 0 -0.34">
+  <freejoint name="cargo_free"/>
+  <geom name="cargo_box" type="box" size="0.25 0.25 0.25" material="cargo" mass="2.0"/>
+</body>
+```
+
+Initial spawn pose is set from scenario `start_configuration` + grasp
+`weld_offset` at episode start (same as v1.0 pick zone).
+
+2. **Weld constraint** — add near the end of the MJCF (inactive by default):
+
+```xml
+<equality>
+  <!-- Activated by bridge when MagneticGraspFSM enters CAPTURE/TRANSPORT -->
+  <weld name="cargo_weld" body1="z_hoist" body2="cargo"
+        relpose="0 0 -0.34 1 0 0 0" active="false"/>
+</equality>
+```
+
+`relpose` matches grasp config `weld_offset: [0.0, 0.0, -0.34]` from
+`ppp_warehouse.yml`. Offset updates must stay in YAML, not Python defaults.
+
+### Bridge ↔ FSM hook (T12-04)
+
+| FSM transition | Bridge action |
+| --- | --- |
+| IDLE → CAPTURE (distance < `capture_radius`) | Set `model.eq_active[eq_id_cargo_weld] = 1`, call `mj_forward` |
+| CAPTURE → TRANSPORT | Keep weld active |
+| TRANSPORT → RELEASE (distance to goal < `goal_radius`) | Set `eq_active = 0`; cargo freejoint integrates under gravity |
+| RELEASE → IDLE | Hide or reposition floor mocap cargo visual if used |
+
+**Planning collision predicate** is unchanged: `MagneticGraspFSM.is_welded` and
+`cargo_corners()` still drive `CSpaceCheckerPPP` / MuJoCo checker during TRANSPORT.
+Physics weld and planning envelope must use the same `weld_offset` from scenario
+grasp config.
+
+### Contact behaviour during transport
+
+- Welded cargo + obstacle contacts generate constraint forces on the gantry.
+- Controller must overcome contact disturbances; tune Z actuator `forcerange` and
+  `kv` if vertical deflection exceeds 10 mm.
+- On RELEASE, cargo must rest inside the goal zone without interpenetrating
+  obstacles (logged contact force peak < threshold at settle — see §4).
+
+### Kinematic mode compatibility
+
+When `physics_mode: false`, the bridge keeps v1.0 behaviour: set `cargo` pose
+from FSM, ignore equality weld. Showcase scripts (`render_mujoco.py`) default to
+kinematic mode until `--physics-mode` is passed (T12-07).
+
+---

--- a/docs/mujoco_physics_v1.2.md
+++ b/docs/mujoco_physics_v1.2.md
@@ -1,0 +1,145 @@
+# MuJoCo physics SITL — v1.2 implementation specification
+
+> **Authoritative v1.2 engineering spec.** Product acceptance criteria remain in
+> [releases.md § v1.2](releases.md#v12--mujoco-physics-sitl). Overview and tuning
+> workflow: [mujoco.md](mujoco.md).
+>
+> **Related:** [config.md § Simulation](config.md#simulation-physics-v12) ·
+> [scenarios.md § SC-v12](scenarios.md#sc-v12--mujoco-physics-validation-v12) ·
+> [requirements.md FR-SIM-07–09](requirements.md#simulation-mujoco)
+
+This document closes the implementation gaps for v1.2: actuator design, cargo weld
+physics, configuration schema, contact logging, and regression test contracts.
+
+---
+
+## 1. Robot actuators and MJCF design
+
+### Shared timing model
+
+| Parameter | Value | Source |
+| --- | --- | --- |
+| Control rate | 50 Hz | `controllers/*.yml` → `update_rate` |
+| MuJoCo integrator timestep | 0.002 s | MJCF `<option timestep="0.002">` |
+| Substeps per control tick | 25 | `floor(1 / (0.002 × 50))` |
+
+Each bridge timer callback (50 Hz):
+
+1. Read the latest `/joint_commands` velocity vector.
+2. Write commands into `data.ctrl` (one actuator per commanded DOF).
+3. Call `mj_step` **25 times** (no pose injection between substeps).
+4. Read `qpos` / `qvel` and publish `/joint_states`.
+
+Kinematic mirror mode (v1.0–v1.1) is unchanged: integrate in Python, write
+`qpos`, call `mj_forward` only.
+
+### Actuator type: velocity servos
+
+FRET v1.2 standardizes on MuJoCo **velocity actuators** (`<actuator><velocity …>`)
+for all shipped robots.
+
+| Alternative considered | Why not chosen |
+| --- | --- |
+| `<motor>` (torque) | Controllers already output joint/world velocities; torque tuning adds an extra gain layer with no v1.0 baseline |
+| `<position>` servos | Trajectory is feedforward velocity from PPP P-control / Pure Pursuit, not position PD |
+| Direct `qpos` writes in physics mode | Violates FR-SIM-07 (pose teleportation) |
+
+Velocity actuators map 1:1 to existing `/joint_commands` semantics: commanded
+value = target joint velocity [m/s] or [rad/s].
+
+Actuator **gains and force limits** live in `config/simulation/mujoco.yml` (see
+[config.md](config.md#simulation-physics-v12)). MJCF declares actuator *names* and
+joint bindings only; numeric gains must not be hardcoded in XML.
+
+### PPP gantry (`ppp_warehouse.xml`)
+
+**Joints (unchanged):** `joint_x`, `joint_y`, `joint_z` — prismatic slides on the
+existing kinematic chain.
+
+**New MJCF block** (insert before `</mujoco>`):
+
+```xml
+<actuator>
+  <velocity name="act_joint_x" joint="joint_x" kv="1" forcelimited="true" forcerange="-5000 5000"/>
+  <velocity name="act_joint_y" joint="joint_y" kv="1" forcelimited="true" forcerange="-5000 5000"/>
+  <velocity name="act_joint_z" joint="joint_z" kv="1" forcelimited="true" forcerange="-8000 8000"/>
+</actuator>
+```
+
+`kv="1"` in MJCF is a placeholder; runtime loads tuned values from YAML via
+`model.actuator_gainprm` (T12-02).
+
+**Command mapping** (`MuJoCoBridgeCore.step_physics`):
+
+| `ctrl` index | Actuator | `/joint_commands[i]` |
+| --- | --- | --- |
+| 0 | `act_joint_x` | X velocity [m/s] |
+| 1 | `act_joint_y` | Y velocity [m/s] |
+| 2 | `act_joint_z` | Z velocity [m/s] |
+
+**Collision geoms for physics:** enable contact on gantry leg/column geoms and
+obstacle boxes (`obs_a`–`obs_d`). Visual-only clutter meshes remain
+`contype="0" conaffinity="0"`. Floor plane already participates in contact.
+
+**Validation target:** EE tracking error ≤ 10 mm (releases V12-2, FR-CTL-02).
+
+### Dubins race (`dubins_race.xml`)
+
+**Joints (unchanged):** per agent, `*_joint_x` (slide X), `*_joint_y` (slide Y),
+`*_joint_yaw` (hinge Z). Six actuators total.
+
+**New MJCF block:**
+
+```xml
+<actuator>
+  <!-- Agent 1 (RRT*) -->
+  <velocity name="act_rrt_x" joint="rrt_joint_x" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+  <velocity name="act_rrt_y" joint="rrt_joint_y" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+  <velocity name="act_rrt_yaw" joint="rrt_joint_yaw" kv="1" forcelimited="true" forcerange="-500 500"/>
+  <!-- Agent 2 (SST) -->
+  <velocity name="act_sst_x" joint="sst_joint_x" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+  <velocity name="act_sst_y" joint="sst_joint_y" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+  <velocity name="act_sst_yaw" joint="sst_joint_yaw" kv="1" forcelimited="true" forcerange="-500 500"/>
+</actuator>
+```
+
+**Command mapping** (`DubinsRaceBridgeCore` physics path):
+
+Pure Pursuit / `DubinsVehicle` integrate holonomically in SE(2) today. The bridge
+maps each agent's world-frame velocity `(v_x, v_y, ω)` to the three joint
+actuators — the same joint layout used for kinematic mirroring in v1.1.
+
+| Agent | `ctrl` indices | Source |
+| --- | --- | --- |
+| RRT* | 0–2 | world `(v_x, v_y, ω)` from tracking loop |
+| SST | 3–5 | world `(v_x, v_y, ω)` from tracking loop |
+
+**Holonomic approximation:** independent X/Y slides do not enforce a non-holonomic
+Dubins constraint at the physics layer. Planning still uses ARCO `DubinsVehicle`;
+execution uses the existing three-DOF joint mirror with **contact-rich** dynamics.
+True differential-drive wheel actuators are deferred to a post-v1.2 refinement if
+needed.
+
+**Collision geoms:** `rrt_collision`, `sst_collision`, and all `str_*_col` boxes
+must use matching `contype` / `conaffinity` (default contact). Visual meshes stay
+non-colliding.
+
+**Inter-agent contact (optional, V12-3):** enabled by default — both collision
+boxes participate in the same contact group. Disable via scenario override
+`inter_agent_contact: false` when debugging single-agent physics.
+
+**Validation target:** both agents reach goal B without structure penetration;
+column contact produces non-zero logged forces (see §4).
+
+### Bridge API additions (T12-01)
+
+| Symbol | Responsibility |
+| --- | --- |
+| `step_physics(commands, substeps)` | Write `ctrl`, run `mj_step` × substeps, refresh internal state from `qpos`/`qvel` |
+| `set_actuator_gains(yaml_section)` | Apply `kv` and force limits from `mujoco.yml` |
+| `physics_mode` property | When `True`, timer uses `step_physics`; when `False`, existing `step()` |
+
+Implementation lives in `src/fret/ros/mujoco_bridge.py`. No open-loop
+`set_positions()` calls are permitted while `physics_mode` is active (FR-SIM-07).
+
+---

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -220,7 +220,8 @@ simulation foundation required for v1.3+ arm releases.
 - Regression clips when physics path diverges from kinematic baseline
 - CI smoke tests with `physics_mode:=true` for PPP and Dubins
 
-Full integration spec: [mujoco.md](mujoco.md).
+Full integration spec: [mujoco.md](mujoco.md) ·
+[v1.2 implementation spec](mujoco_physics_v1.2.md).
 
 ### Scenario IDs
 
@@ -254,7 +255,7 @@ Physics validation runs against existing release scenarios:
 | T12-05 | Contact logging harness + metrics |
 | T12-06 | Physics integration tests (PPP + Dubins) |
 | T12-07 | Update showcase scripts to support physics mode (optional flag) |
-| T12-08 | Document tuning workflow in [mujoco.md](mujoco.md) |
+| T12-08 | Document tuning workflow in [mujoco.md](mujoco.md) and [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md) |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -114,7 +114,7 @@ open-loop integration.
 - [ ] Tag `v1.2.0`
 
 Full specification: [releases.md § v1.2](releases.md#v12--mujoco-physics-sitl) ·
-[mujoco.md](mujoco.md).
+[mujoco.md](mujoco.md) · [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md).
 
 ---
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -69,6 +69,9 @@ robots. No new scenario YAML — physics mode is a parameter on existing scenari
 
 **Pass criteria:** See [releases.md § v1.2](releases.md#v12--mujoco-physics-sitl).
 
+Implementation spec: [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md) ·
+Config: [config.md § Simulation](config.md#simulation-physics-v12).
+
 ---
 
 ### SC-v13a — RRP pillars and slabs (v1.3)
@@ -120,43 +123,137 @@ until v1.3.
 
 ## Scenario YAML schema
 
+All scenario files use the ROS 2 parameters YAML format (`/**:` →
+`ros__parameters:`). They are installed to `share/fret/config/scenarios/` and
+loaded by launch, runners, and tests.
+
+### Common fields
+
+| Key | Type | Required | Description |
+| --- | --- | --- | --- |
+| `scenario_id` | string | yes | Stable identifier (matches filename stem) |
+| `model` | string | yes* | Robot model (`ppp`, `dubins`, `scara`, …) |
+| `backend` | string | no | Simulator backend (`mujoco` for release scenarios) |
+| `start_configuration` | float[] | yes† | Start joint / SE(2) state |
+| `goal_configuration` | float[] | yes† | Goal joint / SE(2) state |
+| `planning_timeout` | float | no | Planner timeout [s] (default from launch) |
+| `duration` | float | no | Scenario run length [s] |
+| `physics_mode` | bool | no | `true` → MuJoCo `mj_step` SITL (v1.2, SC-v12) |
+| `simulation_config` | string | no | Path to `config/simulation/*.yml` (default `simulation/mujoco.yml`) |
+| `recording` | object | no | Bag record toggles and topic list |
+
+\* Regression SCARA scenarios omit `model`; launch passes `model:=scara`.
+
+† Some regression scenarios use `goal_position` + IK instead of explicit
+`start_configuration` (see `static_reach.yml`).
+
+### PPP warehouse (`ppp_warehouse.yml`)
+
 ```yaml
-scenario:
-  name: ppp_warehouse
-  release: v1.0                    # v1.0 | v1.1 | v1.2 | v1.3 | v1.4
-  description: "..."
+/**:
+  ros__parameters:
+    scenario_id: "ppp_warehouse"
+    model: "ppp"
+    backend: "mujoco"
 
-robot:
-  model: ppp                       # ppp | dubins | rrp | scara | rr | six_dof
+    start_configuration: [2.0, 1.0, 2.4]
+    goal_configuration: [10.5, 2.8, 2.65]
 
-simulation:
-  physics_mode: false              # true from v1.2 for mj_step SITL
+    planning_timeout: 30.0
+    duration: 60.0
 
-world:
-  obstacles: []                    # or inline box list; MJCF in src/fret/mjcf/
+    collision_backend: analytic      # analytic | mujoco
+    planner_algorithm: rrt_star
+    plan_include_cargo: true
 
-task:
-  start_configuration: [1.0, 1.0, 0.0]
-  goal_configuration:  [59.0, 19.0, 0.0]
+    physics_mode: false              # true for SC-v12
 
-grasp:
-  mode: magnetic                   # v1.0 only
-  capture_radius: 0.3
-  goal_radius: 0.5
+    grasp:
+      capture_radius: 0.45
+      goal_radius: 0.5
+      weld_offset: [0.0, 0.0, -0.34]
+      box_half_extent: 0.25
 
-planner:
-  algorithm: sst
-  planning_timeout: 30.0
-  collision_backend: mujoco
-
-controller:
-  config: config/controllers/ppp.yml
-
-recording:
-  enabled: true
-  video: true
-  topics: [/joint_states, /joint_commands, /joint_trajectory]
+    recording:
+      enabled: true
+      topics:
+        - /joint_states
+        - /joint_commands
+        - /joint_trajectory
 ```
+
+Grasp keys must match [mujoco_physics_v1.2.md §2](mujoco_physics_v1.2.md#2-cargo-weld-physics-ppp)
+for physics weld `relpose`.
+
+### Dubins race (`dubins_race.yml`)
+
+```yaml
+/**:
+  ros__parameters:
+    scenario_id: "dubins_race"
+    model: "dubins"
+    backend: "mujoco"
+
+    start_configuration: [6.0, 6.0, 0.785]
+    goal_configuration: [74.0, 74.0, 0.0]
+
+    planning_timeout: 30.0
+    duration: 35.0
+    race_timeout: 300.0
+    simulation_dt: 0.05
+
+    obstacle_file: "worlds/dubins_race_obstacles.yml"
+
+    physics_mode: false
+    inter_agent_contact: true        # v1.2 physics: agent–agent collision
+
+    agents:
+      rrt_star:
+        algorithm: rrt_star
+        label: "1"
+        color: [0.267, 0.467, 0.800]
+      sst:
+        algorithm: sst
+        label: "2"
+        color: [0.267, 0.667, 0.400]
+
+    recording:
+      enabled: true
+      topics:
+        - /joint_states
+```
+
+Obstacle layout and Dubins vehicle margins: `config/worlds/dubins_race_obstacles.yml`.
+
+### Regression SCARA (`static_reach.yml` pattern)
+
+```yaml
+/**:
+  ros__parameters:
+    scenario_id: "static_reach"
+    goal_position: [-0.2349, 0.0855, 0.05]
+    goal_configuration: [1.8273, 2.2974, 0.05]
+    skip_ik: false
+    planning_timeout: 10.0
+    duration: 20.0
+    obstacles: []
+    recording:
+      enabled: true
+      topics: [/joint_states, /joint_commands, /joint_trajectory]
+```
+
+### v1.2 physics overlay (SC-v12)
+
+No separate scenario file. Enable physics on existing release scenarios:
+
+```yaml
+    physics_mode: true
+    simulation_config: simulation/mujoco.yml
+```
+
+Or at launch: `physics_mode:=true` (overrides YAML when passed explicitly).
+
+Full simulation parameter schema: [config.md](config.md#simulation-physics-v12).
 
 ---
 


### PR DESCRIPTION
Design decisions (where alternatives existed)

1. Actuator type — velocity servos, not torque or position Controllers already publish velocities (/joint_commands). Velocity actuators map 1:1 without adding a torque-tuning layer. Position servos would fight the existing feedforward tracking model.
2. Dubins physics — keep 3-DOF slide+hinge joints, not differential drive The MJCF already uses joint_x, joint_y, joint_yaw per agent (same as kinematic mirroring). Mapping Pure Pursuit (v_x, v_y, ω) to those actuators minimizes bridge changes. True non-holonomic wheel actuators were deferred — planning still uses ARCO DubinsVehicle; physics uses a holonomic joint mirror with contact dynamics.

3. Cargo weld — toggled MJCF <equality type="weld">, not mocap or per-step pose sync Mocap bodies don't participate properly in contact dynamics. Per-step pose writes violate FR-SIM-07 in physics mode. A weld equality constraint toggled by the bridge on FSM CAPTURE/RELEASE matches MuJoCo's constraint model and allows a physical release at the goal.

4. Cargo body — add freejoint for post-release settling The cargo needs to rest under gravity after RELEASE. A freejoint on the cargo body (with weld active during TRANSPORT) supports that; the fixed child offset alone does not.

5. Actuator gains — YAML (simulation/mujoco.yml), not MJCF MJCF declares actuator names/bindings with placeholder kv="1". Runtime applies tuned kv and force limits via the MuJoCo API. Keeps tuning out of XML and matches the no-hardcoded-parameters policy.

6. physics_mode precedence — launch arg > scenario YAML > bridge config Launch physics_mode:=true overrides scenario files for quick SC-v12 testing. Scenario YAML is the durable default for CI/repro runs.

7. Contact logs — JSONL per contact event, not ROS topic Append-only JSONL to /tmp/fret_physics/<scenario_id>/contacts.jsonl is simpler for CI artifacts (V12-5) than a new ROS message type. A summary metrics.json is written once at shutdown.

8. Regression tests — separate PPP and Dubins integration files Split test_mujoco_physics_ppp.py and test_mujoco_physics_dubins.py because launch graphs and pass criteria differ (weld vs dual-agent columns). Mark @pytest.mark.xfail until T12-01 lands.

9. Showcase regression — SSIM ≥ 0.85 as warning, not hard fail Path length ratio (≤ 1.15) and tracking error are functional gates; visual SSIM is diagnostic only because physics motion is expected to diverge slightly from kinematic clips.