### PR TITLE
docs: mark v1.0.0 and v1.1.0 release tags complete

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ Validated on SCARA (RRP, 3-DOF):
 - [x] Scenario `ppp_warehouse.yml` + launch
 - [x] Headless MP4 render for README / article (RRT* + prune + tracking)
 - [x] V10-1 ROS SITL smoke test
-- [ ] Tag `v1.0.0`
+- [x] Tag `v1.0.0`
 
 ---
 
@@ -88,7 +88,7 @@ Validated on SCARA (RRP, 3-DOF):
 - [x] Rectangular structure forest + dead-end alcoves
 - [x] Pure Pursuit tracking integration
 - [x] Release workflow + R2 upload (overview + follow POVs per scenario)
-- [ ] Tag `v1.1.0`
+- [x] Tag `v1.1.0`
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates `docs/roadmap.md` to reflect shipped release tags.

## Context

v1.1.0 was tagged on commit `a67323c` (`v1.1.0` annotated tag pushed to `origin`). The tag triggers `.github/workflows/release.yml`, which renders PPP + Dubins showcase MP4s and uploads them to Cloudflare R2.

## Changes

- Check off `Tag v1.0.0` (tags `v1.0.0`–`v1.0.9` already exist on the remote)
- Check off `Tag v1.1.0` (tag `v1.1.0` pushed as part of this release)

## Release contents (v1.1.0)

Dubins dual-robot race (SC-v11): two warehouse-floor agents race A→B through a structure forest using RRT* vs SST planners with Pure Pursuit tracking and MuJoCo showcase rendering.

See [docs/releases.md § v1.1](docs/releases.md#v11--dubins-dual-robot-race) for acceptance criteria.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ca2ec4-93ca-42c8-a05f-3bd80e084302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ca2ec4-93ca-42c8-a05f-3bd80e084302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

