### PR TITLE
feat(sim): MuJoCo physics SITL core + actuators (v1.2 PR1)

### DIFF
--- a/scripts/tests/integration.sh
+++ b/scripts/tests/integration.sh
@@ -51,7 +51,9 @@ set -u
 require_command xvfb-run "xvfb-run is required. Run: sudo apt install xvfb"
 require_command pytest "pytest is required. Run: pip install pytest"
 
-if xvfb-run -a pytest tests/integration/ -v; then
+if xvfb-run -a pytest tests/integration/ -v \
+    -p no:launch_testing \
+    -p no:launch_ros; then
     ok "Integration tests: PASSED"
     exit 0
 else

--- a/scripts/tests/smoke.sh
+++ b/scripts/tests/smoke.sh
@@ -110,6 +110,18 @@ run_smoke_test "sitl_ppp_warehouse_mujoco" 30 -- \
     scenario:=ppp_warehouse model:=ppp backend:=mujoco \
     || FAILED=1
 
+run_smoke_test "sitl_ppp_warehouse_physics" 30 -- \
+    env MUJOCO_GL=egl PYOPENGL_PLATFORM=egl \
+    xvfb-run -a ros2 launch fret sitl.py \
+    scenario:=ppp_warehouse model:=ppp backend:=mujoco physics_mode:=true \
+    || FAILED=1
+
+run_smoke_test "sitl_dubins_race_physics" 30 -- \
+    env MUJOCO_GL=egl PYOPENGL_PLATFORM=egl \
+    xvfb-run -a ros2 launch fret sitl.py \
+    scenario:=dubins_race model:=dubins backend:=mujoco physics_mode:=true \
+    || FAILED=1
+
 # Bootstrap SCARA launches — optional when legacy sim stack is installed.
 if ros2 pkg prefix ros_gz_sim >/dev/null 2>&1; then
     run_smoke_test "sim_launch" -- xvfb-run -a ros2 launch fret sim.py model:=scara \

--- a/src/fret/config/simulation/mujoco.yml
+++ b/src/fret/config/simulation/mujoco.yml
@@ -1,6 +1,6 @@
-# MuJoCo simulation bridge configuration (v1.0).
+# MuJoCo simulation bridge configuration (v1.0 + v1.2 physics).
 #
-# Consumed by: MuJoCoBridgeNode (ros/mujoco_bridge.py)
+# Consumed by: MuJoCoBridgeNode, DubinsRaceRosNode (ros/mujoco_bridge.py)
 
 /**:
   ros__parameters:
@@ -9,3 +9,39 @@
     update_rate: 50.0
     initial_joint_positions: [0.0, 0.0, 0.0]
     collision_backend: mujoco
+
+    # v1.2 physics SITL (FR-SIM-09)
+    physics_mode: false
+    mjcf_timestep: 0.002
+    substeps_per_tick: 25
+
+    contact_log_enabled: false
+    contact_log_path: ""
+    metrics_path: ""
+
+    actuators:
+      ppp:
+        names: [act_joint_x, act_joint_y, act_joint_z]
+        kv: [120.0, 120.0, 180.0]
+        forcerange: [[-5000, 5000], [-5000, 5000], [-8000, 8000]]
+      dubins:
+        names:
+          - act_rrt_x
+          - act_rrt_y
+          - act_rrt_yaw
+          - act_sst_x
+          - act_sst_y
+          - act_sst_yaw
+        kv: [80.0, 80.0, 40.0, 80.0, 80.0, 40.0]
+        forcerange:
+          - [-2000, 2000]
+          - [-2000, 2000]
+          - [-500, 500]
+          - [-2000, 2000]
+          - [-2000, 2000]
+          - [-500, 500]
+
+    cargo_weld:
+      equality_name: cargo_weld
+      body_parent: z_hoist
+      body_child: cargo

--- a/src/fret/config/simulation/mujoco.yml
+++ b/src/fret/config/simulation/mujoco.yml
@@ -1,6 +1,7 @@
 # MuJoCo simulation bridge configuration (v1.0 + v1.2 physics).
 #
-# Consumed by: MuJoCoBridgeNode, DubinsRaceRosNode (ros/mujoco_bridge.py)
+# Consumed as a ROS 2 parameter file by MuJoCoBridgeNode (launch/mujoco.py).
+# Nested actuator tables live in mujoco_physics.yml (Python-only load).
 
 /**:
   ros__parameters:
@@ -18,30 +19,3 @@
     contact_log_enabled: false
     contact_log_path: ""
     metrics_path: ""
-
-    actuators:
-      ppp:
-        names: [act_joint_x, act_joint_y, act_joint_z]
-        kv: [120.0, 120.0, 180.0]
-        forcerange: [[-5000, 5000], [-5000, 5000], [-8000, 8000]]
-      dubins:
-        names:
-          - act_rrt_x
-          - act_rrt_y
-          - act_rrt_yaw
-          - act_sst_x
-          - act_sst_y
-          - act_sst_yaw
-        kv: [80.0, 80.0, 40.0, 80.0, 80.0, 40.0]
-        forcerange:
-          - [-2000, 2000]
-          - [-2000, 2000]
-          - [-500, 500]
-          - [-2000, 2000]
-          - [-2000, 2000]
-          - [-500, 500]
-
-    cargo_weld:
-      equality_name: cargo_weld
-      body_parent: z_hoist
-      body_child: cargo

--- a/src/fret/config/simulation/mujoco_physics.yml
+++ b/src/fret/config/simulation/mujoco_physics.yml
@@ -1,0 +1,32 @@
+# MuJoCo physics SITL tables (v1.2) — loaded by Python only, not as ROS params.
+#
+# Consumed by: MuJoCoBridgeCore / DubinsRaceBridgeCore via mujoco_bridge.py
+
+/**:
+  ros__parameters:
+    actuators:
+      ppp:
+        names: [act_joint_x, act_joint_y, act_joint_z]
+        kv: [120.0, 120.0, 180.0]
+        forcerange: [[-5000, 5000], [-5000, 5000], [-8000, 8000]]
+      dubins:
+        names:
+          - act_rrt_x
+          - act_rrt_y
+          - act_rrt_yaw
+          - act_sst_x
+          - act_sst_y
+          - act_sst_yaw
+        kv: [80.0, 80.0, 40.0, 80.0, 80.0, 40.0]
+        forcerange:
+          - [-2000, 2000]
+          - [-2000, 2000]
+          - [-500, 500]
+          - [-2000, 2000]
+          - [-2000, 2000]
+          - [-500, 500]
+
+    cargo_weld:
+      equality_name: cargo_weld
+      body_parent: z_hoist
+      body_child: cargo

--- a/src/fret/launch/mujoco.py
+++ b/src/fret/launch/mujoco.py
@@ -34,6 +34,11 @@ def generate_launch_description() -> LaunchDescription:
         default_value="ppp_warehouse",
         description="Scenario stem for MJCF resolution",
     )
+    physics_mode_arg = DeclareLaunchArgument(
+        "physics_mode",
+        default_value="false",
+        description="Enable MuJoCo physics SITL (mj_step + actuators)",
+    )
 
     mujoco_config = PathJoinSubstitution(
         [pkg_share, "config", "simulation", "mujoco.yml"]
@@ -49,6 +54,7 @@ def generate_launch_description() -> LaunchDescription:
             {
                 "model": LaunchConfiguration("model"),
                 "scenario": LaunchConfiguration("scenario"),
+                "physics_mode": LaunchConfiguration("physics_mode"),
             },
         ],
     )
@@ -57,6 +63,7 @@ def generate_launch_description() -> LaunchDescription:
         [
             model_arg,
             scenario_arg,
+            physics_mode_arg,
             mujoco_bridge_node,
         ]
     )

--- a/src/fret/launch/sitl.py
+++ b/src/fret/launch/sitl.py
@@ -73,6 +73,11 @@ def generate_launch_description() -> LaunchDescription:
         default_value="gazebo",
         description="Simulator backend: gazebo | mujoco",
     )
+    physics_mode_arg = DeclareLaunchArgument(
+        "physics_mode",
+        default_value="false",
+        description="Enable MuJoCo physics SITL (mj_step + actuators)",
+    )
 
     is_mujoco = EqualsSubstitution(LaunchConfiguration("backend"), "mujoco")
     is_gazebo = UnlessCondition(is_mujoco)
@@ -144,6 +149,7 @@ def generate_launch_description() -> LaunchDescription:
         launch_arguments={
             "model": LaunchConfiguration("model"),
             "scenario": LaunchConfiguration("scenario"),
+            "physics_mode": LaunchConfiguration("physics_mode"),
         }.items(),
         condition=IfCondition(is_standard_mujoco),
     )
@@ -153,7 +159,10 @@ def generate_launch_description() -> LaunchDescription:
         executable="dubins_race_node",
         name="dubins_race_node",
         output="screen",
-        parameters=[{"scenario": LaunchConfiguration("scenario")}],
+        parameters=[
+            {"scenario": LaunchConfiguration("scenario")},
+            {"physics_mode": LaunchConfiguration("physics_mode")},
+        ],
         condition=IfCondition(is_dubins_mujoco),
     )
 
@@ -269,6 +278,7 @@ def generate_launch_description() -> LaunchDescription:
             model_arg,
             scenario_arg,
             backend_arg,
+            physics_mode_arg,
             sim_launch,
             mujoco_launch,
             dubins_race_node,

--- a/src/fret/mjcf/dubins_race.xml
+++ b/src/fret/mjcf/dubins_race.xml
@@ -182,4 +182,13 @@
     <camera name="follow" pos="18 14 8" xyaxes="0.9 0.1 0 -0.1 0.9 0.4" fovy="50"/>
     <camera name="finish" pos="74 58 10" xyaxes="-0.8 0.6 0 -0.2 -0.3 0.9" fovy="45"/>
   </worldbody>
+
+  <actuator>
+    <velocity name="act_rrt_x" joint="rrt_joint_x" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+    <velocity name="act_rrt_y" joint="rrt_joint_y" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+    <velocity name="act_rrt_yaw" joint="rrt_joint_yaw" kv="1" forcelimited="true" forcerange="-500 500"/>
+    <velocity name="act_sst_x" joint="sst_joint_x" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+    <velocity name="act_sst_y" joint="sst_joint_y" kv="1" forcelimited="true" forcerange="-2000 2000"/>
+    <velocity name="act_sst_yaw" joint="sst_joint_yaw" kv="1" forcelimited="true" forcerange="-500 500"/>
+  </actuator>
 </mujoco>

--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -122,4 +122,10 @@
     <camera name="follow" mode="targetbody" target="z_hoist" pos="3 1.5 1.5" fovy="48"/>
     <camera name="pick" mode="targetbody" target="cargo" pos="1.8 0.6 0.7" fovy="42"/>
   </worldbody>
+
+  <actuator>
+    <velocity name="act_joint_x" joint="joint_x" kv="1" forcelimited="true" forcerange="-5000 5000"/>
+    <velocity name="act_joint_y" joint="joint_y" kv="1" forcelimited="true" forcerange="-5000 5000"/>
+    <velocity name="act_joint_z" joint="joint_z" kv="1" forcelimited="true" forcerange="-8000 8000"/>
+  </actuator>
 </mujoco>

--- a/src/fret/ros/dubins_race_node.py
+++ b/src/fret/ros/dubins_race_node.py
@@ -250,7 +250,7 @@ def main(args: list[str] | None = None) -> None:  # pragma: no cover
     import rclpy
     import rclpy.node
 
-    class _ConcreteDubinsRaceNode(DubinsRaceRosNode, rclpy.node.Node):
+    class _ConcreteDubinsRaceNode(DubinsRaceRosNode, rclpy.node.Node):  # type: ignore[misc]
         def __init__(self) -> None:
             DubinsRaceRosNode.__init__(self)
 

--- a/src/fret/ros/dubins_race_node.py
+++ b/src/fret/ros/dubins_race_node.py
@@ -68,9 +68,9 @@ class DubinsRaceRosNode:  # pragma: no cover
             .string_value
         )
         self._physics_mode = _parse_bool(
-            self.get_parameter(
-                "physics_mode"
-            ).value  # type: ignore[attr-defined]
+            self.get_parameter("physics_mode")  # type: ignore[attr-defined]
+            .get_parameter_value()
+            .string_value
         )
         self._ready = False
         self._runner: Any = None
@@ -250,7 +250,7 @@ def main(args: list[str] | None = None) -> None:  # pragma: no cover
     import rclpy
     import rclpy.node
 
-    class _ConcreteDubinsRaceNode(DubinsRaceRosNode, rclpy.node.Node):  # type: ignore[misc]
+    class _ConcreteDubinsRaceNode(DubinsRaceRosNode, rclpy.node.Node):
         def __init__(self) -> None:
             DubinsRaceRosNode.__init__(self)
 

--- a/src/fret/ros/dubins_race_node.py
+++ b/src/fret/ros/dubins_race_node.py
@@ -10,6 +10,8 @@ Publishes:
 Parameters:
     scenario (str, default: ``dubins_race``)
         Scenario YAML stem under ``config/scenarios/``.
+    physics_mode (bool, default: ``false``)
+        When ``true``, drive MuJoCo actuators via ``mj_step`` (v1.2).
 """
 
 from __future__ import annotations
@@ -19,6 +21,8 @@ from typing import Any
 
 import numpy as np
 import yaml
+
+from fret.ros.mujoco_bridge import _parse_bool
 
 _RRT_JOINTS: tuple[str, ...] = (
     "rrt_joint_x",
@@ -57,10 +61,15 @@ class DubinsRaceRosNode:  # pragma: no cover
         rclpy.node.Node.__init__(self, "dubins_race_node")
 
         self.declare_parameter("scenario", "dubins_race")  # type: ignore[attr-defined]
+        self.declare_parameter("physics_mode", False)  # type: ignore[attr-defined]
         self._scenario_stem = str(
             self.get_parameter("scenario")  # type: ignore[attr-defined]
             .get_parameter_value()
             .string_value
+        )
+        self._physics_mode = _parse_bool(
+            self.get_parameter("physics_mode")  # type: ignore[attr-defined]
+            .value
         )
         self._ready = False
         self._runner: Any = None
@@ -93,7 +102,12 @@ class DubinsRaceRosNode:  # pragma: no cover
             load_scenario_bundle,
             resolve_obstacle_file,
         )
-        from fret.ros.mujoco_bridge import make_dubins_race_bridge_core
+        from fret.ros.mujoco_bridge import (
+            _load_bridge_config,
+            _resolve_config_path,
+            make_dubins_race_bridge_core,
+            physics_config_from_bridge_yaml,
+        )
         from fret.scenario.dubins_race_runner import DubinsRaceRunner
         from fret.sitl_config import (
             controller_config_path,
@@ -128,6 +142,12 @@ class DubinsRaceRosNode:  # pragma: no cover
             raise RuntimeError(msg)
 
         self._session = session
+        bridge_cfg = _load_bridge_config(_resolve_config_path(None))
+        physics_config = physics_config_from_bridge_yaml(
+            bridge_cfg,
+            "dubins",
+            physics_mode=self._physics_mode,
+        )
         self._bridge = make_dubins_race_bridge_core(
             initial_rrt=np.array(
                 session.rrt_vehicle.pose,
@@ -137,6 +157,7 @@ class DubinsRaceRosNode:  # pragma: no cover
                 session.sst_vehicle.pose,
                 dtype=np.float64,
             ),
+            physics_config=physics_config,
         )
 
         update_rate = _controller_update_rate()
@@ -155,6 +176,7 @@ class DubinsRaceRosNode:  # pragma: no cover
             f"scenario={self._scenario_stem}, "
             f"mjcf={self._bridge.mjcf_path.name}, "
             f"rate={update_rate:.1f} Hz, "
+            f"physics_mode={self._bridge.physics_mode}, "
             f"mujoco_runtime={self._bridge.has_mujoco_runtime}"
         )
         self._publish_state()
@@ -179,6 +201,9 @@ class DubinsRaceRosNode:  # pragma: no cover
             float(sst[1]),
             float(sst[2]),
         ]
+        if self._physics_mode:
+            velocities = self._bridge.get_joint_velocities()
+            msg.velocity = [float(v) for v in velocities]
         self._state_pub.publish(msg)
 
     def _timer_callback(self) -> None:
@@ -209,9 +234,12 @@ class DubinsRaceRosNode:  # pragma: no cover
                 self._race_timer.cancel()
             return
 
-        self._session.step()
-        self._bridge.set_rrt_pose(self._session.rrt_vehicle.pose)
-        self._bridge.set_sst_pose(self._session.sst_vehicle.pose)
+        if self._physics_mode:
+            self._session.step_physics(self._bridge)
+        else:
+            self._session.step()
+            self._bridge.set_rrt_pose(self._session.rrt_vehicle.pose)
+            self._bridge.set_sst_pose(self._session.sst_vehicle.pose)
         self._publish_state()
         self._step_count += 1
 

--- a/src/fret/ros/dubins_race_node.py
+++ b/src/fret/ros/dubins_race_node.py
@@ -68,8 +68,9 @@ class DubinsRaceRosNode:  # pragma: no cover
             .string_value
         )
         self._physics_mode = _parse_bool(
-            self.get_parameter("physics_mode")  # type: ignore[attr-defined]
-            .value
+            self.get_parameter(
+                "physics_mode"
+            ).value  # type: ignore[attr-defined]
         )
         self._ready = False
         self._runner: Any = None
@@ -103,7 +104,7 @@ class DubinsRaceRosNode:  # pragma: no cover
             resolve_obstacle_file,
         )
         from fret.ros.mujoco_bridge import (
-            _load_bridge_config,
+            _load_merged_bridge_config,
             _resolve_config_path,
             make_dubins_race_bridge_core,
             physics_config_from_bridge_yaml,
@@ -142,7 +143,7 @@ class DubinsRaceRosNode:  # pragma: no cover
             raise RuntimeError(msg)
 
         self._session = session
-        bridge_cfg = _load_bridge_config(_resolve_config_path(None))
+        bridge_cfg = _load_merged_bridge_config(_resolve_config_path(None))
         physics_config = physics_config_from_bridge_yaml(
             bridge_cfg,
             "dubins",

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -840,6 +840,15 @@ def _load_bridge_config(config_path: str) -> dict[str, Any]:
     return {}
 
 
+def _load_merged_bridge_config(config_path: str) -> dict[str, Any]:
+    """Load bridge YAML plus optional ``mujoco_physics.yml`` companion tables."""
+    cfg = dict(_load_bridge_config(config_path))
+    physics_path = pathlib.Path(config_path).with_name("mujoco_physics.yml")
+    if physics_path.is_file():
+        cfg.update(_load_bridge_config(str(physics_path)))
+    return cfg
+
+
 class MuJoCoBridgeNode:
     """ROS 2 node bridging MuJoCo joint I/O to the FRET graph.
 
@@ -878,7 +887,7 @@ class MuJoCoBridgeNode:
         self._node: rclpy.node.Node = _Node("mujoco_bridge_node")
 
         resolved = _resolve_config_path(config_path)
-        cfg = _load_bridge_config(resolved)
+        cfg = _load_merged_bridge_config(resolved)
 
         self._node.declare_parameter(
             "model", model or str(cfg.get("model", "ppp"))

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -1,20 +1,25 @@
-"""MuJoCo backend adapter for FRET simulator I/O (v1.0).
+"""MuJoCo backend adapter for FRET simulator I/O (v1.0 + v1.2 physics).
 
 Level-3 ``MuJoCoBridgeCore`` integrates joint velocity commands against an
 MJCF scene without requiring a live ROS context.  When the optional
 ``mujoco`` package is installed the core also keeps an ``MjModel`` /
 ``MjData`` pair in sync for forward kinematics and future rendering hooks.
 
+In **physics mode** (v1.2), velocity commands drive MuJoCo actuators and
+``mj_step`` advances the simulation; joint state is read from ``qpos`` /
+``qvel`` (FR-SIM-07).
+
 Level-4 ``MuJoCoBridgeNode`` subscribes to ``/joint_commands`` and publishes
 ``/joint_states`` at the configured rate (default 50 Hz).
 
-Satisfies requirements FR-SIM-01 and FR-SIM-02.
+Satisfies requirements FR-SIM-01, FR-SIM-02, and FR-SIM-09.
 """
 
 from __future__ import annotations
 
 import os
 import pathlib
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -54,6 +59,154 @@ _SST_JOINT_NAMES: list[str] = [
 ]
 
 _DEFAULT_UPDATE_RATE_HZ: float = 50.0
+_DEFAULT_MJCF_TIMESTEP_S: float = 0.002
+_DEFAULT_SUBSTEPS_PER_TICK: int = 25
+
+
+@dataclass(frozen=True)
+class ActuatorTable:
+    """Runtime actuator gain table loaded from ``simulation/mujoco.yml``."""
+
+    names: tuple[str, ...]
+    kv: tuple[float, ...]
+    forcerange: tuple[tuple[float, float], ...]
+
+
+@dataclass(frozen=True)
+class PhysicsBridgeConfig:
+    """Physics SITL settings for MuJoCo bridge cores (v1.2)."""
+
+    physics_mode: bool
+    substeps_per_tick: int
+    actuators: ActuatorTable | None
+
+
+def _parse_bool(value: Any) -> bool:
+    """Parse ROS / YAML boolean parameters."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"true", "1", "yes", "on"}
+
+
+def _require_actuator_table(cfg: dict[str, Any], model: str) -> ActuatorTable:
+    """Load and validate the actuator table for ``model``."""
+    actuators = cfg.get("actuators")
+    if not isinstance(actuators, dict):
+        raise ValueError("physics_mode requires 'actuators' in mujoco.yml")
+
+    section = actuators.get(model)
+    if not isinstance(section, dict):
+        raise ValueError(
+            f"physics_mode requires actuators.{model} in mujoco.yml"
+        )
+
+    names_raw = section.get("names")
+    kv_raw = section.get("kv")
+    force_raw = section.get("forcerange")
+    if not isinstance(names_raw, list) or not names_raw:
+        raise ValueError(f"actuators.{model}.names must be a non-empty list")
+    if not isinstance(kv_raw, list) or len(kv_raw) != len(names_raw):
+        raise ValueError(
+            f"actuators.{model}.kv must match names length "
+            f"({len(names_raw)})"
+        )
+    if not isinstance(force_raw, list) or len(force_raw) != len(names_raw):
+        raise ValueError(
+            f"actuators.{model}.forcerange must match names length "
+            f"({len(names_raw)})"
+        )
+
+    forcerange: list[tuple[float, float]] = []
+    for entry in force_raw:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+            raise ValueError(
+                f"actuators.{model}.forcerange entries must be [min, max]"
+            )
+        forcerange.append((float(entry[0]), float(entry[1])))
+
+    return ActuatorTable(
+        names=tuple(str(name) for name in names_raw),
+        kv=tuple(float(v) for v in kv_raw),
+        forcerange=tuple(forcerange),
+    )
+
+
+def physics_config_from_bridge_yaml(
+    cfg: dict[str, Any],
+    model: str,
+    *,
+    physics_mode: bool | None = None,
+) -> PhysicsBridgeConfig:
+    """Build :class:`PhysicsBridgeConfig` from bridge YAML parameters."""
+    mode = (
+        _parse_bool(physics_mode)
+        if physics_mode is not None
+        else _parse_bool(cfg.get("physics_mode", False))
+    )
+    substeps = int(cfg.get("substeps_per_tick", _DEFAULT_SUBSTEPS_PER_TICK))
+    if substeps <= 0:
+        raise ValueError("substeps_per_tick must be positive")
+
+    actuators = _require_actuator_table(cfg, model) if mode else None
+    return PhysicsBridgeConfig(
+        physics_mode=mode,
+        substeps_per_tick=substeps,
+        actuators=actuators,
+    )
+
+
+def _bind_joint_addresses(
+    model: Any,
+    mujoco: Any,
+    joint_names: list[str],
+) -> tuple[list[int], list[int]]:
+    """Return ``(qpos_adrs, qvel_adrs)`` for ordered joint names."""
+    qpos_adrs: list[int] = []
+    qvel_adrs: list[int] = []
+    for name in joint_names:
+        joint_id = mujoco.mj_name2id(
+            model,
+            mujoco.mjtObj.mjOBJ_JOINT,
+            name,
+        )
+        if joint_id < 0:
+            raise ValueError(f"Joint not found in MJCF: {name}")
+        qpos_adrs.append(int(model.jnt_qposadr[joint_id]))
+        qvel_adrs.append(int(model.jnt_dofadr[joint_id]))
+    return qpos_adrs, qvel_adrs
+
+
+def _bind_actuator_ids(
+    model: Any,
+    mujoco: Any,
+    actuator_names: tuple[str, ...],
+) -> list[int]:
+    """Return MuJoCo actuator ids in command order."""
+    actuator_ids: list[int] = []
+    for name in actuator_names:
+        act_id = mujoco.mj_name2id(
+            model,
+            mujoco.mjtObj.mjOBJ_ACTUATOR,
+            name,
+        )
+        if act_id < 0:
+            raise ValueError(f"Actuator not found in MJCF: {name}")
+        actuator_ids.append(int(act_id))
+    return actuator_ids
+
+
+def _apply_actuator_gains(model: Any, table: ActuatorTable) -> None:
+    """Apply YAML actuator gains to an ``MjModel``."""
+    if model.nu != len(table.names):
+        raise ValueError(
+            f"MJCF has {model.nu} actuators; expected {len(table.names)}"
+        )
+    for idx, (kv, (fmin, fmax)) in enumerate(
+        zip(table.kv, table.forcerange, strict=True)
+    ):
+        model.actuator_gainprm[idx, 0] = float(kv)
+        model.actuator_forcerange[idx, 0] = float(fmin)
+        model.actuator_forcerange[idx, 1] = float(fmax)
 
 
 def _project_root() -> pathlib.Path:
@@ -123,6 +276,7 @@ def make_mujoco_bridge_core(
     *,
     mjcf_path: str | pathlib.Path | None = None,
     initial_positions: npt.NDArray[np.float64] | None = None,
+    physics_config: PhysicsBridgeConfig | None = None,
 ) -> MuJoCoBridgeCore:
     """Build a model-appropriate MuJoCo bridge core (FR-SYS-01).
 
@@ -131,6 +285,7 @@ def make_mujoco_bridge_core(
         scenario: Scenario stem used for MJCF resolution.
         mjcf_path: Optional explicit MJCF path override.
         initial_positions: Optional initial joint configuration.
+        physics_config: Optional physics SITL settings (v1.2).
 
     Returns:
         Configured ``MuJoCoBridgeCore`` instance.
@@ -149,12 +304,15 @@ def make_mujoco_bridge_core(
         if q0.shape != (kin.dof,):
             raise ValueError(f"initial_positions must have shape ({kin.dof},)")
 
-        return MuJoCoBridgeCore(
+        core = MuJoCoBridgeCore(
             mjcf_path=resolved,
             joint_names=kin.joint_names,
             limits=_PPP_MJCF_LIMITS,
             initial_positions=q0,
         )
+        if physics_config is not None:
+            core.configure_physics(physics_config)
+        return core
 
     if model == "dubins":
         raise ValueError(
@@ -193,12 +351,40 @@ class MuJoCoBridgeCore:
             self._limits[:, 1],
         )
         self._velocities = np.zeros_like(self._positions)
+        self._physics_mode = False
+        self._substeps_per_tick = _DEFAULT_SUBSTEPS_PER_TICK
+        self._actuator_ids: list[int] = []
         self._mujoco: Any | None = None
         self._model: Any | None = None
         self._data: Any | None = None
         self._qpos_adrs: list[int] = []
+        self._qvel_adrs: list[int] = []
         self._load_mujoco_optional()
-        self._write_mujoco_state()
+        self._seed_mujoco_state()
+
+    @property
+    def physics_mode(self) -> bool:
+        """Return ``True`` when actuator-driven ``mj_step`` is active."""
+        return self._physics_mode
+
+    def configure_physics(self, config: PhysicsBridgeConfig) -> None:
+        """Enable or disable physics SITL mode (v1.2)."""
+        self._physics_mode = bool(config.physics_mode)
+        self._substeps_per_tick = int(config.substeps_per_tick)
+        if not self._physics_mode:
+            return
+        if self._model is None or self._mujoco is None:
+            raise RuntimeError(
+                "physics_mode requires the optional mujoco package"
+            )
+        if config.actuators is None:
+            raise ValueError("physics_mode requires actuator configuration")
+        self._actuator_ids = _bind_actuator_ids(
+            self._model,
+            self._mujoco,
+            config.actuators.names,
+        )
+        _apply_actuator_gains(self._model, config.actuators)
 
     @property
     def joint_names(self) -> list[str]:
@@ -233,7 +419,14 @@ class MuJoCoBridgeCore:
 
         Args:
             positions: Joint configuration, shape ``(DOF,)``.
+
+        Raises:
+            RuntimeError: When ``physics_mode`` is active (FR-SIM-07).
         """
+        if self._physics_mode:
+            raise RuntimeError(
+                "set_positions() is forbidden while physics_mode is active"
+            )
         q = np.asarray(positions, dtype=np.float64)
         if q.shape != self._positions.shape:
             raise ValueError(
@@ -241,6 +434,53 @@ class MuJoCoBridgeCore:
             )
         self._positions = np.clip(q, self._limits[:, 0], self._limits[:, 1])
         self._write_mujoco_state()
+
+    def step_physics(
+        self,
+        velocities: npt.NDArray[np.float64],
+        *,
+        substeps: int | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Advance the MuJoCo simulation with velocity actuator commands.
+
+        Args:
+            velocities: Target joint velocities, shape ``(DOF,)``.
+            substeps: Optional override for ``mj_step`` count per tick.
+
+        Returns:
+            Simulated joint positions read from ``qpos``.
+
+        Raises:
+            RuntimeError: When MuJoCo is unavailable or physics is disabled.
+        """
+        if not self._physics_mode:
+            raise RuntimeError("step_physics() requires physics_mode=True")
+        if self._model is None or self._data is None or self._mujoco is None:
+            raise RuntimeError("step_physics() requires the mujoco package")
+
+        v = np.asarray(velocities, dtype=np.float64)
+        if v.shape != self._positions.shape:
+            raise ValueError(
+                f"Expected velocity shape {self._positions.shape}, got {v.shape}"
+            )
+        if len(self._actuator_ids) != v.shape[0]:
+            raise RuntimeError("Actuator count does not match DOF")
+
+        self._velocities = v.copy()
+        for idx, act_id in enumerate(self._actuator_ids):
+            self._data.ctrl[act_id] = float(v[idx])
+
+        step_count = (
+            self._substeps_per_tick if substeps is None else int(substeps)
+        )
+        if step_count <= 0:
+            raise ValueError("substeps must be positive")
+
+        for _ in range(step_count):
+            self._mujoco.mj_step(self._model, self._data)
+
+        self._read_state_from_mujoco()
+        return self._positions.copy()
 
     def step(
         self,
@@ -256,6 +496,8 @@ class MuJoCoBridgeCore:
         Returns:
             Updated joint positions after integration.
         """
+        if self._physics_mode:
+            return self.step_physics(velocities)
         v = np.asarray(velocities, dtype=np.float64)
         if v.shape != self._positions.shape:
             raise ValueError(
@@ -280,21 +522,44 @@ class MuJoCoBridgeCore:
         self._mujoco = mujoco
         self._model = mujoco.MjModel.from_xml_path(str(self._mjcf_path))
         self._data = mujoco.MjData(self._model)
-        adrs: list[int] = []
-        for name in self._joint_names:
-            joint_id = mujoco.mj_name2id(
-                self._model,
-                mujoco.mjtObj.mjOBJ_JOINT,
-                name,
-            )
-            if joint_id < 0:
-                raise ValueError(f"Joint not found in MJCF: {name}")
-            adrs.append(int(self._model.jnt_qposadr[joint_id]))
-        self._qpos_adrs = adrs
+        self._qpos_adrs, self._qvel_adrs = _bind_joint_addresses(
+            self._model,
+            mujoco,
+            self._joint_names,
+        )
+
+    def _seed_mujoco_state(self) -> None:
+        """Write initial ``qpos`` once at construction (before physics mode)."""
+        if self._model is None or self._data is None or self._mujoco is None:
+            return
+        for idx, adr in enumerate(self._qpos_adrs):
+            self._data.qpos[adr] = float(self._positions[idx])
+        self._mujoco.mj_forward(self._model, self._data)
+
+    def _read_state_from_mujoco(self) -> None:
+        if self._model is None or self._data is None:
+            return
+        positions = np.empty(len(self._qpos_adrs), dtype=np.float64)
+        velocities = np.empty(len(self._qvel_adrs), dtype=np.float64)
+        for idx, (qpos_adr, qvel_adr) in enumerate(
+            zip(self._qpos_adrs, self._qvel_adrs, strict=True)
+        ):
+            positions[idx] = float(self._data.qpos[qpos_adr])
+            velocities[idx] = float(self._data.qvel[qvel_adr])
+        self._positions = np.clip(
+            positions,
+            self._limits[:, 0],
+            self._limits[:, 1],
+        )
+        self._velocities = velocities
 
     def _write_mujoco_state(self) -> None:
         if self._model is None or self._data is None or self._mujoco is None:
             return
+        if self._physics_mode:
+            raise RuntimeError(
+                "pose injection is forbidden while physics_mode is active"
+            )
         for idx, adr in enumerate(self._qpos_adrs):
             self._data.qpos[adr] = float(self._positions[idx])
         self._mujoco.mj_forward(self._model, self._data)
@@ -303,9 +568,14 @@ class MuJoCoBridgeCore:
 class DubinsRaceBridgeCore:
     """MuJoCo state mirror for the dual-agent Dubins race scene.
 
-    Writes RRT* and SST vehicle poses into ``dubins_race.xml`` joint
-    coordinates without integrating dynamics (poses come from ARCO tracking).
+    In kinematic mode, writes RRT* and SST vehicle poses into
+    ``dubins_race.xml`` joint coordinates without integrating dynamics.
+
+    In physics mode (v1.2), six velocity actuators are driven via
+    :meth:`step_physics` and poses are read from simulated ``qpos``.
     """
+
+    _JOINT_NAMES: tuple[str, ...] = tuple(_RRT_JOINT_NAMES + _SST_JOINT_NAMES)
 
     def __init__(
         self,
@@ -313,6 +583,7 @@ class DubinsRaceBridgeCore:
         mjcf_path: str | pathlib.Path | None = None,
         initial_rrt: npt.NDArray[np.float64] | None = None,
         initial_sst: npt.NDArray[np.float64] | None = None,
+        physics_config: PhysicsBridgeConfig | None = None,
     ) -> None:
         resolved = resolve_mjcf_path("dubins", "dubins_race", mjcf_path)
         self._mjcf_path = resolved
@@ -339,8 +610,39 @@ class DubinsRaceBridgeCore:
         self._model: Any | None = None
         self._data: Any | None = None
         self._joint_adrs: dict[str, int] = {}
+        self._qvel_adrs: dict[str, int] = {}
+        self._physics_mode = False
+        self._substeps_per_tick = _DEFAULT_SUBSTEPS_PER_TICK
+        self._actuator_ids: list[int] = []
+        self._velocities = np.zeros(6, dtype=np.float64)
         self._load_mujoco_optional()
-        self._write_mujoco_state()
+        self._seed_mujoco_state()
+        if physics_config is not None:
+            self.configure_physics(physics_config)
+
+    @property
+    def physics_mode(self) -> bool:
+        """Return ``True`` when actuator-driven ``mj_step`` is active."""
+        return self._physics_mode
+
+    def configure_physics(self, config: PhysicsBridgeConfig) -> None:
+        """Enable or disable physics SITL mode (v1.2)."""
+        self._physics_mode = bool(config.physics_mode)
+        self._substeps_per_tick = int(config.substeps_per_tick)
+        if not self._physics_mode:
+            return
+        if self._model is None or self._mujoco is None:
+            raise RuntimeError(
+                "physics_mode requires the optional mujoco package"
+            )
+        if config.actuators is None:
+            raise ValueError("physics_mode requires actuator configuration")
+        self._actuator_ids = _bind_actuator_ids(
+            self._model,
+            self._mujoco,
+            config.actuators.names,
+        )
+        _apply_actuator_gains(self._model, config.actuators)
 
     @property
     def mjcf_path(self) -> pathlib.Path:
@@ -354,12 +656,20 @@ class DubinsRaceBridgeCore:
 
     def set_rrt_pose(self, pose: tuple[float, float, float]) -> None:
         """Update RRT* agent pose ``(x, y, heading)``."""
+        if self._physics_mode:
+            raise RuntimeError(
+                "set_rrt_pose() is forbidden while physics_mode is active"
+            )
         self._rrt = np.array(pose, dtype=np.float64)
         self._rrt = np.clip(self._rrt, self._limits[:, 0], self._limits[:, 1])
         self._write_mujoco_state()
 
     def set_sst_pose(self, pose: tuple[float, float, float]) -> None:
         """Update SST agent pose ``(x, y, heading)``."""
+        if self._physics_mode:
+            raise RuntimeError(
+                "set_sst_pose() is forbidden while physics_mode is active"
+            )
         self._sst = np.array(pose, dtype=np.float64)
         self._sst = np.clip(self._sst, self._limits[:, 0], self._limits[:, 1])
         self._write_mujoco_state()
@@ -372,6 +682,42 @@ class DubinsRaceBridgeCore:
         """Return SST pose copy."""
         return self._sst.copy()
 
+    def get_joint_velocities(self) -> npt.NDArray[np.float64]:
+        """Return the most recent six-DOF velocity commands."""
+        return self._velocities.copy()
+
+    def step_physics(
+        self,
+        velocities: npt.NDArray[np.float64],
+        *,
+        substeps: int | None = None,
+    ) -> npt.NDArray[np.float64]:
+        """Advance both agents with six velocity actuator commands."""
+        if not self._physics_mode:
+            raise RuntimeError("step_physics() requires physics_mode=True")
+        if self._model is None or self._data is None or self._mujoco is None:
+            raise RuntimeError("step_physics() requires the mujoco package")
+
+        v = np.asarray(velocities, dtype=np.float64).reshape(6)
+        if len(self._actuator_ids) != 6:
+            raise RuntimeError("Dubins race MJCF must expose six actuators")
+
+        self._velocities = v.copy()
+        for idx, act_id in enumerate(self._actuator_ids):
+            self._data.ctrl[act_id] = float(v[idx])
+
+        step_count = (
+            self._substeps_per_tick if substeps is None else int(substeps)
+        )
+        if step_count <= 0:
+            raise ValueError("substeps must be positive")
+
+        for _ in range(step_count):
+            self._mujoco.mj_step(self._model, self._data)
+
+        self._read_state_from_mujoco()
+        return np.concatenate([self._rrt, self._sst]).astype(np.float64)
+
     def _load_mujoco_optional(self) -> None:
         try:
             import mujoco
@@ -382,24 +728,59 @@ class DubinsRaceBridgeCore:
             self._mujoco = mujoco
             self._model = mujoco.MjModel.from_xml_path(str(self._mjcf_path))
             self._data = mujoco.MjData(self._model)
-            for name in _RRT_JOINT_NAMES + _SST_JOINT_NAMES:
-                joint_id = mujoco.mj_name2id(
-                    self._model,
-                    mujoco.mjtObj.mjOBJ_JOINT,
-                    name,
-                )
-                if joint_id < 0:
-                    raise ValueError(f"Joint not found in MJCF: {name}")
-                self._joint_adrs[name] = int(self._model.jnt_qposadr[joint_id])
+            qpos_adrs, qvel_adrs = _bind_joint_addresses(
+                self._model,
+                mujoco,
+                list(self._JOINT_NAMES),
+            )
+            for name, adr in zip(self._JOINT_NAMES, qpos_adrs, strict=True):
+                self._joint_adrs[name] = adr
+            for name, adr in zip(self._JOINT_NAMES, qvel_adrs, strict=True):
+                self._qvel_adrs[name] = adr
         except Exception:
             self._mujoco = None
             self._model = None
             self._data = None
             self._joint_adrs = {}
+            self._qvel_adrs = {}
+
+    def _seed_mujoco_state(self) -> None:
+        """Write initial agent poses once at construction."""
+        if self._model is None or self._data is None or self._mujoco is None:
+            return
+        mapping = {
+            "rrt_joint_x": float(self._rrt[0]),
+            "rrt_joint_y": float(self._rrt[1]),
+            "rrt_joint_yaw": float(self._rrt[2]),
+            "sst_joint_x": float(self._sst[0]),
+            "sst_joint_y": float(self._sst[1]),
+            "sst_joint_yaw": float(self._sst[2]),
+        }
+        for name, value in mapping.items():
+            adr = self._joint_adrs.get(name)
+            if adr is not None:
+                self._data.qpos[adr] = value
+        self._mujoco.mj_forward(self._model, self._data)
+
+    def _read_state_from_mujoco(self) -> None:
+        if self._data is None:
+            return
+        rrt = np.empty(3, dtype=np.float64)
+        sst = np.empty(3, dtype=np.float64)
+        for idx, name in enumerate(_RRT_JOINT_NAMES):
+            rrt[idx] = float(self._data.qpos[self._joint_adrs[name]])
+        for idx, name in enumerate(_SST_JOINT_NAMES):
+            sst[idx] = float(self._data.qpos[self._joint_adrs[name]])
+        self._rrt = np.clip(rrt, self._limits[:, 0], self._limits[:, 1])
+        self._sst = np.clip(sst, self._limits[:, 0], self._limits[:, 1])
 
     def _write_mujoco_state(self) -> None:
         if self._model is None or self._data is None or self._mujoco is None:
             return
+        if self._physics_mode:
+            raise RuntimeError(
+                "pose injection is forbidden while physics_mode is active"
+            )
         mapping = {
             "rrt_joint_x": float(self._rrt[0]),
             "rrt_joint_y": float(self._rrt[1]),
@@ -420,12 +801,14 @@ def make_dubins_race_bridge_core(
     mjcf_path: str | pathlib.Path | None = None,
     initial_rrt: npt.NDArray[np.float64] | None = None,
     initial_sst: npt.NDArray[np.float64] | None = None,
+    physics_config: PhysicsBridgeConfig | None = None,
 ) -> DubinsRaceBridgeCore:
     """Build a dual-agent MuJoCo bridge for SC-v11."""
     return DubinsRaceBridgeCore(
         mjcf_path=mjcf_path,
         initial_rrt=initial_rrt,
         initial_sst=initial_sst,
+        physics_config=physics_config,
     )
 
 
@@ -511,6 +894,14 @@ class MuJoCoBridgeNode:
             "initial_joint_positions",
             list(cfg.get("initial_joint_positions", [0.0, 0.0, 0.0])),
         )
+        self._node.declare_parameter(
+            "physics_mode",
+            _parse_bool(cfg.get("physics_mode", False)),
+        )
+        self._node.declare_parameter(
+            "substeps_per_tick",
+            int(cfg.get("substeps_per_tick", _DEFAULT_SUBSTEPS_PER_TICK)),
+        )
 
         model_name = str(
             self._node.get_parameter("model")
@@ -534,11 +925,26 @@ class MuJoCoBridgeNode:
         )
         q0 = np.asarray(initial, dtype=np.float64)
 
+        physics_mode = _parse_bool(
+            self._node.get_parameter("physics_mode").value
+        )
+        cfg_for_physics = dict(cfg)
+        cfg_for_physics["physics_mode"] = physics_mode
+        cfg_for_physics["substeps_per_tick"] = int(
+            self._node.get_parameter("substeps_per_tick").value
+        )
+        physics_config = physics_config_from_bridge_yaml(
+            cfg_for_physics,
+            model_name,
+            physics_mode=physics_mode,
+        )
+
         self._core = make_mujoco_bridge_core(
             model_name,
             scenario_name,
             mjcf_path=mjcf_path,
             initial_positions=q0,
+            physics_config=physics_config,
         )
         self._latest_cmd = np.zeros(
             self._core.get_positions().shape, dtype=np.float64
@@ -568,6 +974,7 @@ class MuJoCoBridgeNode:
             f"model={model_name}, scenario={scenario_name}, "
             f"mjcf={self._core.mjcf_path.name}, "
             f"rate={self._update_rate} Hz, "
+            f"physics_mode={self._core.physics_mode}, "
             f"mujoco_runtime={self._core.has_mujoco_runtime}"
         )
 
@@ -616,11 +1023,14 @@ def main(args: list[str] | None = None) -> None:  # pragma: no cover
 
 
 __all__ = [
+    "ActuatorTable",
     "DubinsRaceBridgeCore",
     "MuJoCoBridgeCore",
     "MuJoCoBridgeNode",
+    "PhysicsBridgeConfig",
     "integrate_joint_velocities",
     "make_dubins_race_bridge_core",
     "make_mujoco_bridge_core",
+    "physics_config_from_bridge_yaml",
     "resolve_mjcf_path",
 ]

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -881,7 +881,7 @@ class MuJoCoBridgeNode:
 
         self._rclpy = rclpy
 
-        class _Node(rclpy.node.Node):
+        class _Node(rclpy.node.Node):  # type: ignore[misc]
             pass
 
         self._node: rclpy.node.Node = _Node("mujoco_bridge_node")

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -881,7 +881,7 @@ class MuJoCoBridgeNode:
 
         self._rclpy = rclpy
 
-        class _Node(rclpy.node.Node):  # type: ignore[misc]
+        class _Node(rclpy.node.Node):
             pass
 
         self._node: rclpy.node.Node = _Node("mujoco_bridge_node")

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -150,6 +150,61 @@ class DubinsRaceSimulation:
         self.sim_time_s += self.dt
         return self.finished
 
+    def step_physics(self, bridge: Any) -> bool:
+        """Advance one physics SITL tick via MuJoCo actuators (v1.2).
+
+        Computes world-frame velocity commands from Pure Pursuit, drives
+        ``bridge.step_physics``, then syncs vehicle poses from simulated
+        ``qpos`` for the next tracking iteration.
+
+        Args:
+            bridge: :class:`~fret.ros.mujoco_bridge.DubinsRaceBridgeCore`
+                configured with ``physics_mode=True``.
+
+        Returns:
+            ``True`` when both agents reached the goal.
+        """
+        if self.finished:
+            return True
+
+        rrt_cmd, rrt_metrics = _agent_world_velocity_command(
+            self.rrt_loop,
+            self.rrt_path,
+            agent_finished=self.rrt_finish is not None,
+        )
+        sst_cmd, sst_metrics = _agent_world_velocity_command(
+            self.sst_loop,
+            self.sst_path,
+            agent_finished=self.sst_finish is not None,
+        )
+        commands = np.array([*rrt_cmd, *sst_cmd], dtype=np.float64)
+        bridge.step_physics(commands)
+        _sync_vehicle_pose(self.rrt_vehicle, bridge.get_rrt_pose())
+        _sync_vehicle_pose(self.sst_vehicle, bridge.get_sst_pose())
+
+        self.max_cross_track_error_m = max(
+            self.max_cross_track_error_m,
+            abs(float(rrt_metrics["cross_track_error"])),
+            abs(float(sst_metrics["cross_track_error"])),
+        )
+
+        if self.rrt_finish is None and (
+            _distance_to_goal(self.rrt_vehicle.pose, self.world.goal_xy)
+            <= self.goal_radius
+        ):
+            self.rrt_finish = self.sim_time_s
+
+        if self.sst_finish is None and (
+            _distance_to_goal(self.sst_vehicle.pose, self.world.goal_xy)
+            <= self.goal_radius
+        ):
+            self.sst_finish = self.sim_time_s
+
+        self.rrt_pose_history.append(self.rrt_vehicle.pose)
+        self.sst_pose_history.append(self.sst_vehicle.pose)
+        self.sim_time_s += self.dt
+        return self.finished
+
     def to_result(
         self,
         rrt_plan: AgentPlanResult,
@@ -413,6 +468,53 @@ def _min_pose_history_clearance(
             for pose in poses
         )
     )
+
+
+def _agent_world_velocity_command(
+    loop: TrackingLoop,
+    path: list[tuple[float, float]],
+    *,
+    agent_finished: bool,
+) -> tuple[tuple[float, float, float], dict[str, Any]]:
+    """Return world ``(v_x, v_y, omega)`` without integrating the vehicle."""
+    if agent_finished:
+        return (0.0, 0.0, 0.0), {
+            "cross_track_error": 0.0,
+            "heading_error": 0.0,
+            "pose": loop.vehicle.pose,
+            "speed": 0.0,
+            "turn_rate": 0.0,
+            "curvature": 0.0,
+            "repulsion_turn_rate": 0.0,
+        }
+
+    pose = loop.vehicle.pose
+    speed_ref = loop.cruise_speed / (
+        1.0 + loop.curvature_gain * abs(loop.controller.curvature)
+    )
+    speed_cmd, turn_rate_cmd = loop.controller.track(pose, path, speed_ref)
+    x, y, theta = pose
+    repulsion = loop._repulsion_turn_rate(x, y, theta)
+    turn_rate_cmd += repulsion
+    vx = speed_cmd * math.cos(theta)
+    vy = speed_cmd * math.sin(theta)
+    metrics: dict[str, Any] = {
+        "cross_track_error": loop.controller.cross_track_error,
+        "heading_error": loop.controller.heading_error,
+        "pose": pose,
+        "speed": speed_cmd,
+        "turn_rate": turn_rate_cmd,
+        "curvature": loop.controller.curvature,
+        "repulsion_turn_rate": repulsion,
+    }
+    return (vx, vy, turn_rate_cmd), metrics
+
+
+def _sync_vehicle_pose(vehicle: Any, pose: npt.NDArray[np.float64]) -> None:
+    """Copy simulated ``(x, y, heading)`` into a Dubins vehicle model."""
+    vehicle.x = float(pose[0])
+    vehicle.y = float(pose[1])
+    vehicle.heading = float(pose[2])
 
 
 def _distance_to_goal(

--- a/tests/ros/test_mujoco_bridge.py
+++ b/tests/ros/test_mujoco_bridge.py
@@ -16,6 +16,7 @@ from fret.ros.mujoco_bridge import (
     integrate_joint_velocities,
     make_dubins_race_bridge_core,
     make_mujoco_bridge_core,
+    physics_config_from_bridge_yaml,
     resolve_mjcf_path,
 )
 
@@ -149,4 +150,105 @@ def test_load_mujoco_config_defaults() -> None:
     assert cfg["scenario"] == "ppp_warehouse"
     assert cfg["update_rate"] == 50.0
     assert cfg["initial_joint_positions"] == [0.0, 0.0, 0.0]
+    assert cfg["physics_mode"] is False
+    assert cfg["substeps_per_tick"] == 25
+    assert "actuators" in cfg
     assert pathlib.Path(config_path).is_file()
+
+
+def test_physics_config_from_yaml_kinematic_default() -> None:
+    """Kinematic mode should not require actuator runtime binding."""
+    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+
+    cfg = _load_bridge_config(_resolve_config_path(None))
+    physics = physics_config_from_bridge_yaml(cfg, "ppp")
+    assert physics.physics_mode is False
+    assert physics.actuators is None
+
+
+def test_physics_config_from_yaml_physics_mode() -> None:
+    """Physics mode should load the PPP actuator table."""
+    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+
+    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = dict(cfg)
+    cfg["physics_mode"] = True
+    physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
+    assert physics.physics_mode is True
+    assert physics.actuators is not None
+    assert physics.actuators.names == (
+        "act_joint_x",
+        "act_joint_y",
+        "act_joint_z",
+    )
+
+
+@pytest.mark.skipif(
+    not make_mujoco_bridge_core("ppp", "ppp_warehouse").has_mujoco_runtime,
+    reason="mujoco package not installed",
+)
+def test_bridge_core_step_physics_advances_position() -> None:
+    """Physics mode should integrate joint motion via mj_step."""
+    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+
+    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = dict(cfg)
+    cfg["physics_mode"] = True
+    physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
+    core = make_mujoco_bridge_core(
+        "ppp",
+        "ppp_warehouse",
+        physics_config=physics,
+    )
+    q0 = core.get_positions().copy()
+    q1 = core.step_physics(np.array([0.5, 0.0, 0.0]))
+    assert core.physics_mode is True
+    assert q1[0] > q0[0]
+
+
+@pytest.mark.skipif(
+    not make_mujoco_bridge_core("ppp", "ppp_warehouse").has_mujoco_runtime,
+    reason="mujoco package not installed",
+)
+def test_set_positions_forbidden_in_physics_mode() -> None:
+    """Pose injection must fail while physics_mode is active (FR-SIM-07)."""
+    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+
+    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = dict(cfg)
+    cfg["physics_mode"] = True
+    physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
+    core = make_mujoco_bridge_core(
+        "ppp",
+        "ppp_warehouse",
+        physics_config=physics,
+    )
+    with pytest.raises(RuntimeError, match="set_positions"):
+        core.set_positions(np.zeros(3))
+
+
+@pytest.mark.skipif(
+    not make_dubins_race_bridge_core().has_mujoco_runtime,
+    reason="mujoco package not installed",
+)
+def test_dubins_bridge_step_physics_runs() -> None:
+    """Dual-agent physics step should execute without pose injection."""
+    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+
+    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = dict(cfg)
+    cfg["physics_mode"] = True
+    physics = physics_config_from_bridge_yaml(cfg, "dubins", physics_mode=True)
+    core = make_dubins_race_bridge_core(
+        initial_rrt=np.array([6.0, 6.0, 0.0]),
+        initial_sst=np.array([6.0, 6.4, 0.0]),
+        physics_config=physics,
+    )
+    result = core.step_physics(np.array([0.4, 0.0, 0.0, 0.4, 0.0, 0.0]))
+    assert result.shape == (6,)
+    np.testing.assert_allclose(
+        core.get_joint_velocities(),
+        [0.4, 0.0, 0.0, 0.4, 0.0, 0.0],
+    )
+    with pytest.raises(RuntimeError, match="set_rrt_pose"):
+        core.set_rrt_pose((0.0, 0.0, 0.0))

--- a/tests/ros/test_mujoco_bridge.py
+++ b/tests/ros/test_mujoco_bridge.py
@@ -141,6 +141,7 @@ def test_load_mujoco_config_defaults() -> None:
     """Default mujoco.yml should load PPP parameters."""
     from fret.ros.mujoco_bridge import (
         _load_bridge_config,
+        _load_merged_bridge_config,
         _resolve_config_path,
     )
 
@@ -152,15 +153,19 @@ def test_load_mujoco_config_defaults() -> None:
     assert cfg["initial_joint_positions"] == [0.0, 0.0, 0.0]
     assert cfg["physics_mode"] is False
     assert cfg["substeps_per_tick"] == 25
-    assert "actuators" in cfg
+    merged = _load_merged_bridge_config(config_path)
+    assert "actuators" in merged
     assert pathlib.Path(config_path).is_file()
 
 
 def test_physics_config_from_yaml_kinematic_default() -> None:
     """Kinematic mode should not require actuator runtime binding."""
-    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
 
-    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
     physics = physics_config_from_bridge_yaml(cfg, "ppp")
     assert physics.physics_mode is False
     assert physics.actuators is None
@@ -168,9 +173,12 @@ def test_physics_config_from_yaml_kinematic_default() -> None:
 
 def test_physics_config_from_yaml_physics_mode() -> None:
     """Physics mode should load the PPP actuator table."""
-    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
 
-    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
     cfg = dict(cfg)
     cfg["physics_mode"] = True
     physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
@@ -189,9 +197,12 @@ def test_physics_config_from_yaml_physics_mode() -> None:
 )
 def test_bridge_core_step_physics_advances_position() -> None:
     """Physics mode should integrate joint motion via mj_step."""
-    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
 
-    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
     cfg = dict(cfg)
     cfg["physics_mode"] = True
     physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
@@ -212,9 +223,12 @@ def test_bridge_core_step_physics_advances_position() -> None:
 )
 def test_set_positions_forbidden_in_physics_mode() -> None:
     """Pose injection must fail while physics_mode is active (FR-SIM-07)."""
-    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
 
-    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
     cfg = dict(cfg)
     cfg["physics_mode"] = True
     physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
@@ -233,9 +247,12 @@ def test_set_positions_forbidden_in_physics_mode() -> None:
 )
 def test_dubins_bridge_step_physics_runs() -> None:
     """Dual-agent physics step should execute without pose injection."""
-    from fret.ros.mujoco_bridge import _load_bridge_config, _resolve_config_path
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
 
-    cfg = _load_bridge_config(_resolve_config_path(None))
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
     cfg = dict(cfg)
     cfg["physics_mode"] = True
     physics = physics_config_from_bridge_yaml(cfg, "dubins", physics_mode=True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **v1.2 PR1** (T12-01, T12-02, T12-03): upgrade the MuJoCo bridge from kinematic mirroring to actuator-driven `mj_step` integration, with `physics_mode` wiring for PPP and Dubins scenarios.

- **`step_physics()`** on `MuJoCoBridgeCore` and `DubinsRaceBridgeCore` — writes velocity commands to `data.ctrl`, runs 25 substeps per 50 Hz tick, reads state from `qpos`/`qvel`
- **`physics_mode` parameter** (FR-SIM-09) — launch arg `physics_mode:=true`, scenario YAML, or `simulation/mujoco.yml`; blocks open-loop pose injection while active (FR-SIM-07)
- **MJCF velocity actuators** for `ppp_warehouse.xml` (3 DOF) and `dubins_race.xml` (6 DOF)
- **Actuator gains** in `config/simulation/mujoco.yml` (runtime via `actuator_gainprm` / `actuator_forcerange`)
- **Dubins race physics path** — `DubinsRaceSimulation.step_physics()` + `dubins_race_node` physics branch

Kinematic mode (default) is unchanged.

## Test plan

- [x] `python3 -m pytest tests/ros/test_mujoco_bridge.py -v -p no:launch_testing -p no:launch_ros` — 19 passed
- [x] `./scripts/build.sh`
- [x] Smoke: `sitl_ppp_warehouse_physics` — PASSED (30s timeout)
- [x] Smoke: `sitl_dubins_race_physics` — PASSED (30s timeout)
- [x] Smoke: existing `sitl_ppp_warehouse_mujoco` kinematic — PASSED

## Traceability

- **Release:** v1.2 MuJoCo physics SITL (PR 1 of 3)
- **Tasks:** T12-01, T12-02, T12-03
- **Criteria:** V12-1 (physics SITL launches without error)
- **Requirements:** FR-SIM-07, FR-SIM-09

## Follow-up (PR2 / PR3)

- Cargo weld physics (T12-04)
- Contact logging + integration tests (T12-05, T12-06)
- Showcase `--physics-mode` flag + tuning docs (T12-07, T12-08)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4ea903-e513-4efe-86b3-b11a341f089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4ea903-e513-4efe-86b3-b11a341f089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

