### PR TITLE
feat(sim): PPP cargo weld physics (v1.2 PR2 / T12-04)

### DIFF
--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -102,13 +102,15 @@
             <geom name="cable_r" type="cylinder" fromto="0.12 0 0 0.12 0 3" size="0.012" material="cable" contype="0" conaffinity="0"/>
             <geom name="ee_gripper" type="box" size="0.28 0.22 0.08" material="gantry"/>
             <geom name="ee_spreader" type="box" pos="0 0 -0.06" size="0.30 0.26 0.04" material="rail"/>
-
-            <body name="cargo" pos="0 0 -0.34">
-              <geom name="cargo_box" type="box" size="0.25 0.25 0.25" material="cargo" mass="2.0"/>
-            </body>
           </body>
         </body>
       </body>
+    </body>
+
+    <!-- Cargo free body (MuJoCo requires freejoint at worldbody top level). -->
+    <body name="cargo" pos="2.0 1.0 0.25">
+      <freejoint name="cargo_free"/>
+      <geom name="cargo_box" type="box" size="0.25 0.25 0.25" material="cargo" mass="2.0"/>
     </body>
 
     <!-- Floor cargo shown before pick and after place (mocap, visual only). -->
@@ -128,4 +130,9 @@
     <velocity name="act_joint_y" joint="joint_y" kv="1" forcelimited="true" forcerange="-5000 5000"/>
     <velocity name="act_joint_z" joint="joint_z" kv="1" forcelimited="true" forcerange="-8000 8000"/>
   </actuator>
+
+  <equality>
+    <weld name="cargo_weld" body1="z_hoist" body2="cargo"
+          relpose="0 0 -0.34 1 0 0 0" active="false"/>
+  </equality>
 </mujoco>

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -25,9 +25,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
+from fret.control.kinematics_ppp import PPPKinematics
+
 if TYPE_CHECKING:
     from fret.control.grasp_magnet import MagneticGraspFSM
-    from fret.control.kinematics_ppp import PPPKinematics
 
 # MJCF preview scale (1:5) limits for ppp_warehouse.xml.
 _PPP_MJCF_LIMITS: npt.NDArray[np.float64] = np.array(

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 import os
 import pathlib
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
 
-from fret.control.kinematics_ppp import PPPKinematics
+if TYPE_CHECKING:
+    from fret.control.grasp_magnet import MagneticGraspFSM
+    from fret.control.kinematics_ppp import PPPKinematics
 
 # MJCF preview scale (1:5) limits for ppp_warehouse.xml.
 _PPP_MJCF_LIMITS: npt.NDArray[np.float64] = np.array(
@@ -1078,8 +1080,8 @@ class MuJoCoBridgeNode:
         self._latest_cmd = np.zeros(
             self._core.get_positions().shape, dtype=np.float64
         )
-        self._ppp_grasp = None
-        self._ppp_kin = None
+        self._ppp_grasp: MagneticGraspFSM | None = None
+        self._ppp_kin: PPPKinematics | None = None
         self._ppp_box_anchor: npt.NDArray[np.float64] | None = None
         self._ppp_goal: npt.NDArray[np.float64] | None = None
         self._ppp_grasp_captured = False

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -81,6 +81,34 @@ class PhysicsBridgeConfig:
     actuators: ActuatorTable | None
 
 
+@dataclass(frozen=True)
+class CargoWeldConfig:
+    """PPP cargo equality-weld settings (v1.2, T12-04)."""
+
+    equality_name: str
+    body_parent: str
+    body_child: str
+
+
+def cargo_weld_config_from_bridge_yaml(cfg: dict[str, Any]) -> CargoWeldConfig:
+    """Build :class:`CargoWeldConfig` from merged bridge YAML."""
+    section = cfg.get("cargo_weld")
+    if not isinstance(section, dict):
+        raise ValueError("cargo_weld section missing from mujoco_physics.yml")
+    equality_name = str(section.get("equality_name", "")).strip()
+    body_parent = str(section.get("body_parent", "")).strip()
+    body_child = str(section.get("body_child", "")).strip()
+    if not equality_name or not body_parent or not body_child:
+        raise ValueError(
+            "cargo_weld requires equality_name, body_parent, and body_child"
+        )
+    return CargoWeldConfig(
+        equality_name=equality_name,
+        body_parent=body_parent,
+        body_child=body_child,
+    )
+
+
 def _parse_bool(value: Any) -> bool:
     """Parse ROS / YAML boolean parameters."""
     if isinstance(value, bool):
@@ -359,6 +387,9 @@ class MuJoCoBridgeCore:
         self._data: Any | None = None
         self._qpos_adrs: list[int] = []
         self._qvel_adrs: list[int] = []
+        self._cargo_eq_id: int | None = None
+        self._cargo_qpos_adr: int | None = None
+        self._cargo_weld_active = False
         self._load_mujoco_optional()
         self._seed_mujoco_state()
 
@@ -385,6 +416,96 @@ class MuJoCoBridgeCore:
             config.actuators.names,
         )
         _apply_actuator_gains(self._model, config.actuators)
+
+    def configure_cargo_weld(self, config: CargoWeldConfig) -> None:
+        """Bind the PPP cargo equality weld for grasp physics (T12-04)."""
+        if self._model is None or self._mujoco is None or self._data is None:
+            raise RuntimeError(
+                "configure_cargo_weld requires the optional mujoco package"
+            )
+        eq_id = self._mujoco.mj_name2id(
+            self._model,
+            self._mujoco.mjtObj.mjOBJ_EQUALITY,
+            config.equality_name,
+        )
+        if eq_id < 0:
+            raise ValueError(
+                f"Equality constraint not found in MJCF: {config.equality_name}"
+            )
+        joint_id = self._mujoco.mj_name2id(
+            self._model,
+            self._mujoco.mjtObj.mjOBJ_JOINT,
+            "cargo_free",
+        )
+        if joint_id < 0:
+            raise ValueError("Cargo freejoint not found in MJCF: cargo_free")
+        self._cargo_eq_id = int(eq_id)
+        self._cargo_qpos_adr = int(self._model.jnt_qposadr[joint_id])
+        self._cargo_weld_active = bool(self._data.eq_active[eq_id])
+
+    def set_cargo_weld_active(self, active: bool) -> None:
+        """Enable or disable the cargo weld equality constraint."""
+        if (
+            self._cargo_eq_id is None
+            or self._model is None
+            or self._data is None
+        ):
+            return
+        if self._mujoco is None:
+            return
+        flag = bool(active)
+        if flag == self._cargo_weld_active:
+            return
+        self._data.eq_active[self._cargo_eq_id] = int(flag)
+        self._cargo_weld_active = flag
+        self._mujoco.mj_forward(self._model, self._data)
+
+    def seed_cargo_pose(self, position: npt.NDArray[np.float64]) -> None:
+        """Set initial cargo freejoint pose before simulation starts."""
+        if self._physics_mode:
+            raise RuntimeError(
+                "seed_cargo_pose() is forbidden while physics_mode is active"
+            )
+        self._write_cargo_pose(position)
+
+    def set_cargo_pose(self, position: npt.NDArray[np.float64]) -> None:
+        """Write cargo freejoint pose in kinematic mode (v1.0 mirror path)."""
+        if self._physics_mode:
+            raise RuntimeError(
+                "set_cargo_pose() is forbidden while physics_mode is active"
+            )
+        self._write_cargo_pose(position)
+
+    def sync_cargo_grasp(
+        self,
+        *,
+        is_welded: bool,
+        cargo_pose: npt.NDArray[np.float64],
+    ) -> None:
+        """Apply grasp FSM output to cargo weld or kinematic pose (T12-04)."""
+        if self._physics_mode:
+            self.set_cargo_weld_active(is_welded)
+            return
+        self.set_cargo_weld_active(False)
+        self.set_cargo_pose(cargo_pose)
+
+    def _write_cargo_pose(self, position: npt.NDArray[np.float64]) -> None:
+        if (
+            self._cargo_qpos_adr is None
+            or self._model is None
+            or self._data is None
+        ):
+            return
+        if self._mujoco is None:
+            return
+        pos = np.asarray(position, dtype=np.float64).reshape(3)
+        adr = self._cargo_qpos_adr
+        self._data.qpos[adr : adr + 3] = pos
+        self._data.qpos[adr + 3 : adr + 7] = np.array(
+            [1.0, 0.0, 0.0, 0.0],
+            dtype=np.float64,
+        )
+        self._mujoco.mj_forward(self._model, self._data)
 
     @property
     def joint_names(self) -> list[str]:
@@ -953,11 +1074,19 @@ class MuJoCoBridgeNode:
             scenario_name,
             mjcf_path=mjcf_path,
             initial_positions=q0,
-            physics_config=physics_config,
         )
         self._latest_cmd = np.zeros(
             self._core.get_positions().shape, dtype=np.float64
         )
+        self._ppp_grasp = None
+        self._ppp_kin = None
+        self._ppp_box_anchor: npt.NDArray[np.float64] | None = None
+        self._ppp_goal: npt.NDArray[np.float64] | None = None
+        self._ppp_grasp_captured = False
+        if model_name == "ppp":
+            self._init_ppp_grasp(scenario_name, q0, cfg)
+        if physics_config.physics_mode:
+            self._core.configure_physics(physics_config)
 
         cmd_qos = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -987,6 +1116,77 @@ class MuJoCoBridgeNode:
             f"mujoco_runtime={self._core.has_mujoco_runtime}"
         )
 
+    def _init_ppp_grasp(
+        self,
+        scenario_name: str,
+        q0: npt.NDArray[np.float64],
+        cfg: dict[str, Any],
+    ) -> None:
+        """Load PPP grasp FSM and seed cargo pose for SITL (T12-04)."""
+        from fret.config_loader import load_scenario_bundle
+        from fret.control.grasp_magnet import (
+            MagneticGraspFSM,
+            parse_grasp_config,
+        )
+        from fret.control.kinematics_ppp import PPPKinematics
+        from fret.sitl_config import scenario_config_path
+
+        bundle = load_scenario_bundle(scenario_config_path(scenario_name))
+        if bundle.grasp is None:
+            return
+
+        grasp_cfg = parse_grasp_config(bundle.grasp)
+        params = bundle.parameters
+        start = np.asarray(
+            params.get("start_configuration", q0),
+            dtype=np.float64,
+        )
+        goal = np.asarray(params["goal_configuration"], dtype=np.float64)
+        self._ppp_kin = PPPKinematics()
+        self._ppp_grasp = MagneticGraspFSM(grasp_cfg)
+        self._ppp_box_anchor = np.array(
+            [
+                start[0],
+                start[1],
+                float(grasp_cfg.box_half_extent[2]),
+            ],
+            dtype=np.float64,
+        )
+        self._ppp_goal = goal
+        if self._core.has_mujoco_runtime and "cargo_weld" in cfg:
+            self._core.configure_cargo_weld(
+                cargo_weld_config_from_bridge_yaml(cfg)
+            )
+            self._core.seed_cargo_pose(self._ppp_box_anchor)
+        self._ppp_grasp.begin_transport()
+
+    def _sync_ppp_cargo_grasp(self, q: npt.NDArray[np.float64]) -> None:
+        """Advance grasp FSM and mirror cargo weld / pose in MuJoCo."""
+        if (
+            self._ppp_grasp is None
+            or self._ppp_kin is None
+            or self._ppp_box_anchor is None
+            or self._ppp_goal is None
+        ):
+            return
+
+        from fret.control.grasp_magnet import GraspState
+
+        ee = self._ppp_kin.forward_kinematics(q)[:3, 3]
+        state = self._ppp_grasp.update(
+            ee, self._ppp_box_anchor, self._ppp_goal
+        )
+        if state == GraspState.TRANSPORT:
+            self._ppp_grasp_captured = True
+        if self._ppp_grasp.is_welded or self._ppp_grasp_captured:
+            cargo_pose = self._ppp_grasp.cargo_position
+        else:
+            cargo_pose = self._ppp_box_anchor
+        self._core.sync_cargo_grasp(
+            is_welded=self._ppp_grasp.is_welded,
+            cargo_pose=cargo_pose,
+        )
+
     def _command_callback(self, msg: Any) -> None:
         data = list(getattr(msg, "data", []))
         dof = len(self._latest_cmd)
@@ -1001,6 +1201,8 @@ class MuJoCoBridgeNode:
         from sensor_msgs.msg import JointState
 
         dt = 1.0 / self._update_rate
+        q_before = self._core.get_positions()
+        self._sync_ppp_cargo_grasp(q_before)
         positions = self._core.step(self._latest_cmd, dt)
         velocities = self._core.get_velocities()
 
@@ -1033,10 +1235,12 @@ def main(args: list[str] | None = None) -> None:  # pragma: no cover
 
 __all__ = [
     "ActuatorTable",
+    "CargoWeldConfig",
     "DubinsRaceBridgeCore",
     "MuJoCoBridgeCore",
     "MuJoCoBridgeNode",
     "PhysicsBridgeConfig",
+    "cargo_weld_config_from_bridge_yaml",
     "integrate_joint_velocities",
     "make_dubins_race_bridge_core",
     "make_mujoco_bridge_core",

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -45,7 +45,12 @@ from fret.planning.ppp_obstacles import (
     load_preview_workspace_bounds,
 )
 from fret.planning.trajectory_generator import TrajectoryGenerator
-from fret.ros.mujoco_bridge import make_mujoco_bridge_core
+from fret.ros.mujoco_bridge import (
+    cargo_weld_config_from_bridge_yaml,
+    make_mujoco_bridge_core,
+    _load_merged_bridge_config,
+    _resolve_config_path,
+)
 from fret.scene.occupancy_adapter import OccupancyAdapter
 from fret.sitl_config import controller_config_path, scenario_config_path
 
@@ -216,6 +221,32 @@ def _path_is_collision_free(
         workspace_bounds=workspace_bounds,
     )
     return all(checker.is_collision_free(q) for q in path)
+
+
+def _configure_ppp_cargo_bridge(
+    bridge: Any,
+    box_anchor: npt.NDArray[np.float64],
+) -> None:
+    """Bind cargo weld and seed the pick-zone pose when MuJoCo is available."""
+    if not bridge.has_mujoco_runtime:
+        return
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
+    if "cargo_weld" not in cfg:
+        return
+    bridge.configure_cargo_weld(cargo_weld_config_from_bridge_yaml(cfg))
+    bridge.seed_cargo_pose(box_anchor)
+
+
+def _ppp_cargo_pose(
+    grasp: MagneticGraspFSM,
+    *,
+    box_anchor: npt.NDArray[np.float64],
+    grasp_captured: bool,
+) -> npt.NDArray[np.float64]:
+    """World-frame cargo centre for kinematic mirroring."""
+    if grasp.is_welded or grasp_captured:
+        return grasp.cargo_position
+    return box_anchor
 
 
 def _track_carrot_path(
@@ -425,6 +456,7 @@ class PPPWarehouseRunner:
             ],
             dtype=np.float64,
         )
+        _configure_ppp_cargo_bridge(bridge, box_anchor)
         grasp.begin_transport()
 
         max_err_m = 0.0
@@ -440,6 +472,14 @@ class PPPWarehouseRunner:
                 grasp_captured = True
             if grasp_captured and not grasp.is_welded:
                 grasp_released = True
+            bridge.sync_cargo_grasp(
+                is_welded=grasp.is_welded,
+                cargo_pose=_ppp_cargo_pose(
+                    grasp,
+                    box_anchor=box_anchor,
+                    grasp_captured=grasp_captured,
+                ),
+            )
 
         rate_hz = ctrl.update_rate
         dt = 1.0 / rate_hz

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -46,10 +46,10 @@ from fret.planning.ppp_obstacles import (
 )
 from fret.planning.trajectory_generator import TrajectoryGenerator
 from fret.ros.mujoco_bridge import (
-    cargo_weld_config_from_bridge_yaml,
-    make_mujoco_bridge_core,
     _load_merged_bridge_config,
     _resolve_config_path,
+    cargo_weld_config_from_bridge_yaml,
+    make_mujoco_bridge_core,
 )
 from fret.scene.occupancy_adapter import OccupancyAdapter
 from fret.sitl_config import controller_config_path, scenario_config_path

--- a/tests/ros/test_mujoco_bridge.py
+++ b/tests/ros/test_mujoco_bridge.py
@@ -13,6 +13,7 @@ import pytest
 from fret.ros.mujoco_bridge import (
     DubinsRaceBridgeCore,
     MuJoCoBridgeCore,
+    cargo_weld_config_from_bridge_yaml,
     integrate_joint_velocities,
     make_dubins_race_bridge_core,
     make_mujoco_bridge_core,
@@ -269,3 +270,55 @@ def test_dubins_bridge_step_physics_runs() -> None:
     )
     with pytest.raises(RuntimeError, match="set_rrt_pose"):
         core.set_rrt_pose((0.0, 0.0, 0.0))
+
+
+def test_cargo_weld_config_from_yaml() -> None:
+    """Merged mujoco config should expose PPP cargo weld settings."""
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
+
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
+    weld = cargo_weld_config_from_bridge_yaml(cfg)
+    assert weld.equality_name == "cargo_weld"
+    assert weld.body_parent == "z_hoist"
+    assert weld.body_child == "cargo"
+
+
+@pytest.mark.skipif(
+    not make_mujoco_bridge_core("ppp", "ppp_warehouse").has_mujoco_runtime,
+    reason="mujoco package not installed",
+)
+def test_cargo_weld_toggle_kinematic_pose() -> None:
+    """Kinematic mode should mirror cargo pose; physics mode toggles weld."""
+    from fret.ros.mujoco_bridge import (
+        _load_merged_bridge_config,
+        _resolve_config_path,
+    )
+
+    cfg = _load_merged_bridge_config(_resolve_config_path(None))
+    weld_cfg = cargo_weld_config_from_bridge_yaml(cfg)
+    core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    core.configure_cargo_weld(weld_cfg)
+
+    box_anchor = np.array([2.0, 1.0, 0.25], dtype=np.float64)
+    core.seed_cargo_pose(box_anchor)
+
+    transport_pose = np.array([2.0, 1.0, 2.06], dtype=np.float64)
+    core.sync_cargo_grasp(is_welded=True, cargo_pose=transport_pose)
+    assert core._cargo_weld_active is False
+
+    cfg = dict(cfg)
+    cfg["physics_mode"] = True
+    physics = physics_config_from_bridge_yaml(cfg, "ppp", physics_mode=True)
+    physics_core = make_mujoco_bridge_core("ppp", "ppp_warehouse")
+    physics_core.configure_cargo_weld(weld_cfg)
+    physics_core.seed_cargo_pose(box_anchor)
+    physics_core.configure_physics(physics)
+    physics_core.sync_cargo_grasp(is_welded=True, cargo_pose=transport_pose)
+    assert physics_core._cargo_weld_active is True
+    physics_core.sync_cargo_grasp(is_welded=False, cargo_pose=transport_pose)
+    assert physics_core._cargo_weld_active is False
+    with pytest.raises(RuntimeError, match="set_cargo_pose"):
+        physics_core.set_cargo_pose(transport_pose)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements v1.2 **cargo weld physics** (T12-04) for the PPP warehouse scenario — the second of three MuJoCo physics SITL PRs.

- **MJCF:** Cargo is now a top-level `freejoint` body with a toggled `<equality weld>` to `z_hoist` (MuJoCo requires free joints at worldbody level).
- **Bridge:** `MuJoCoBridgeCore` adds `CargoWeldConfig`, `configure_cargo_weld()`, `seed_cargo_pose()`, `set_cargo_pose()`, and `sync_cargo_grasp()` — kinematic mode mirrors cargo pose from the FSM; physics mode toggles `eq_active` without pose teleportation (FR-SIM-07).
- **Wiring:** `PPPWarehouseRunner` and `MuJoCoBridgeNode` (PPP model) run `MagneticGraspFSM` each tick and sync cargo weld/pose. Node seeds cargo before enabling `physics_mode`.
- **Tests:** New unit test for cargo weld config and kinematic vs physics sync; existing PPP warehouse integration tests (V10-4 grasp) pass.

## Spec traceability

| Task | Requirement |
| --- | --- |
| T12-04 | Cargo weld engage/release tied to `MagneticGraspFSM` |
| FR-SIM-07 | No pose injection while `physics_mode` is active |
| V10-4 | Cargo welded at pick zone, released at goal |

## Test plan

- [x] `python3 -m pytest tests/ros/test_mujoco_bridge.py -p no:launch_testing -p no:launch_ros`
- [x] `python3 -m pytest tests/integration/test_scenario_ppp_warehouse.py -p no:launch_testing -p no:launch_ros`
- [x] Full unit suite: 444 passed

## Follow-up (PR3)

Contact logging, physics integration tests, showcase `--physics-mode`, tuning docs (T12-05–08).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4ea903-e513-4efe-86b3-b11a341f089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4ea903-e513-4efe-86b3-b11a341f089a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

