### PR TITLE
fix(sim): unblock Dubins physics SITL release renders

### DIFF
--- a/src/fret/mjcf/dubins_race.xml
+++ b/src/fret/mjcf/dubins_race.xml
@@ -153,10 +153,10 @@
 
     <!-- Agent 1: RRT* (blue TurtleBot3) -->
     <body name="car_rrt" pos="0 0 0.05">
-      <joint name="rrt_joint_x" type="slide" axis="1 0 0" range="0 80" damping="2"/>
-      <joint name="rrt_joint_y" type="slide" axis="0 1 0" range="0 80" damping="2"/>
-      <joint name="rrt_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="1"/>
-      <geom name="rrt_collision" type="box" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
+      <joint name="rrt_joint_x" type="slide" axis="1 0 0" range="0 80" damping="80"/>
+      <joint name="rrt_joint_y" type="slide" axis="0 1 0" range="0 80" damping="80"/>
+      <joint name="rrt_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="20"/>
+      <geom name="rrt_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
       <geom name="rrt_base" type="mesh" mesh="tb3_base" pos="-0.13 0 0.04" euler="0 0 1.5708" material="car_rrt" contype="0" conaffinity="0"/>
       <geom name="rrt_lds" type="mesh" mesh="tb3_lds" pos="-0.13 0 0.73" euler="0 0 1.5708" material="marker_light" contype="0" conaffinity="0"/>
       <geom name="rrt_wheel_l" type="mesh" mesh="tb3_tire" pos="0 0.32 0.13" quat="0.707388 -0.706825 0 0" material="wheel" contype="0" conaffinity="0"/>
@@ -166,10 +166,10 @@
 
     <!-- Agent 2: SST (green TurtleBot3) -->
     <body name="car_sst" pos="0 0 0.05">
-      <joint name="sst_joint_x" type="slide" axis="1 0 0" range="0 80" damping="2"/>
-      <joint name="sst_joint_y" type="slide" axis="0 1 0" range="0 80" damping="2"/>
-      <joint name="sst_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="1"/>
-      <geom name="sst_collision" type="box" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
+      <joint name="sst_joint_x" type="slide" axis="1 0 0" range="0 80" damping="80"/>
+      <joint name="sst_joint_y" type="slide" axis="0 1 0" range="0 80" damping="80"/>
+      <joint name="sst_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="20"/>
+      <geom name="sst_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
       <geom name="sst_base" type="mesh" mesh="tb3_base" pos="-0.13 0 0.04" euler="0 0 1.5708" material="car_sst" contype="0" conaffinity="0"/>
       <geom name="sst_lds" type="mesh" mesh="tb3_lds" pos="-0.13 0 0.73" euler="0 0 1.5708" material="marker_dark" contype="0" conaffinity="0"/>
       <geom name="sst_wheel_l" type="mesh" mesh="tb3_tire" pos="0 0.32 0.13" quat="0.707388 -0.706825 0 0" material="wheel" contype="0" conaffinity="0"/>

--- a/tests/ros/test_mujoco_bridge.py
+++ b/tests/ros/test_mujoco_bridge.py
@@ -268,6 +268,8 @@ def test_dubins_bridge_step_physics_runs() -> None:
         core.get_joint_velocities(),
         [0.4, 0.0, 0.0, 0.4, 0.0, 0.0],
     )
+    assert core.get_rrt_pose()[0] > 6.0
+    assert core.get_sst_pose()[0] > 6.0
     with pytest.raises(RuntimeError, match="set_rrt_pose"):
         core.set_rrt_pose((0.0, 0.0, 0.0))
 

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -348,11 +348,13 @@ def test_make_dubins_overview_camera_targets_midpoint() -> None:
 
 def test_simulate_dubins_race_poses_covers_transit() -> None:
     """Release dubins clip must traverse the warehouse floor."""
+    pytest.importorskip("mujoco")
     pytest.importorskip("arco")
     rrt, sst, sim_time_s = rm.simulate_dubins_race_poses(
         "dubins_race",
         duration_s=None,
         fps=10,
+        physics_mode=True,
     )
     assert rrt.shape[0] >= 2
     assert sst.shape[0] >= 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the failing **Release / showcase-video** job ([run #82](https://github.com/alexandrelheinen/fret/actions/runs/29052843005/job/86237471465)).

The Dubins race render step crashed with:

```
RuntimeError: Dubins race clip lacks horizontal transit (RRT* span=[0.04, 0.008], SST span=[0.04, 0.003])
```

After switching release renders to `physics_mode=True`, race cars barely moved because their collision boxes penetrated the floor plane (~4 cm), generating persistent contact constraints that pinned the slide joints during `mj_step`.

## Changes

- **MJCF (`dubins_race.xml`)**: offset `rrt_collision` / `sst_collision` geoms by `pos="0 0 0.04"` so the footprint rests on `z=0`; increase slide damping to `80` and yaw damping to `20` (aligned with PPP physics tuning) to stabilize velocity tracking.
- **Tests**: assert Dubins `step_physics` advances position; run `test_simulate_dubins_race_poses_covers_transit` with `physics_mode=True` to match the release workflow.

## Verification

```bash
python3 -m pytest \
  tests/simulation/test_render_mujoco.py::test_simulate_dubins_race_poses_covers_transit \
  tests/ros/test_mujoco_bridge.py::test_dubins_bridge_step_physics_runs \
  -p no:launch_testing -p no:launch_ros
```

Both tests pass locally; Dubins pose span is now ~75 m (was ~0.04 m).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea776003-6de9-4601-854d-ecb6078cb54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea776003-6de9-4601-854d-ecb6078cb54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

