### PR TITLE
ci: fix parallel unit shard coverage upload and dubins wall clock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           name: coverage-${{ matrix.shard }}
           path: .coverage.${{ matrix.shard }}
+          include-hidden-files: true
           if-no-files-found: error
 
   unit-coverage:

--- a/tests/scenario/test_dubins_race_e2e.py
+++ b/tests/scenario/test_dubins_race_e2e.py
@@ -25,7 +25,9 @@ _SCENARIO_PATH = (
     / "scenarios"
     / "dubins_race.yml"
 )
-_RACE_TIMEOUT_S = 120.0
+_RACE_SIM_TIMEOUT_S = 120.0
+# Wall clock includes dual planning (SST can take ~80s in CI) plus race simulation.
+_WALL_CLOCK_BUDGET_S = 240.0
 
 
 def test_obstacle_file_exists() -> None:
@@ -49,9 +51,9 @@ def test_dual_agents_plan_and_finish_race() -> None:
     assert result.both_reached_goal is True
     assert result.rrt_time_to_goal_s is not None
     assert result.sst_time_to_goal_s is not None
-    assert result.rrt_time_to_goal_s <= _RACE_TIMEOUT_S
-    assert result.sst_time_to_goal_s <= _RACE_TIMEOUT_S
-    assert elapsed <= _RACE_TIMEOUT_S + 30.0
+    assert result.rrt_time_to_goal_s <= _RACE_SIM_TIMEOUT_S
+    assert result.sst_time_to_goal_s <= _RACE_SIM_TIMEOUT_S
+    assert elapsed <= _WALL_CLOCK_BUDGET_S
     assert result.min_obstacle_clearance_m >= 0.0
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the unit shard failures from the parallel CI workflow (#85).

## Root causes

1. **control / planning / scene / simulation** — tests **passed**, but the job failed on **Upload shard coverage** because `.coverage.*` files are dotfiles and `upload-artifact@v4` excludes hidden files by default.

2. **simulation** — `test_dual_agents_plan_and_finish_race` exceeded the wall-clock budget (180s > 150s) after raising SST `max_sample_count` to 8000. Sim-time goals were still within 120s.

## Changes

- `tests.yml`: `include-hidden-files: true` on shard coverage upload
- `test_dubins_race_e2e.py`: separate sim timeout (120s) from wall-clock budget (240s)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea776003-6de9-4601-854d-ecb6078cb54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea776003-6de9-4601-854d-ecb6078cb54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

