### PR TITLE
fix(sim): restore kinematic release showcases after v1.1.1 physics regression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
             --collision-backend mujoco \
             --planner-algorithm rrt_star \
             --full-duration \
+            --kinematic-mode \
             --output-dir showcase_renders \
             --timing-json showcase_renders/ppp_timing.json \
             --fps 30 \
@@ -81,6 +82,7 @@ jobs:
             --collision-backend mujoco \
             --planner-algorithm sst \
             --full-duration \
+            --kinematic-mode \
             --output-dir showcase_renders \
             --timing-json showcase_renders/dubins_timing.json \
             --fps 30 \

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -1236,7 +1236,7 @@ def render_dubins_race_showcase_videos(
     width: int = 1280,
     height: int = 720,
     realtime_postprocess: bool = True,
-    physics_mode: bool = True,
+    physics_mode: bool = False,
 ) -> list[RenderResult]:
     """Render dual-agent Dubins race MP4s (V11-2 / V11-4)."""
     mujoco, _iio = _require_mujoco()
@@ -1547,7 +1547,7 @@ def render_video(
     planner_algorithm: str = "rrt_star",
     use_tracking: bool = True,
     realtime_postprocess: bool = True,
-    physics_mode: bool = True,
+    physics_mode: bool = False,
 ) -> RenderResult:
     """Render a headless MuJoCo MP4 for the PPP warehouse preview.
 
@@ -1600,7 +1600,7 @@ def render_showcase_videos(
     planner_algorithm: str = "rrt_star",
     use_tracking: bool = True,
     realtime_postprocess: bool = True,
-    physics_mode: bool = True,
+    physics_mode: bool = False,
 ) -> list[RenderResult]:
     """Render one MP4 per showcase camera in a single simulation pass.
 
@@ -1973,7 +1973,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--physics-mode",
         action="store_true",
-        help="Drive MuJoCo via mj_step actuators (default; v1.2 physics SITL)",
+        help="Drive MuJoCo via mj_step actuators (v1.2 physics SITL; opt-in)",
     )
     parser.add_argument(
         "--kinematic-mode",
@@ -2047,7 +2047,7 @@ def main(argv: list[str] | None = None) -> int:
 
     use_tracking = not args.no_tracking
     realtime_postprocess = not args.no_realtime_postprocess
-    physics_mode = not args.kinematic_mode or bool(args.physics_mode)
+    physics_mode = bool(args.physics_mode) and not args.kinematic_mode
 
     if args.all_cameras:
         cameras = list_showcase_cameras(mjcf_path, scenario=args.scenario)

--- a/src/fret/mjcf/ppp_warehouse.xml
+++ b/src/fret/mjcf/ppp_warehouse.xml
@@ -66,42 +66,42 @@
       <geom name="foot_bl" type="box" pos="12 0 0.05" size="0.24 0.24 0.05" material="frame" contype="0" conaffinity="0"/>
       <geom name="foot_br" type="box" pos="12 5 0.05" size="0.24 0.24 0.05" material="frame" contype="0" conaffinity="0"/>
 
-      <geom name="leg_fl" type="box" pos="0 0 1.5" size="0.12 0.12 1.48" material="frame"/>
-      <geom name="leg_fr" type="box" pos="0 5 1.5" size="0.12 0.12 1.48" material="frame"/>
-      <geom name="leg_bl" type="box" pos="12 0 1.5" size="0.12 0.12 1.48" material="frame"/>
-      <geom name="leg_br" type="box" pos="12 5 1.5" size="0.12 0.12 1.48" material="frame"/>
+      <geom name="leg_fl" type="box" pos="0 0 1.5" size="0.12 0.12 1.48" material="frame" contype="0" conaffinity="0"/>
+      <geom name="leg_fr" type="box" pos="0 5 1.5" size="0.12 0.12 1.48" material="frame" contype="0" conaffinity="0"/>
+      <geom name="leg_bl" type="box" pos="12 0 1.5" size="0.12 0.12 1.48" material="frame" contype="0" conaffinity="0"/>
+      <geom name="leg_br" type="box" pos="12 5 1.5" size="0.12 0.12 1.48" material="frame" contype="0" conaffinity="0"/>
 
-      <geom name="tie_front" type="box" pos="6 0 2.98" size="6.2 0.08 0.06" material="frame"/>
-      <geom name="tie_back" type="box" pos="6 5 2.98" size="6.2 0.08 0.06" material="frame"/>
+      <geom name="tie_front" type="box" pos="6 0 2.98" size="6.2 0.08 0.06" material="frame" contype="0" conaffinity="0"/>
+      <geom name="tie_back" type="box" pos="6 5 2.98" size="6.2 0.08 0.06" material="frame" contype="0" conaffinity="0"/>
 
-      <geom name="runway_rail_near" type="box" pos="6 0.28 3.04" size="6.2 0.10 0.07" material="rail_top"/>
-      <geom name="runway_rail_far" type="box" pos="6 4.72 3.04" size="6.2 0.10 0.07" material="rail_top"/>
+      <geom name="runway_rail_near" type="box" pos="6 0.28 3.04" size="6.2 0.10 0.07" material="rail_top" contype="0" conaffinity="0"/>
+      <geom name="runway_rail_far" type="box" pos="6 4.72 3.04" size="6.2 0.10 0.07" material="rail_top" contype="0" conaffinity="0"/>
       <geom name="chain_y_near" type="box" pos="6 0.12 3.12" size="6.0 0.05 0.04" material="chain" contype="0" conaffinity="0"/>
       <geom name="chain_y_far" type="box" pos="6 4.88 3.12" size="6.0 0.05 0.04" material="chain" contype="0" conaffinity="0"/>
 
       <body name="x_carriage" pos="0 0 3">
-        <joint name="joint_x" type="slide" axis="1 0 0" range="0 12" damping="80"/>
-        <geom name="x_car_near" type="box" pos="0 0.28 -0.03" size="0.20 0.14 0.11" material="carriage"/>
-        <geom name="x_car_far" type="box" pos="0 4.72 -0.03" size="0.20 0.14 0.11" material="carriage"/>
-        <geom name="x_bridge" type="box" pos="0 2.5 -0.05" size="0.16 2.46 0.08" material="gantry"/>
-        <geom name="x_bridge_rail_l" type="box" pos="0 0.28 -0.02" size="0.08 0.12 0.04" material="rail"/>
-        <geom name="x_bridge_rail_r" type="box" pos="0 4.72 -0.02" size="0.08 0.12 0.04" material="rail"/>
+        <joint name="joint_x" type="slide" axis="1 0 0" range="0 12" damping="12"/>
+        <geom name="x_car_near" type="box" pos="0 0.28 -0.03" size="0.20 0.14 0.11" material="carriage" contype="0" conaffinity="0"/>
+        <geom name="x_car_far" type="box" pos="0 4.72 -0.03" size="0.20 0.14 0.11" material="carriage" contype="0" conaffinity="0"/>
+        <geom name="x_bridge" type="box" pos="0 2.5 -0.05" size="0.16 2.46 0.08" material="gantry" contype="0" conaffinity="0"/>
+        <geom name="x_bridge_rail_l" type="box" pos="0 0.28 -0.02" size="0.08 0.12 0.04" material="rail" contype="0" conaffinity="0"/>
+        <geom name="x_bridge_rail_r" type="box" pos="0 4.72 -0.02" size="0.08 0.12 0.04" material="rail" contype="0" conaffinity="0"/>
 
         <body name="y_carriage" pos="0 0 0">
-          <joint name="joint_y" type="slide" axis="0 1 0" range="0 5" damping="80"/>
-          <geom name="y_trolley" type="box" pos="0 0 -0.08" size="0.30 0.22 0.12" material="carriage"/>
-          <geom name="y_trolley_head" type="box" pos="0 0 0.02" size="0.20 0.18 0.06" material="rail"/>
+          <joint name="joint_y" type="slide" axis="0 1 0" range="0 5" damping="12"/>
+          <geom name="y_trolley" type="box" pos="0 0 -0.08" size="0.30 0.22 0.12" material="carriage" contype="0" conaffinity="0"/>
+          <geom name="y_trolley_head" type="box" pos="0 0 0.02" size="0.20 0.18 0.06" material="rail" contype="0" conaffinity="0"/>
 
           <body name="z_hoist" pos="0 0 -3">
-            <joint name="joint_z" type="slide" axis="0 0 1" range="0 3" damping="120"/>
-            <geom name="z_column" type="box" size="0.11 0.11 1.45" pos="0 0 1.45" material="z_axis"/>
+            <joint name="joint_z" type="slide" axis="0 0 1" range="0 3" damping="18"/>
+            <geom name="z_column" type="box" size="0.11 0.11 1.45" pos="0 0 1.45" material="z_axis" contype="0" conaffinity="0"/>
             <geom name="z_guide_l" type="box" size="0.03 0.14 1.45" pos="-0.10 0 1.45" material="rail" contype="0" conaffinity="0"/>
             <geom name="z_guide_r" type="box" size="0.03 0.14 1.45" pos="0.10 0 1.45" material="rail" contype="0" conaffinity="0"/>
             <geom name="chain_z" type="box" pos="0 0 2.85" size="0.05 0.18 0.04" material="chain" contype="0" conaffinity="0"/>
             <geom name="cable_l" type="cylinder" fromto="-0.12 0 0 -0.12 0 3" size="0.012" material="cable" contype="0" conaffinity="0"/>
             <geom name="cable_r" type="cylinder" fromto="0.12 0 0 0.12 0 3" size="0.012" material="cable" contype="0" conaffinity="0"/>
-            <geom name="ee_gripper" type="box" size="0.28 0.22 0.08" material="gantry"/>
-            <geom name="ee_spreader" type="box" pos="0 0 -0.06" size="0.30 0.26 0.04" material="rail"/>
+            <geom name="ee_gripper" type="box" size="0.28 0.22 0.08" material="gantry" contype="0" conaffinity="0"/>
+            <geom name="ee_spreader" type="box" pos="0 0 -0.06" size="0.30 0.26 0.04" material="rail" contype="0" conaffinity="0"/>
           </body>
         </body>
       </body>

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -58,6 +58,8 @@ from fret.sitl_config import controller_config_path, scenario_config_path
 
 _DEFAULT_SCENARIO = scenario_config_path("ppp_warehouse")
 _DEFAULT_CONTROLLER = controller_config_path("ppp")
+# Kinematic carrot gate (3 mm) is too tight once mj_step lag is in the loop.
+_PHYSICS_MAX_CARROT_LAG_M: float = 0.12
 
 
 @dataclass(frozen=True)
@@ -346,7 +348,7 @@ def _track_carrot_path(
             max_joint_velocity=max_joint_velocity,
             max_joint_acc=max_joint_acc,
             race_speed=race_speed,
-            max_carrot_lag=max_carrot_lag,
+            max_carrot_lag=max(max_carrot_lag, _PHYSICS_MAX_CARROT_LAG_M),
             dt=dt,
             goal_tolerance=goal_tolerance,
             on_step=on_step,

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -389,6 +389,7 @@ _RELEASE_PPP_CLI: list[str] = [
     "--timing-json",
     "showcase_renders/ppp_timing.json",
     "--full-duration",
+    "--kinematic-mode",
     "--fps",
     "30",
     "--width",
@@ -418,6 +419,7 @@ _RELEASE_DUBINS_CLI: list[str] = [
     "--timing-json",
     "showcase_renders/dubins_timing.json",
     "--full-duration",
+    "--kinematic-mode",
     "--fps",
     "30",
     "--width",
@@ -437,8 +439,8 @@ def test_release_workflow_cli_args_parse() -> None:
     assert ppp_args.scenario == "ppp_warehouse"
     assert ppp_args.all_cameras is True
     assert ppp_args.no_tracking is False
-    assert ppp_args.kinematic_mode is False
-    assert not ppp_args.kinematic_mode  # release uses default physics path
+    assert ppp_args.kinematic_mode is True
+    assert ppp_args.physics_mode is False
 
     kinematic_args = parser.parse_args(_RELEASE_PPP_KINEMATIC_CLI)
     assert kinematic_args.kinematic_mode is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

v1.1.1 release showcase MP4s regressed because release CI started defaulting to **v1.2 physics SITL** (`mj_step` actuators) before the PPP gantry and cargo models were physics-ready. This restores **v1.1.0 kinematic mirror** behavior for release renders while landing MJCF fixes that unblock future physics tuning.

## Root cause (PPP gantry)

| Mode | Behavior |
|------|----------|
| v1.1.0 kinematic | Python integrates joint velocities → writes `qpos` → `mj_forward` (visual mirror) |
| v1.1.1 physics (default) | Velocity actuators + `mj_step`; contacts and constraints apply |

Physics PPP run (before this PR):
- Robot descends for pick (~10 s sim) then **stalls at start XY** for the remaining ~13+ minutes of sim time
- `grasp_captured=True`, `grasp_released=False`, tracking fault (>10 mm)
- `qpos` span in X/Y ≈ 0 m

Investigation showed actuator force on `joint_x` was **fully cancelled by constraint forces** (`qfrc_constraint ≈ -qfrc_actuator`) from overlapping gantry collision geoms (`tie_front`↔`x_bridge`, `runway_rail`↔carriage, etc.). The procedural gantry mesh was authored for kinematic mirroring, not dynamics.

Secondary blocker after pick: magnetic weld engages while cargo still contacts the floor, preventing lift/transit.

## Dubins race

Physics Dubins **does** complete (both agents reach goal) but sim time is ~5× slower (~180 s vs ~37 s kinematic). With `--full-duration`, release export generates ~5300 frames per camera → **20–45+ min** wall time in CI (45 min job timeout). No video after 25 min is consistent with a still-running physics sim + render pass.

## Changes

1. **Release workflow** — add `--kinematic-mode` to PPP and Dubins `video.sh` invocations
2. **`render_mujoco.py`** — physics is opt-in (`--physics-mode`); kinematic mirror is default again
3. **`ppp_warehouse.xml`** — disable gantry self-collision; reduce joint damping (prep for v1.2)
4. **`ppp_warehouse_runner.py`** — physics carrot lag gate relaxed to 0.12 m (kinematic gate 3 mm is too tight once `mj_step` lag exists)

## Validation

- `pytest tests/simulation/test_render_mujoco.py::test_release_workflow_cli_args_parse`
- `pytest tests/ros/test_mujoco_bridge.py`

## Follow-up (v1.2)

- Cargo weld vs floor contact during pick/place
- Tune `mujoco_physics.yml` actuator `kv` / force limits under load
- Physics-specific controller carrot policy (Dubins already has `_PHYSICS_MAX_POSITION_LAG_M`)
- Optional: cap Dubins physics showcase duration or keep kinematic until physics RTF improves

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74d56e4-a5da-41e8-ae09-159d6c98e0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74d56e4-a5da-41e8-ae09-159d6c98e0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

