### PR TITLE
Release: publish PPP and Dubins R2 uploads independently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release
 
 # Renders PPP + Dubins MuJoCo showcase MP4s (overview + follow POV each) on
 # version tags, verifies pixels are non-blank, uploads to Cloudflare R2.
+# Each scenario publishes independently — one render failure does not block
+# the other from reaching R2.
 
 on:
   push:
@@ -98,8 +100,65 @@ jobs:
           path: showcase_renders/
           if-no-files-found: error
 
-  publish:
+  publish-ppp:
+    needs: render-ppp
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download PPP showcase renders
+        uses: actions/download-artifact@v4
+        with:
+          name: showcase-ppp
+          path: showcase_renders
+
+      - name: Upload PPP clips to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          ./scripts/release/upload_scenario_r2.sh ppp_warehouse ppp_warehouse.mp4
+
+  publish-dubins:
+    needs: render-dubins
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+      R2_BUCKET: ${{ secrets.R2_BUCKET }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Dubins showcase renders
+        uses: actions/download-artifact@v4
+        with:
+          name: showcase-dubins
+          path: showcase_renders
+
+      - name: Upload Dubins clips to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
+        run: |
+          ./scripts/release/upload_scenario_r2.sh dubins_race dubins_race.mp4
+
+  publish-meta:
     needs: [render-ppp, render-dubins]
+    if: >-
+      always() &&
+      (needs.render-ppp.result == 'success' || needs.render-dubins.result == 'success')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
@@ -110,15 +169,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download showcase renders
+      - name: Download PPP showcase renders
+        if: needs.render-ppp.result == 'success'
         uses: actions/download-artifact@v4
         with:
-          pattern: showcase-*
-          merge-multiple: true
-          path: .
+          name: showcase-ppp
+          path: showcase_renders
+
+      - name: Download Dubins showcase renders
+        if: needs.render-dubins.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: showcase-dubins
+          path: showcase_renders
 
       - name: List rendered showcase files
-        run: ls -la showcase_renders/
+        run: ls -la showcase_renders/ || true
 
       - name: Write release metadata
         env:
@@ -141,33 +207,16 @@ jobs:
             showcase_renders/
             meta.json
           retention-days: 90
+          if-no-files-found: warn
 
-      - name: Upload to Cloudflare R2
+      - name: Upload metadata to Cloudflare R2
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.ref_name }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            TAG="${{ github.event.inputs.release_tag }}"
-          else
-            TAG="${{ github.ref_name }}"
-          fi
-
           python3 -m pip install --break-system-packages awscli
-
-          for mp4 in showcase_renders/*.mp4; do
-            base="$(basename "${mp4}")"
-            aws s3 cp "${mp4}" \
-              "s3://${R2_BUCKET}/releases/${TAG}/${base}" \
-              --endpoint-url "${R2_ENDPOINT}" \
-              --content-type video/mp4
-            aws s3 cp "${mp4}" \
-              "s3://${R2_BUCKET}/latest/${base}" \
-              --endpoint-url "${R2_ENDPOINT}" \
-              --content-type video/mp4
-          done
-
           aws s3 cp meta.json \
             "s3://${R2_BUCKET}/releases/${TAG}/meta.json" \
             --endpoint-url "${R2_ENDPOINT}" \
@@ -176,13 +225,3 @@ jobs:
             "s3://${R2_BUCKET}/latest/meta.json" \
             --endpoint-url "${R2_ENDPOINT}" \
             --content-type application/json
-
-          # Backward-compatible primary pointers for README / download script.
-          aws s3 cp showcase_renders/ppp_warehouse_overview.mp4 \
-            "s3://${R2_BUCKET}/latest/ppp_warehouse.mp4" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --content-type video/mp4
-          aws s3 cp showcase_renders/dubins_race_overview.mp4 \
-            "s3://${R2_BUCKET}/latest/dubins_race.mp4" \
-            --endpoint-url "${R2_ENDPOINT}" \
-            --content-type video/mp4

--- a/scripts/release/upload_scenario_r2.sh
+++ b/scripts/release/upload_scenario_r2.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Upload one scenario's showcase MP4s to Cloudflare R2.
+#
+# Usage:
+#   upload_scenario_r2.sh <scenario_prefix> <latest_alias_basename>
+#
+# Example:
+#   upload_scenario_r2.sh ppp_warehouse ppp_warehouse.mp4
+#   upload_scenario_r2.sh dubins_race dubins_race.mp4
+#
+# Requires: awscli, R2_ENDPOINT, R2_BUCKET, AWS_ACCESS_KEY_ID,
+# AWS_SECRET_ACCESS_KEY, TAG
+set -Eeuo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <scenario_prefix> <latest_alias_basename>" >&2
+  exit 2
+fi
+
+scenario_prefix="$1"
+latest_alias="$2"
+renders_dir="${RENDERS_DIR:-showcase_renders}"
+
+if [[ -z "${TAG:-}" ]]; then
+  echo "TAG env var is required" >&2
+  exit 2
+fi
+if [[ -z "${R2_ENDPOINT:-}" || -z "${R2_BUCKET:-}" ]]; then
+  echo "R2_ENDPOINT and R2_BUCKET env vars are required" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+matches=("${renders_dir}/${scenario_prefix}"*.mp4)
+if [[ ${#matches[@]} -eq 0 ]]; then
+  echo "No MP4 files matching ${renders_dir}/${scenario_prefix}*.mp4" >&2
+  exit 1
+fi
+
+python3 -m pip install --break-system-packages awscli >/dev/null
+
+for mp4 in "${matches[@]}"; do
+  base="$(basename "${mp4}")"
+  echo "Uploading ${base} → releases/${TAG}/ and latest/"
+  aws s3 cp "${mp4}" \
+    "s3://${R2_BUCKET}/releases/${TAG}/${base}" \
+    --endpoint-url "${R2_ENDPOINT}" \
+    --content-type video/mp4
+  aws s3 cp "${mp4}" \
+    "s3://${R2_BUCKET}/latest/${base}" \
+    --endpoint-url "${R2_ENDPOINT}" \
+    --content-type video/mp4
+done
+
+primary="${renders_dir}/${scenario_prefix}_overview.mp4"
+if [[ -f "${primary}" ]]; then
+  echo "Updating latest/${latest_alias} from ${primary##*/}"
+  aws s3 cp "${primary}" \
+    "s3://${R2_BUCKET}/latest/${latest_alias}" \
+    --endpoint-url "${R2_ENDPOINT}" \
+    --content-type video/mp4
+fi

--- a/scripts/release/write_showcase_meta.py
+++ b/scripts/release/write_showcase_meta.py
@@ -43,7 +43,7 @@ def write_showcase_meta(
         prefix = f"{scenario}_"
         scenario_files = [path for path in renders if path.name.startswith(prefix)]
         if not scenario_files:
-            raise SystemExit(f"Missing showcase clips for {scenario}")
+            continue
 
         timing_path = renders_dir / str(cfg["timing_file"])
         if not timing_path.is_file():
@@ -82,12 +82,16 @@ def write_showcase_meta(
             }
         )
 
+    if not showcases:
+        raise SystemExit("No showcase clips found for any scenario")
+
     meta: dict[str, object] = {
         "repo": repo,
         "git_sha": git_sha,
         "git_ref": tag,
         "release_cameras": ["overview", "follow"],
         "realtime_playback": True,
+        "partial": len(showcases) < len(_EXPECTED),
         "fps": 30,
         "width": 1280,
         "height": 720,

--- a/tests/release/test_write_showcase_meta.py
+++ b/tests/release/test_write_showcase_meta.py
@@ -65,3 +65,35 @@ def test_write_showcase_meta_merges_parallel_render_outputs(tmp_path: Path) -> N
     assert len(meta["showcases"]) == 2
     assert meta["primary_videos"]["ppp_warehouse"] == "ppp_warehouse_overview.mp4"
     assert (tmp_path / "meta.json").is_file()
+
+
+def test_write_showcase_meta_accepts_single_scenario(tmp_path: Path) -> None:
+    """Partial release uploads should still produce valid metadata."""
+    renders = tmp_path / "showcase_renders"
+    renders.mkdir()
+    for name in ("dubins_race_overview.mp4", "dubins_race_follow.mp4"):
+        (renders / name).write_bytes(b"\x00" * 64)
+
+    _write_timing(
+        renders / "dubins_timing.json",
+        [
+            {
+                "file": "dubins_race_overview.mp4",
+                "sim_time_s": 32.0,
+                "real_time_factor": 1.0,
+            }
+        ],
+    )
+
+    meta = write_showcase_meta(
+        renders_dir=renders,
+        tag="v9.9.9",
+        repo="owner/fret",
+        git_sha="abc123",
+        workflow_run="https://example.com/run/2",
+        output_path=tmp_path / "meta.json",
+    )
+
+    assert meta["partial"] is True
+    assert len(meta["showcases"]) == 1
+    assert meta["showcases"][0]["scenario"] == "dubins_race"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Release workflow used a single `publish` job with `needs: [render-ppp, render-dubins]`. If PPP timed out (as on the `v1.1.3` tag), Dubins clips were rendered but **never uploaded to R2**.

## Solution

Split publishing into three jobs:

| Job | Runs when | Uploads |
|-----|-----------|---------|
| `publish-ppp` | `render-ppp` succeeds | `ppp_warehouse_*.mp4` + `latest/ppp_warehouse.mp4` |
| `publish-dubins` | `render-dubins` succeeds | `dubins_race_*.mp4` + `latest/dubins_race.mp4` |
| `publish-meta` | ≥1 render succeeds | `meta.json` (with `"partial": true` if only one scenario) |

`write_showcase_meta.py` now skips missing scenarios instead of failing.

New helper: `scripts/release/upload_scenario_r2.sh`.

## Verification

- `tests/release/test_write_showcase_meta.py` (including new single-scenario case)
- Formatting check passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74d56e4-a5da-41e8-ae09-159d6c98e0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74d56e4-a5da-41e8-ae09-159d6c98e0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

