### PR TITLE
feat(sim): v1.1.5 physics render cap, joint_states test, grasp release fix

### DIFF
--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -235,6 +235,23 @@ def resolve_scenario_duration(
     return duration if duration > 0.0 else default_s
 
 
+def resolve_physics_showcase_duration_s(
+    scenario: str,
+    sim_time_s: float,
+    duration_s: float | None,
+) -> float:
+    """Cap physics showcase clip length to scenario nominal duration (V115-03).
+
+    Physics SITL can run far longer than the kinematic showcase clip.  Release
+    and dry-run renders subsample to ``min(sim_time_s, scenario.duration)`` so
+    ``--physics-mode --full-duration`` stays within release job timeouts.
+    """
+    if duration_s is not None:
+        return float(duration_s)
+    nominal_s = resolve_scenario_duration(scenario)
+    return min(float(sim_time_s), nominal_s)
+
+
 def resolve_scenario_simulation_dt(
     scenario: str,
     *,
@@ -1021,11 +1038,11 @@ def simulate_ppp_warehouse_qpos(
         if result.sim_duration_s > 0.0
         else float(max(0, history.shape[0] - 1)) * (1.0 / 50.0)
     )
-    nominal_s = resolve_scenario_duration("ppp_warehouse")
-    if duration_s is None:
-        render_duration_s = min(sim_time_s, nominal_s)
-    else:
-        render_duration_s = float(duration_s)
+    render_duration_s = resolve_physics_showcase_duration_s(
+        "ppp_warehouse",
+        sim_time_s,
+        duration_s,
+    )
     n_frames = max(2, int(round(render_duration_s * fps)))
     return _resample_qpos_history(history, n_frames), sim_time_s
 
@@ -1067,8 +1084,10 @@ def simulate_dubins_race_poses(
     else:
         sim_time_s = float(max(0, len(rrt_hist) - 1)) * sim_dt
 
-    render_duration_s = (
-        sim_time_s if duration_s is None else float(duration_s)
+    render_duration_s = resolve_physics_showcase_duration_s(
+        scenario,
+        sim_time_s,
+        duration_s,
     )
     n_frames = max(2, int(round(render_duration_s * fps)))
     return (

--- a/scripts/tests/physics_showcase_dry_run.sh
+++ b/scripts/tests/physics_showcase_dry_run.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# V115-03: physics showcase dry-run within release job timeouts.
+#
+# Runs headless physics-mode showcase renders (PPP 30 min, Dubins 45 min caps)
+# using scenario-duration clip subsampling so CI/release dry-runs finish in time.
+#
+# Usage:
+#   bash scripts/tests/physics_showcase_dry_run.sh
+#
+# Requires: pip install -e ".[sim]", ffmpeg, EGL (MUJOCO_GL=egl).
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+source "${SCRIPT_DIR}/../common.sh"
+
+export MUJOCO_GL="${MUJOCO_GL:-egl}"
+export PYOPENGL_PLATFORM="${PYOPENGL_PLATFORM:-egl}"
+
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/fret_physics_showcase_dry_run}"
+mkdir -p "${OUTPUT_DIR}"
+
+PPP_TIMEOUT_S="${PPP_TIMEOUT_S:-1800}"
+DUBINS_TIMEOUT_S="${DUBINS_TIMEOUT_S:-2700}"
+
+FAILED=0
+
+info "V115-03 physics showcase dry-run (output: ${OUTPUT_DIR})"
+
+info "PPP physics render (timeout ${PPP_TIMEOUT_S}s)"
+if timeout "${PPP_TIMEOUT_S}s" ./scripts/video.sh \
+    --model ppp \
+    --scenario ppp_warehouse \
+    --all-cameras \
+    --collision-backend mujoco \
+    --planner-algorithm rrt_star \
+    --full-duration \
+    --physics-mode \
+    --output-dir "${OUTPUT_DIR}/ppp" \
+    --timing-json "${OUTPUT_DIR}/ppp/timing.json" \
+    --fps 30 \
+    --width 640 \
+    --height 360; then
+    ok "ppp_physics_showcase: PASSED"
+else
+    code=$?
+    fail "ppp_physics_showcase: FAILED (exit ${code})"
+    FAILED=1
+fi
+
+info "Dubins physics render (timeout ${DUBINS_TIMEOUT_S}s)"
+if timeout "${DUBINS_TIMEOUT_S}s" ./scripts/video.sh \
+    --model dubins \
+    --scenario dubins_race \
+    --all-cameras \
+    --collision-backend mujoco \
+    --planner-algorithm sst \
+    --full-duration \
+    --physics-mode \
+    --output-dir "${OUTPUT_DIR}/dubins" \
+    --timing-json "${OUTPUT_DIR}/dubins/timing.json" \
+    --fps 30 \
+    --width 640 \
+    --height 360; then
+    ok "dubins_physics_showcase: PASSED"
+else
+    code=$?
+    fail "dubins_physics_showcase: FAILED (exit ${code})"
+    FAILED=1
+fi
+
+if [[ "${FAILED}" -eq 0 ]]; then
+    ok "Physics showcase dry-run PASSED"
+    exit 0
+fi
+
+fail "Physics showcase dry-run FAILED"
+exit 1

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -66,8 +66,8 @@ _DEFAULT_CONTROLLER = controller_config_path("ppp")
 _PICK_WELD_Z_TOLERANCE_M: float = 0.08
 # Release cargo only at place depth — not during cruise transit over goal XY.
 _PLACE_RELEASE_Z_TOLERANCE_M: float = 0.08
-# v1.1.4 intermediate gate [m] — 250 mm toward V12-2 (10 mm needs place-hold fix).
-_PHYSICS_EE_ERROR_LIMIT_M: float = 0.25
+# v1.1.5: tracking gate [m]; grasp release XY uses goal_radius (see below).
+_PHYSICS_TRACKING_ERROR_LIMIT_M: float = 0.25
 
 
 @dataclass(frozen=True)
@@ -291,11 +291,11 @@ def _ppp_physics_grasp_update(
 def _ppp_physics_grasp_released(
     ee: npt.NDArray[np.float64],
     goal: npt.NDArray[np.float64],
+    *,
+    goal_radius: float,
 ) -> bool:
     """Return True when cargo release is valid at place depth under physics."""
-    xy_close = (
-        float(np.linalg.norm(ee[:2] - goal[:2])) < _PHYSICS_EE_ERROR_LIMIT_M
-    )
+    xy_close = float(np.linalg.norm(ee[:2] - goal[:2])) < goal_radius
     z_at_place = (
         abs(float(ee[2]) - float(goal[2])) <= _PLACE_RELEASE_Z_TOLERANCE_M
     )
@@ -686,7 +686,9 @@ class PPPWarehouseRunner:
                 grasp_captured = True
             if grasp_captured and not grasp.is_welded:
                 if physics_mode:
-                    if _ppp_physics_grasp_released(ee, goal):
+                    if _ppp_physics_grasp_released(
+                        ee, goal, goal_radius=grasp_cfg.goal_radius
+                    ):
                         grasp_released = True
                 else:
                     grasp_released = True
@@ -764,7 +766,7 @@ class PPPWarehouseRunner:
         _grasp_tick(bridge.get_positions())
         if physics_mode:
             max_err_m = float(np.linalg.norm(bridge.get_positions() - goal))
-            controller_faulted = max_err_m > _PHYSICS_EE_ERROR_LIMIT_M
+            controller_faulted = max_err_m > _PHYSICS_TRACKING_ERROR_LIMIT_M
         else:
             max_err_m = track_err_m
             if not controller_faulted and max_err_m > ee_error_limit_m:

--- a/tests/integration/test_mujoco_physics_joint_states.py
+++ b/tests/integration/test_mujoco_physics_joint_states.py
@@ -1,0 +1,98 @@
+"""V12-4 / FR-SIM-07: /joint_states provenance under physics_mode."""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import time
+
+import numpy as np
+import pytest
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+from fret.ros.mujoco_bridge import MuJoCoBridgeNode, make_mujoco_bridge_core
+
+_SIM_CONFIG_DIR = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "src"
+    / "fret"
+    / "config"
+    / "simulation"
+)
+
+
+def _mujoco_available() -> bool:
+    return make_mujoco_bridge_core("ppp", "ppp_warehouse").has_mujoco_runtime
+
+
+def _physics_bridge_config(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Copy bridge YAML pair with ``physics_mode: true`` for SITL tests."""
+    for name in ("mujoco.yml", "mujoco_physics.yml"):
+        shutil.copy(_SIM_CONFIG_DIR / name, tmp_path / name)
+    cfg_path = tmp_path / "mujoco.yml"
+    text = cfg_path.read_text(encoding="utf-8").replace(
+        "physics_mode: false",
+        "physics_mode: true",
+    )
+    cfg_path.write_text(text, encoding="utf-8")
+    return cfg_path
+
+
+@pytest.mark.skipif(
+    not _mujoco_available(), reason="mujoco package not installed"
+)
+def test_physics_joint_states_match_simulated_qpos(
+    ros_context: None,
+    test_node: Node,
+    tmp_path: pathlib.Path,
+) -> None:
+    """V12-4: bridge publishes mj_step qpos/qvel — no open-loop pose injection."""
+    del ros_context
+
+    cfg_path = _physics_bridge_config(tmp_path)
+    bridge = MuJoCoBridgeNode(config_path=str(cfg_path))
+    assert bridge._core.physics_mode is True
+
+    received: list[JointState] = []
+
+    def _on_joint_state(msg: JointState) -> None:
+        received.append(msg)
+
+    test_node.create_subscription(
+        JointState,
+        "/joint_states",
+        _on_joint_state,
+        10,
+    )
+    cmd_pub = test_node.create_publisher(Float64MultiArray, "/joint_commands", 10)
+
+    core = bridge._core
+    q0 = core.get_positions().copy()
+    deadline = time.monotonic() + 4.0
+    while time.monotonic() < deadline and len(received) < 5:
+        cmd = Float64MultiArray()
+        cmd.data = [0.5, 0.0, 0.0]
+        cmd_pub.publish(cmd)
+        rclpy.spin_once(bridge._node, timeout_sec=0.05)
+        rclpy.spin_once(test_node, timeout_sec=0.05)
+
+    bridge._node.destroy_node()
+
+    assert len(received) >= 2, "expected /joint_states from physics bridge"
+    stamps = [
+        float(msg.header.stamp.sec) + msg.header.stamp.nanosec * 1e-9
+        for msg in received
+    ]
+    assert stamps[-1] >= stamps[0], "joint_states stamps must be monotonic"
+
+    final_positions = np.asarray(received[-1].position, dtype=np.float64)
+    assert (
+        final_positions[0] > q0[0]
+    ), "physics step must advance joint X from actuator commands"
+    assert received[-1].velocity, "physics bridge must publish joint velocities"
+
+    with pytest.raises(RuntimeError, match="set_positions"):
+        core.set_positions(np.zeros(3))

--- a/tests/integration/test_mujoco_physics_ppp.py
+++ b/tests/integration/test_mujoco_physics_ppp.py
@@ -47,7 +47,7 @@ def test_ppp_physics_run_completes_with_contact_log() -> None:
     not _mujoco_available(), reason="mujoco package not installed"
 )
 def test_ppp_physics_tracking_within_v114_limit() -> None:
-    """V114-02: physics E2E tracking ≤ 250 mm (intermediate toward V12-2 10 mm)."""
+    """V114-02: physics E2E tracking ≤ 250 mm (V12-2 10 mm remains v1.2.0)."""
     runner = PPPWarehouseRunner(scenario_path=_SCENARIO_PATH)
     result = runner.run(physics_mode=True)
     assert result.planning_status == PlanningStatus.SUCCESS
@@ -55,3 +55,21 @@ def test_ppp_physics_tracking_within_v114_limit() -> None:
     assert result.grasp_released is True
     assert result.controller_faulted is False
     assert result.max_tracking_error_m <= 0.25
+
+
+@pytest.mark.skipif(
+    not _mujoco_available(), reason="mujoco package not installed"
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason="V12-2 10 mm blocked by place-hold Z stability until v1.2.0",
+)
+def test_ppp_physics_tracking_within_v12_limit() -> None:
+    """V12-2 aspirational gate: physics E2E tracking ≤ 10 mm."""
+    runner = PPPWarehouseRunner(scenario_path=_SCENARIO_PATH)
+    result = runner.run(physics_mode=True)
+    assert result.planning_status == PlanningStatus.SUCCESS
+    assert result.grasp_captured is True
+    assert result.grasp_released is True
+    assert result.controller_faulted is False
+    assert result.max_tracking_error_m <= 0.010

--- a/tests/scenario/test_ppp_physics_grasp_release.py
+++ b/tests/scenario/test_ppp_physics_grasp_release.py
@@ -1,0 +1,27 @@
+"""Unit tests for PPP physics grasp release gating (v1.1.5)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fret.scenario.ppp_warehouse_runner import _ppp_physics_grasp_released
+
+
+def test_grasp_release_xy_uses_goal_radius_not_tracking_limit() -> None:
+    """Release XY gate must use scenario goal_radius, not V12-2 tracking limit."""
+    goal = np.array([10.5, 2.8, 2.65])
+    ee_within_radius = np.array([10.35, 2.75, 2.65])
+    ee_outside_radius = np.array([10.0, 2.4, 2.65])
+
+    assert _ppp_physics_grasp_released(
+        ee_within_radius, goal, goal_radius=0.5
+    )
+    assert not _ppp_physics_grasp_released(
+        ee_outside_radius, goal, goal_radius=0.5
+    )
+    # 200 mm XY offset is inside 0.5 m goal_radius but would fail a 10 mm gate.
+    ee_200mm_xy = np.array([10.7, 2.8, 2.65])
+    assert _ppp_physics_grasp_released(ee_200mm_xy, goal, goal_radius=0.5)
+    assert not _ppp_physics_grasp_released(
+        ee_200mm_xy, goal, goal_radius=0.10
+    )

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -429,6 +429,35 @@ _RELEASE_DUBINS_CLI: list[str] = [
 ]
 
 
+def test_resolve_scenario_duration_ppp_warehouse() -> None:
+    duration = rm.resolve_scenario_duration("ppp_warehouse")
+    assert duration == pytest.approx(60.0)
+
+
+def test_resolve_physics_showcase_duration_caps_to_nominal() -> None:
+    """V115-03: physics clips subsample long sim runs to scenario duration."""
+    capped = rm.resolve_physics_showcase_duration_s(
+        "ppp_warehouse",
+        sim_time_s=573.0,
+        duration_s=None,
+    )
+    assert capped == pytest.approx(60.0)
+
+    explicit = rm.resolve_physics_showcase_duration_s(
+        "dubins_race",
+        sim_time_s=180.0,
+        duration_s=20.0,
+    )
+    assert explicit == pytest.approx(20.0)
+
+    dubins_capped = rm.resolve_physics_showcase_duration_s(
+        "dubins_race",
+        sim_time_s=180.0,
+        duration_s=None,
+    )
+    assert dubins_capped == pytest.approx(35.0)
+
+
 def test_release_workflow_cli_args_parse() -> None:
     """Release workflow flags must parse without missing Namespace attributes."""
     parser = rm.build_parser()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Advances FRET toward **v1.1.5** (regression harness & release prep) per `docs/version_plan_v1.2.md`:

1. **PPP release render timeout (V115-03)** — physics showcase clips now subsample to `min(sim_time, scenario.duration)` for both PPP and Dubins, preventing `--physics-mode --full-duration` from rendering thousands of frames beyond the kinematic clip length.
2. **Physics showcase dry-run (V115-03)** — new `scripts/tests/physics_showcase_dry_run.sh` wraps PPP/Dubins physics renders with release-job timeouts (30/45 min).
3. **PPP 10 mm tracking blocker** — fixes grasp-release XY gating to use `goal_radius` (0.5 m) instead of the V12-2 tracking limit; keeps V114 250 mm integration gate green; adds strict `xfail` for V12-2 10 mm (current best ~207 mm — place-hold settle deferred to v1.2.0).
4. **V12-4 joint_states (FR-SIM-07)** — integration test verifies `MuJoCoBridgeNode` publishes simulated `qpos`/`qvel` under `physics_mode` and forbids pose injection.

## Test plan

- [x] `pytest tests/integration/test_mujoco_physics_ppp.py` — V114 pass, V12-2 xfail
- [x] `pytest tests/integration/test_mujoco_physics_joint_states.py`
- [x] `pytest tests/scenario/test_ppp_physics_grasp_release.py`
- [x] `pytest tests/simulation/test_render_mujoco.py -k resolve_physics_showcase`
- [x] `bash scripts/check/formatting.sh`
- [ ] `bash scripts/tests/physics_showcase_dry_run.sh` (manual / workflow_dispatch; long-running)

## Traceability

| Item | Requirement / task |
|------|-------------------|
| Physics render cap | V115-03, FR-SIM-08 |
| Dry-run script | V115-03 |
| Grasp release fix | V113/V114, FR-GSP-* |
| V12-2 xfail | V12-2 (v1.2.0) |
| Joint states test | V12-4, FR-SIM-07 |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b7e3f48-9276-4601-bbd9-620c2a20792c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b7e3f48-9276-4601-bbd9-620c2a20792c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

