### PR TITLE
fix(sim): restore smooth 30fps physics showcase videos

### DIFF
--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -96,6 +96,7 @@ class ShowcaseTiming:
 
     sim_time_s: float
     render_duration_s: float
+    wall_sim_time_s: float | None = None
 
     @property
     def real_time_factor(self) -> float:
@@ -103,6 +104,36 @@ class ShowcaseTiming:
         if self.sim_time_s <= 0.0:
             return 1.0
         return self.render_duration_s / self.sim_time_s
+
+
+def showcase_playback_timing(
+    *,
+    wall_sim_time_s: float,
+    render_duration_s: float,
+) -> ShowcaseTiming:
+    """Build RTF timing for a physics or kinematic showcase clip.
+
+    Physics SITL (V115-03) resamples the full ``qpos`` log into
+    ``render_duration_s`` at fixed fps when wall-clock sim exceeds the scenario
+    nominal duration.      That encode is already a time-compressed playback; using ``wall_sim_time_s``
+    for ffmpeg ``setpts`` would stretch frames to ``n_frames / wall_sim_time_s``
+    effective fps (slideshow on PPP/Dubins).
+    """
+    playback_sim_s = (
+        render_duration_s
+        if wall_sim_time_s > render_duration_s + 0.02
+        else wall_sim_time_s
+    )
+    wall = (
+        wall_sim_time_s
+        if wall_sim_time_s > playback_sim_s + 0.02
+        else None
+    )
+    return ShowcaseTiming(
+        sim_time_s=playback_sim_s,
+        render_duration_s=render_duration_s,
+        wall_sim_time_s=wall,
+    )
 
 
 @dataclass(frozen=True)
@@ -1275,8 +1306,8 @@ def render_dubins_race_showcase_videos(
     )
     _assert_dubins_race_moves(rrt_poses, sst_poses)
     render_duration_s = float(len(rrt_poses)) / float(fps)
-    timing = ShowcaseTiming(
-        sim_time_s=sim_time_s,
+    timing = showcase_playback_timing(
+        wall_sim_time_s=sim_time_s,
         render_duration_s=render_duration_s,
     )
 
@@ -1671,8 +1702,8 @@ def render_showcase_videos(
             fps=fps,
         )
         render_duration_s = float(len(qpos_trajectory)) / float(fps)
-        timing = ShowcaseTiming(
-            sim_time_s=sim_time_s,
+        timing = showcase_playback_timing(
+            wall_sim_time_s=sim_time_s,
             render_duration_s=render_duration_s,
         )
 
@@ -1748,8 +1779,8 @@ def render_showcase_videos(
         start=path_waypoints[0],
     )
     render_duration_s = float(len(trajectory)) / float(fps)
-    timing = ShowcaseTiming(
-        sim_time_s=sim_time_s,
+    timing = showcase_playback_timing(
+        wall_sim_time_s=sim_time_s,
         render_duration_s=render_duration_s,
     )
 
@@ -1867,18 +1898,20 @@ def write_showcase_timing_json(
     """Persist per-clip timing metadata for release workflows."""
     import json
 
-    payload = {
-        "clips": [
-            {
-                "camera": result.camera,
-                "file": result.path.name,
-                "sim_time_s": result.timing.sim_time_s,
-                "render_duration_s": result.timing.render_duration_s,
-                "real_time_factor": result.timing.real_time_factor,
-            }
-            for result in results
-        ]
-    }
+    clips: list[dict[str, float | str]] = []
+    for result in results:
+        timing = result.timing
+        clip: dict[str, float | str] = {
+            "camera": result.camera,
+            "file": result.path.name,
+            "sim_time_s": timing.sim_time_s,
+            "render_duration_s": timing.render_duration_s,
+            "real_time_factor": timing.real_time_factor,
+        }
+        if timing.wall_sim_time_s is not None:
+            clip["wall_sim_time_s"] = timing.wall_sim_time_s
+        clips.append(clip)
+    payload = {"clips": clips}
     output_path.write_text(
         json.dumps(payload, indent=2) + "\n",
         encoding="utf-8",

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -368,6 +368,38 @@ def test_showcase_timing_real_time_factor() -> None:
     assert timing.real_time_factor == pytest.approx(2.5)
 
 
+def test_showcase_playback_timing_skips_rtf_when_physics_subsampled() -> None:
+    """V115-03 capped physics clips must not stretch to wall-clock sim time."""
+    timing = rm.showcase_playback_timing(
+        wall_sim_time_s=1739.6,
+        render_duration_s=60.0,
+    )
+    assert timing.sim_time_s == pytest.approx(60.0)
+    assert timing.render_duration_s == pytest.approx(60.0)
+    assert timing.real_time_factor == pytest.approx(1.0)
+    assert timing.wall_sim_time_s == pytest.approx(1739.6)
+
+
+def test_showcase_playback_timing_keeps_rtf_when_sim_within_cap() -> None:
+    timing = rm.showcase_playback_timing(
+        wall_sim_time_s=32.0,
+        render_duration_s=32.0,
+    )
+    assert timing.sim_time_s == pytest.approx(32.0)
+    assert timing.real_time_factor == pytest.approx(1.0)
+    assert timing.wall_sim_time_s is None
+
+
+def test_showcase_playback_timing_dubins_physics_cap() -> None:
+    timing = rm.showcase_playback_timing(
+        wall_sim_time_s=103.4,
+        render_duration_s=35.0,
+    )
+    assert timing.sim_time_s == pytest.approx(35.0)
+    assert timing.real_time_factor == pytest.approx(1.0)
+    assert timing.wall_sim_time_s == pytest.approx(103.4)
+
+
 def test_resolve_scenario_duration_reads_yaml() -> None:
     assert rm.resolve_scenario_duration("ppp_warehouse") == pytest.approx(60.0)
     assert rm.resolve_scenario_duration("dubins_race") == pytest.approx(35.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

v1.2.0 release showcase MP4s look hyper-lagged / frame-by-frame compared to smooth 30fps v1.1.0 clips.

## Root cause

Two pipeline changes landed together in v1.2.0:

1. **Release CI switched from kinematic to physics SITL** (`--physics-mode` instead of `--no-tracking` / kinematic pose mirroring).
2. **V115-03 duration cap** subsamples the full physics `qpos` log into `min(sim_time, scenario.duration)` seconds at fixed 30fps so renders finish within CI timeouts.

The existing **ffmpeg RTF post-process** (`setpts=PTS/rtf`) still used **wall-clock `sim_time_s`**. When physics runs much slower than the capped clip (PPP ~1740s sim → 60s encode; Dubins ~103s → 35s), ffmpeg stretched ~1800 frames across the full sim duration — effective **~1 fps for PPP** and **~10 fps for Dubins**.

v1.1.0 kinematic renders had `sim_time ≈ render_duration` (RTF ≈ 1) with smooth cubic joint interpolation at 30fps.

## Fix

- Add `showcase_playback_timing()` so capped physics subsamples use `render_duration_s` for RTF (skip destructive ffmpeg stretch).
- Record `wall_sim_time_s` in timing JSON when it differs from playback sim time.

## Follow-up (not in this PR)

PPP physics SITL still runs ~29× slower than the 60s scenario nominal; the fixed clip is a smooth 30fps **time-lapse**. Tuning `ppp_physics.yml` (`race_speed`, settle loop) to bring wall sim near scenario duration would enable true real-time physics showcases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-723965a6-80c9-4876-85bc-d800f3025b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-723965a6-80c9-4876-85bc-d800f3025b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

