### PR TITLE
fix(dubins): restore physics CI after PR #100 dummy agent overlap

### DIFF
--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -1120,15 +1120,21 @@ def simulate_dubins_race_poses(
         record_poses=True,
         physics_mode=physics_mode,
     )
-    if not result.both_reached_goal and not physics_mode:
+    if not result.both_reached_goal:
         raise RuntimeError(
-            "Dubins race simulation failed before both agents reached goal"
+            "Dubins race simulation failed before both agents reached goal "
+            f"(race_duration_s={result.race_duration_s:.1f}, "
+            f"max_cross_track_error_m={result.max_cross_track_error_m:.2f})"
         )
 
     rrt_hist = np.asarray(result.rrt_pose_history, dtype=np.float64)
     sst_hist = np.asarray(result.sst_pose_history, dtype=np.float64)
     dummy_hist = np.asarray(result.dummy_pose_history, dtype=np.float64)
     sim_dt = resolve_scenario_simulation_dt(scenario)
+    race_samples = max(1, int(round(float(result.race_duration_s) / sim_dt)) + 1)
+    rrt_hist = rrt_hist[:race_samples]
+    sst_hist = sst_hist[:race_samples]
+    dummy_hist = dummy_hist[:race_samples]
     if (
         result.rrt_time_to_goal_s is not None
         and result.sst_time_to_goal_s is not None

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -51,6 +51,8 @@ _PPP_PICK_ASCEND_S: float = 3.5
 _PPP_PLACE_DESCEND_S: float = 4.0
 _PPP_PLACE_ASCEND_S: float = 3.0
 _PPP_SHOWCASE_TRANSIT_SPEED_M_S: float = 0.45
+# Mid-field rack (obs_d) can push RRT* past the 30 s scenario timeout on CI runners.
+_PPP_PHYSICS_SHOWCASE_PLANNING_TIMEOUT_S: float = 90.0
 # Legacy fallback when --collision-backend is not set.
 _PPP_WAREHOUSE_WAYPOINTS: list[npt.NDArray[np.float64]] = [
     np.array([2.0, 1.0, 2.4]),
@@ -1057,12 +1059,22 @@ def simulate_ppp_warehouse_qpos(
     _ensure_fret_importable()
     from fret.scenario.ppp_warehouse_runner import PPPWarehouseRunner
 
+    params = PPPWarehouseRunner().load_parameters()
+    scenario_timeout = float(params["planning_timeout"])
     result = PPPWarehouseRunner().run(
         physics_mode=True,
         record_positions=True,
+        planning_timeout=max(
+            scenario_timeout,
+            _PPP_PHYSICS_SHOWCASE_PLANNING_TIMEOUT_S,
+        ),
     )
     if not result.qpos_history:
-        raise RuntimeError("PPP physics simulation produced no qpos history")
+        raise RuntimeError(
+            "PPP physics simulation produced no qpos history "
+            f"(planning_status={result.planning_status!r}, "
+            f"planning_duration_s={result.planning_duration_s:.1f})"
+        )
 
     history = np.asarray(result.qpos_history, dtype=np.float64)
     sim_time_s = (

--- a/src/fret/mjcf/dubins_race.xml
+++ b/src/fret/mjcf/dubins_race.xml
@@ -160,7 +160,7 @@
       <joint name="rrt_joint_x" type="slide" axis="1 0 0" range="0 80" damping="50"/>
       <joint name="rrt_joint_y" type="slide" axis="0 1 0" range="0 80" damping="50"/>
       <joint name="rrt_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="12"/>
-      <geom name="rrt_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
+      <geom name="rrt_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0" contype="2" conaffinity="1"/>
       <geom name="rrt_base" type="mesh" mesh="tb3_base" pos="-0.13 0 0.04" euler="0 0 1.5708" material="car_rrt" contype="0" conaffinity="0"/>
       <geom name="rrt_standoff_fl" type="cylinder" pos="0.05 0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>
       <geom name="rrt_standoff_fr" type="cylinder" pos="0.05 -0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>
@@ -175,7 +175,7 @@
       <joint name="sst_joint_x" type="slide" axis="1 0 0" range="0 80" damping="50"/>
       <joint name="sst_joint_y" type="slide" axis="0 1 0" range="0 80" damping="50"/>
       <joint name="sst_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="12"/>
-      <geom name="sst_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
+      <geom name="sst_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0" contype="2" conaffinity="1"/>
       <geom name="sst_base" type="mesh" mesh="tb3_base" pos="-0.13 0 0.04" euler="0 0 1.5708" material="car_sst" contype="0" conaffinity="0"/>
       <geom name="sst_standoff_fl" type="cylinder" pos="0.05 0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>
       <geom name="sst_standoff_fr" type="cylinder" pos="0.05 -0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>
@@ -190,7 +190,7 @@
       <joint name="dummy_joint_x" type="slide" axis="1 0 0" range="0 80" damping="50"/>
       <joint name="dummy_joint_y" type="slide" axis="0 1 0" range="0 80" damping="50"/>
       <joint name="dummy_joint_yaw" type="hinge" axis="0 0 1" range="-3.14159 3.14159" damping="12"/>
-      <geom name="dummy_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0"/>
+      <geom name="dummy_collision" type="box" pos="0 0 0.04" size="0.36 0.22 0.09" rgba="0 0 0 0" contype="2" conaffinity="1"/>
       <geom name="dummy_base" type="mesh" mesh="tb3_base" pos="-0.13 0 0.04" euler="0 0 1.5708" material="car_dummy" contype="0" conaffinity="0"/>
       <geom name="dummy_standoff_fl" type="cylinder" pos="0.05 0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>
       <geom name="dummy_standoff_fr" type="cylinder" pos="0.05 -0.18 0.22" size="0.014 0.055" material="tb3_hardware" contype="0" conaffinity="0"/>

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -227,7 +227,12 @@ class DubinsRaceSimulation:
         bridge.step_physics(commands)
         _sync_vehicle_pose(self.rrt_vehicle, bridge.get_rrt_pose())
         _sync_vehicle_pose(self.sst_vehicle, bridge.get_sst_pose())
-        self.dummy_pose = tuple(float(v) for v in bridge.get_dummy_pose())
+        dummy_qpos = bridge.get_dummy_pose()
+        self.dummy_pose = (
+            float(dummy_qpos[0]),
+            float(dummy_qpos[1]),
+            float(dummy_qpos[2]),
+        )
 
         self.max_cross_track_error_m = max(
             self.max_cross_track_error_m,

--- a/src/fret/scenario/ppp_warehouse_runner.py
+++ b/src/fret/scenario/ppp_warehouse_runner.py
@@ -516,6 +516,7 @@ class PPPWarehouseRunner:
         physics_mode: bool = False,
         contact_log_enabled: bool = False,
         record_positions: bool = False,
+        planning_timeout: float | None = None,
     ) -> PPPWarehouseRunResult:
         """Execute planning, tracking, grasp, and collision validation."""
         bundle = load_scenario_bundle(self._scenario_path)
@@ -525,7 +526,11 @@ class PPPWarehouseRunner:
             raise ValueError("ppp_warehouse scenario requires grasp_config")
         start = np.asarray(params["start_configuration"], dtype=np.float64)
         goal = np.asarray(params["goal_configuration"], dtype=np.float64)
-        timeout = float(params["planning_timeout"])
+        timeout = float(
+            params["planning_timeout"]
+            if planning_timeout is None
+            else planning_timeout
+        )
         grasp_cfg = _parse_grasp_config(bundle.grasp)
         plan_include_cargo = bool(params["plan_include_cargo"])
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes post–PR #100 regressions on CI, release renders, and the v1.2.1 Dubins showcase video.

## Dubins physics + v1.2.1 video regression

PR #100 added a third dummy robot at arena start `(6, 6)` while RRT* / SST spawn ~0.4 m away. All three collision boxes used default `contype=1/conaffinity=1`, so MuJoCo contact forces **physically glued** the agents together. The race hit the 300 s timeout without reaching the goal.

The release renderer then **resampled the full 300 s pose log into a 35 s clip** (~8.6× apparent speed), producing the fast, stuck-together v1.2.1 `dubins_race_overview.mp4`.

### Fixes
- Agent collision geoms → `contype="2" conaffinity="1"` (hit obstacles, not each other)
- `mypy` dummy_pose assignment fix
- Render: fail physics export when agents miss goal; trim pose logs to `race_duration_s`

### Measured (seed=11, physics_mode)
| | v1.2.1 (broken) | PR #101 (fixed) |
|---|---|---|
| `both_reached_goal` | False | True |
| Race duration | 300 s (timeout) | ~56 s |
| RRT* X travel | ~11 m | ~71 m |
| RRT*–dummy separation mid-race | 0.41 m (glued) | 47.8 m |
| Resample speedup (300→35 s) | **8.57×** | **1.59×** |

## PPP release render (v1.2.1)

`render-ppp` failed when RRT* planning exceeded the 30 s scenario timeout on CI after the mid-field rack layout. Physics showcase export now gets 90 s planning headroom.

## Verification

- Formatting + mypy pass
- Dubins integration physics (3/3)
- `test_simulate_dubins_race_poses_covers_transit` pass (with collision fix)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c27ce458-21b2-4265-9f44-95c53dd32ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c27ce458-21b2-4265-9f44-95c53dd32ad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

