### PR TITLE
docs(agents): report-writing skill v1.1 — proportional PR proof reports

### DIFF
--- a/.cursor/skills/report-writing/SKILL.md
+++ b/.cursor/skills/report-writing/SKILL.md
@@ -7,161 +7,214 @@ description: >-
   long-running bug investigation. Depth scales with PR size and problem
   difficulty — one sentence for trivial tuning, engineer-grade evidence
   (metrics, graphs, renders) for large refactors and chronic failures.
+metadata:
+  author: fret
+  version: "1.1.0"
+  policy: AGENTS.md#proof-reports-mandatory
 ---
 
-# Report writing (proof that work works)
+# Report writing — proof that work works
 
-Agents must **prove** outcomes, not assert them. A report is the deliverable
-that lets the maintainer decide without re-running your investigation.
+Agents must **prove** outcomes, not assert them. The report is the deliverable
+that lets the maintainer merge or reject **without re-running your investigation**.
 
-Use this skill **whenever you create or update a PR**, finish a cloud-agent
-task, or the user asks “does it work?”, “convince me”, or “show me evidence”.
+## When to use (mandatory triggers)
 
-Official agent policy also lives in [AGENTS.md](../../../AGENTS.md) (Proof
-reports section) and [CONTRIBUTING.md](../../../CONTRIBUTING.md) (Rules for AI
-agents).
+Load this skill when **any** of these occur:
+
+- Creating or updating a **pull request**
+- Finishing a **cloud-agent** task that implies a PR
+- User asks: “does it work?”, “convince me”, “show evidence”, “report”
+- **Release / CI / showcase** pipeline failure
+- User says a prior fix **created another problem** or names a known failure mode
+  (e.g. “time-compression”, “flake”, “psychological manipulation”)
+- **Stochastic** behavior (RNG, timing, CI runner variance) or **visual/export**
+  output (video, MuJoCo, plots) where logs can mislead
+
+Repo policy: [AGENTS.md](../../../AGENTS.md#proof-reports-mandatory),
+[CONTRIBUTING.md](../../../CONTRIBUTING.md) (Rules for AI agents → Communication).
 
 ---
 
-## Choose report depth (mandatory)
+## Step 0 — Pick tier (before writing)
 
-Estimate **tier** from (a) diff size, (b) blast radius, (c) how long the
-problem has resisted fix, (d) whether behavior is stochastic or visual.
+Estimate tier from **four inputs**:
 
-| Tier | When | User-facing report |
+| Input | Ask |
+| --- | --- |
+| **Diff size** | Files changed, LOC, modules touched |
+| **Blast radius** | CI, release, sim, public API, data |
+| **Problem age** | First attempt vs chronic / multi-PR arc |
+| **Observability** | Deterministic pass/fail vs stochastic / visual |
+
+### Tier rubric
+
+| Tier | When | Deliverable |
 | --- | --- | --- |
-| **T0** | Typo, comment, pure format, single-line config with obvious effect | **One sentence** — what changed and that gates passed |
-| **T1** | Small fix (≤3 files, ≤~80 LOC), deterministic pass/fail | **2–4 bullets** — problem, fix, verification command + result |
-| **T2** | Multi-file feature/fix, CI repair, new test coverage | **Short sections** — Problem / Fix / Verification; include gate output or test counts |
-| **T3** | Release blocker, flaky CI, physics/sim/render pipeline, cross-module bug | **Evidence report** — metrics table + at least one chart or before/after comparison |
-| **T4** | Large refactor, architecture change, chronic issue (multiple failed PRs), release tag | **Engineer-grade report** — full layer stack below + artifacts the maintainer can open |
+| **T0** | Typo, comment, format-only, obvious one-liner | **One sentence** + gates passed |
+| **T1** | ≤3 files, ≤~80 LOC, deterministic | **2–4 bullets** (problem, fix, command, result) |
+| **T2** | Multi-file fix/feature, CI repair, new tests | **Problem / Fix / Verification** + gate output |
+| **T3** | Release blocker, flake, sim/render pipeline, cross-module | **Evidence report** + metric table + chart or before/after |
+| **T4** | Refactor, architecture, chronic bug, tag release, maintainer distrust | **Engineer-grade** — full layer stack + artifacts + recurrence |
 
-**Escalate one tier** when any of these apply:
+### Escalate +1 tier when
 
-- Prior agent PR claimed success but CI or user still red
-- Stochastic behavior (RNG, timing, race, CI runner variance)
-- Visual/export output (video, MuJoCo, plots) where logs lie
-- Maintainer said they already know the failure mode (e.g. “time-compression”,
-  “psychological manipulation”, “flake”) — show **mechanism**, not symptoms
+- A previous agent PR claimed success but CI/user still red
+- Behavior is **stochastic** (planner RNG, race, CI speed)
+- **Export/resampling** can make failure look like success
+- Maintainer already knows the trick — prove **mechanism**, not symptoms
 
-**Never** ship T0 for a T3 problem.
+**Never** ship T0 for a T3+ problem.
 
----
-
-## Engineer-grade report layers (T3–T4)
-
-Build evidence in order. Each layer answers a skeptic question.
-
-### Layer 1 — Reproduce verbatim
-
-- Quote the **exact** CI log line, exception, or user-reported run URL
-- Re-run the same command locally; show matching numbers (duration, error code)
-
-*Answers: “Did you actually hit my failure?”*
-
-### Layer 2 — Control variables
-
-- Change **one** thing at a time (seed, timeout, flag, commit)
-- Same environment assumptions as CI (EGL, pytest plugins, workflow flags)
-
-*Answers: “Is this environment noise or your code?”*
-
-### Layer 3 — State space / time domain
-
-- Trajectories, tables, bar charts — not raw log dumps
-- Plot **viewer time vs simulation time** when export/resampling is involved
-- Success rates over N trials when behavior is stochastic
-
-*Answers: “What actually happened in the system?”*
-
-### Layer 4 — Pixel / artifact proof
-
-- Screenshots, MP4 frame grabs, MuJoCo renders via the **same script** as CI
-- Save under `/opt/cursor/artifacts/<topic>/` and embed in PR or summary
-
-*Answers: “Would I see the same thing in the product?”*
-
-### Layer 5 — Fix chain (decision guide)
-
-Close with a short causal chain:
-
-```
-root cause → symptom → wrong fix (if any) → correct fix → verification
-```
-
-*Answers: “What should I merge and what should I watch?”*
+Templates per tier: [references/report-template.md](references/report-template.md)
 
 ---
 
-## Exemplar (T4)
+## Step 1 — Separate timeline from analysis (T2+)
 
-**Case:** Dubins physics release export — failed runs resampled from 300 s into
-35 s clips (8.6× apparent speedup); rejecting fake clips exposed unseeded
-planner flake (~25% CI failure).
+SRE best practice ([Google postmortem culture](https://sre.google/sre-book/postmortem-culture/)):
 
-**What we showed:**
+1. **Timeline** — sourced facts only (log lines, timestamps, command exit codes)
+2. **Analysis** — interpretation, clearly labeled
+3. **Recurrence** — have we seen this before? what happened to the last fix?
 
-1. CI error verbatim (`race_duration_s=300.0`, `max_cross_track_error_m=67.8`)
-2. 8×8 trial success rate (unseeded 75% vs seeded 100%)
-3. XY trajectory overlay (same physics, different plan)
-4. Viewer clock vs sim clock plot (resampling mechanism)
-5. MuJoCo overview snapshots (goal at x≈74 m only when seeded success)
-
-Methodology is reusable; see `scripts/evidence_dubins_physics_seed.py` when
-present on the branch.
+Do **not** mix “the database was slow” (vague) with “P99 latency 2000 ms at 23:47:12” (evidence). See [references/sre-principles.md](references/sre-principles.md).
 
 ---
 
-## Where to write the report
+## Step 2 — Evidence layers (T3–T4)
+
+Build in order. Each layer answers one skeptic question.
+
+| Layer | Content | Question answered |
+| --- | --- | --- |
+| **1. Reproduce verbatim** | CI URL, quoted exception, matching local repro | “Did you hit *my* failure?” |
+| **2. Control variable** | Change one knob (seed, timeout, flag); same env as CI | “Environment or code?” |
+| **3. State / time domain** | Trajectories, bar charts, success rates over N trials; **viewer clock vs sim clock** if resampling | “What actually happened?” |
+| **4. Pixel proof** | Screenshots / MuJoCo frames via **same script as CI** | “Would I see this in the product?” |
+| **5. Fix chain** | `root cause → symptom → wrong fix → correct fix → verification` | “What should I merge?” |
+
+### Honest failure vs deceptive success
+
+When export pipelines **resample** long failed runs into short clips, the viewer
+clock diverges from physics clock — apparent speedup without real success.
+**Rejecting** such exports is correct; **seeding/tuning** so physics actually
+finishes is the complementary fix. Never swap one deception for another (e.g.
+skip export checks to green CI).
+
+---
+
+## Step 3 — Exemplar (T4): Dubins physics release
+
+Maintainer feedback: *“You fixed one problem, you created another”* — honest
+rejection of fake clips exposed unseeded planner flake.
+
+| Layer | What we showed |
+| --- | --- |
+| 1 | CI: `race_duration_s=300.0`, `max_cross_track_error_m=67.80` |
+| 2 | Same physics controller; only `planner_rng_seed` changes |
+| 3 | 8×8 trial success rate; XY trajectories; viewer vs sim time (8.6×) |
+| 4 | MuJoCo overview: goal x≈74 m only on seeded success |
+| 5 | `unseeded flake → time-compress export → reject clips → seed RNG` |
+
+Repro script (when on branch): `scripts/evidence_dubins_physics_seed.py`  
+Artifacts: `/opt/cursor/artifacts/dubins_physics_evidence/*.png`
+
+---
+
+## Step 4 — Where to publish
 
 | Audience | Location |
 | --- | --- |
-| Maintainer (chat) | Final turn summary — lead with verdict, then layers |
-| PR reviewers | PR body: **Verification** section; embed images or link artifacts |
-| Long investigations | Optional `docs/postmortems/<topic>.md` only if user asks |
+| Maintainer (chat) | Final turn — **verdict first**, then layers; embed images |
+| PR reviewers | PR body **## Verification** (+ **## Problem** at T2+) |
+| Chronic issues | `docs/postmortems/<topic>.md` only if user asks |
 
-PR body minimum (T1+):
+### PR body skeleton (T1+)
 
 ```markdown
+## Problem
+[One paragraph or verbatim CI quote]
+
+## Fix
+[What changed and why — mechanism, not symptom only]
+
 ## Verification
-- Commands run: `...`
-- Result: pass / fail counts, timings, key metric
-- [T3+] Evidence: charts or screenshots in summary or artifacts
+- Commands: `...`
+- Results: exit codes, counts, timings
+- [T3+] Charts/screenshots or artifact paths
+
+## Recurrence
+[Prior attempts / what this fix adds beyond last PR]
 ```
 
 ---
 
-## Anti-patterns (do not)
+## Step 5 — Follow-ups (T3+)
 
-- “Should work” / “CI will pass” without command output
-- Describing fixes without showing the **failure mode** first
-- Replacing one deception with another (e.g. fake pass by skipping export checks)
-- Wall of grep output instead of one chart
-- Claiming flake is fixed from a single lucky run
+Each action item needs five fields (incident postmortem norm):
+
+**Owner** · **Verb** (add/remove/update/test/deploy) · **Measurable outcome** · **Tracker** · **Due**
+
+Avoid vague verbs: “investigate”, “explore”, “monitor” without a metric.
 
 ---
 
-## Commands to cite often
+## Anti-patterns
+
+| Do not | Do instead |
+| --- | --- |
+| “Should work” / “CI will pass” | Paste command + exit code |
+| Fix without showing failure mode | Reproduce first |
+| Single lucky run for flake | N trials + success rate |
+| Log wall | One chart or table |
+| Symptom-only patch on chronic bug | Recurrence + mechanism |
+| Time-compress failed sim into showcase | Reject + fix root cause |
+
+---
+
+## Commands (FRET)
 
 ```bash
 bash scripts/check/formatting.sh
 bash scripts/check/types.sh
 bash scripts/check/pre_push.sh --skip-ros
 python3 -m pytest tests/ --ignore=tests/integration -p no:launch_testing -p no:launch_ros
-```
-
-For render/physics evidence:
-
-```bash
-export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl
+export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl   # headless MuJoCo / release renders
 ```
 
 ---
 
-## Cursor Automations (optional, maintainer)
+## Progressive references
 
-Repo skills are loaded by the agent from `.cursor/skills/`; they are **not**
-auto-triggered by GitHub events on their own. To run report-style review on
-every PR open, create a [Cursor Automation](https://cursor.com/docs/cloud-agent/automations)
-with trigger **PR opened** and a prompt that references this skill
-(`report-writing`).
+Load only when needed:
+
+- [references/report-template.md](references/report-template.md) — copy-paste T0–T4 bodies
+- [references/sre-principles.md](references/sre-principles.md) — evidence, blameless, Five Whys, recurrence
+
+---
+
+## Maintainer: PR-open automation (optional)
+
+Skills are discovered from `.cursor/skills/`; GitHub does **not** auto-run them.
+
+To enforce on every PR:
+
+1. [Cursor Automations](https://cursor.com/docs/cloud-agent/automations) → trigger **PR opened**
+2. Prompt: “Follow `report-writing` skill; assess tier from diff + issue history; post proportional **Verification** comment.”
+
+Or invoke manually: `/report-writing` or `@report-writing` in Agent chat.
+
+---
+
+## Maintainer: create / edit this skill
+
+| Action | How |
+| --- | --- |
+| **Edit** | Change `.cursor/skills/report-writing/SKILL.md`; keep `name` = folder name |
+| **Scaffold new skill** | Agent chat → `/create-skill` |
+| **Manual layout** | `.cursor/skills/<name>/SKILL.md` + optional `scripts/`, `references/`, `assets/` |
+| **Also loaded from** | `.agents/skills/` (same layout), `~/.cursor/skills/` (global) |
+| **Force manual only** | `disable-model-invocation: true` in frontmatter |
+
+Docs: [cursor.com/docs/skills](https://cursor.com/docs/skills)

--- a/.cursor/skills/report-writing/SKILL.md
+++ b/.cursor/skills/report-writing/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: report-writing
+description: >-
+  Write proportional proof reports when creating or updating pull requests,
+  completing cloud-agent tasks, or when the maintainer asks whether work
+  actually works. Load on every new PR creation, PR update, release fix, or
+  long-running bug investigation. Depth scales with PR size and problem
+  difficulty — one sentence for trivial tuning, engineer-grade evidence
+  (metrics, graphs, renders) for large refactors and chronic failures.
+---
+
+# Report writing (proof that work works)
+
+Agents must **prove** outcomes, not assert them. A report is the deliverable
+that lets the maintainer decide without re-running your investigation.
+
+Use this skill **whenever you create or update a PR**, finish a cloud-agent
+task, or the user asks “does it work?”, “convince me”, or “show me evidence”.
+
+Official agent policy also lives in [AGENTS.md](../../../AGENTS.md) (Proof
+reports section) and [CONTRIBUTING.md](../../../CONTRIBUTING.md) (Rules for AI
+agents).
+
+---
+
+## Choose report depth (mandatory)
+
+Estimate **tier** from (a) diff size, (b) blast radius, (c) how long the
+problem has resisted fix, (d) whether behavior is stochastic or visual.
+
+| Tier | When | User-facing report |
+| --- | --- | --- |
+| **T0** | Typo, comment, pure format, single-line config with obvious effect | **One sentence** — what changed and that gates passed |
+| **T1** | Small fix (≤3 files, ≤~80 LOC), deterministic pass/fail | **2–4 bullets** — problem, fix, verification command + result |
+| **T2** | Multi-file feature/fix, CI repair, new test coverage | **Short sections** — Problem / Fix / Verification; include gate output or test counts |
+| **T3** | Release blocker, flaky CI, physics/sim/render pipeline, cross-module bug | **Evidence report** — metrics table + at least one chart or before/after comparison |
+| **T4** | Large refactor, architecture change, chronic issue (multiple failed PRs), release tag | **Engineer-grade report** — full layer stack below + artifacts the maintainer can open |
+
+**Escalate one tier** when any of these apply:
+
+- Prior agent PR claimed success but CI or user still red
+- Stochastic behavior (RNG, timing, race, CI runner variance)
+- Visual/export output (video, MuJoCo, plots) where logs lie
+- Maintainer said they already know the failure mode (e.g. “time-compression”,
+  “psychological manipulation”, “flake”) — show **mechanism**, not symptoms
+
+**Never** ship T0 for a T3 problem.
+
+---
+
+## Engineer-grade report layers (T3–T4)
+
+Build evidence in order. Each layer answers a skeptic question.
+
+### Layer 1 — Reproduce verbatim
+
+- Quote the **exact** CI log line, exception, or user-reported run URL
+- Re-run the same command locally; show matching numbers (duration, error code)
+
+*Answers: “Did you actually hit my failure?”*
+
+### Layer 2 — Control variables
+
+- Change **one** thing at a time (seed, timeout, flag, commit)
+- Same environment assumptions as CI (EGL, pytest plugins, workflow flags)
+
+*Answers: “Is this environment noise or your code?”*
+
+### Layer 3 — State space / time domain
+
+- Trajectories, tables, bar charts — not raw log dumps
+- Plot **viewer time vs simulation time** when export/resampling is involved
+- Success rates over N trials when behavior is stochastic
+
+*Answers: “What actually happened in the system?”*
+
+### Layer 4 — Pixel / artifact proof
+
+- Screenshots, MP4 frame grabs, MuJoCo renders via the **same script** as CI
+- Save under `/opt/cursor/artifacts/<topic>/` and embed in PR or summary
+
+*Answers: “Would I see the same thing in the product?”*
+
+### Layer 5 — Fix chain (decision guide)
+
+Close with a short causal chain:
+
+```
+root cause → symptom → wrong fix (if any) → correct fix → verification
+```
+
+*Answers: “What should I merge and what should I watch?”*
+
+---
+
+## Exemplar (T4)
+
+**Case:** Dubins physics release export — failed runs resampled from 300 s into
+35 s clips (8.6× apparent speedup); rejecting fake clips exposed unseeded
+planner flake (~25% CI failure).
+
+**What we showed:**
+
+1. CI error verbatim (`race_duration_s=300.0`, `max_cross_track_error_m=67.8`)
+2. 8×8 trial success rate (unseeded 75% vs seeded 100%)
+3. XY trajectory overlay (same physics, different plan)
+4. Viewer clock vs sim clock plot (resampling mechanism)
+5. MuJoCo overview snapshots (goal at x≈74 m only when seeded success)
+
+Methodology is reusable; see `scripts/evidence_dubins_physics_seed.py` when
+present on the branch.
+
+---
+
+## Where to write the report
+
+| Audience | Location |
+| --- | --- |
+| Maintainer (chat) | Final turn summary — lead with verdict, then layers |
+| PR reviewers | PR body: **Verification** section; embed images or link artifacts |
+| Long investigations | Optional `docs/postmortems/<topic>.md` only if user asks |
+
+PR body minimum (T1+):
+
+```markdown
+## Verification
+- Commands run: `...`
+- Result: pass / fail counts, timings, key metric
+- [T3+] Evidence: charts or screenshots in summary or artifacts
+```
+
+---
+
+## Anti-patterns (do not)
+
+- “Should work” / “CI will pass” without command output
+- Describing fixes without showing the **failure mode** first
+- Replacing one deception with another (e.g. fake pass by skipping export checks)
+- Wall of grep output instead of one chart
+- Claiming flake is fixed from a single lucky run
+
+---
+
+## Commands to cite often
+
+```bash
+bash scripts/check/formatting.sh
+bash scripts/check/types.sh
+bash scripts/check/pre_push.sh --skip-ros
+python3 -m pytest tests/ --ignore=tests/integration -p no:launch_testing -p no:launch_ros
+```
+
+For render/physics evidence:
+
+```bash
+export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl
+```
+
+---
+
+## Cursor Automations (optional, maintainer)
+
+Repo skills are loaded by the agent from `.cursor/skills/`; they are **not**
+auto-triggered by GitHub events on their own. To run report-style review on
+every PR open, create a [Cursor Automation](https://cursor.com/docs/cloud-agent/automations)
+with trigger **PR opened** and a prompt that references this skill
+(`report-writing`).

--- a/.cursor/skills/report-writing/references/report-template.md
+++ b/.cursor/skills/report-writing/references/report-template.md
@@ -1,0 +1,109 @@
+# Report templates by tier
+
+Copy the matching template into the PR body **Verification** section or the
+final chat summary.
+
+---
+
+## T0 — one sentence
+
+```markdown
+## Verification
+Bumped `planning_timeout` default in `dubins_race.yml` (30→35 s); `bash scripts/check/formatting.sh` and `bash scripts/check/types.sh` pass.
+```
+
+---
+
+## T1 — bullets
+
+```markdown
+## Verification
+- **Problem:** `mypy` missing `Any` import in `planner_node_ros.py`
+- **Fix:** added `from typing import Any`
+- **Commands:** `bash scripts/check/types.sh` → exit 0
+```
+
+---
+
+## T2 — short sections
+
+```markdown
+## Problem
+PPP `render-ppp` job timed out at 36 s with empty `qpos_history` on CI.
+
+## Fix
+Raise physics showcase `planning_timeout` to 90 s in `render_mujoco.py` only.
+
+## Verification
+- `bash scripts/check/formatting.sh` — pass
+- `bash scripts/check/types.sh` — pass
+- `python3 -m pytest tests/simulation/test_render_mujoco.py -k ppp` — 12 passed
+```
+
+---
+
+## T3 — evidence report
+
+```markdown
+## Problem (verbatim)
+CI `render-dubins` exit 1:
+`RuntimeError: Dubins race simulation failed before both agents reached goal
+(race_duration_s=300.0, max_cross_track_error_m=67.80)`
+Run: https://github.com/org/repo/actions/runs/NNNNNN
+
+## Timeline (sourced)
+| Time | Event | Source |
+| --- | --- | --- |
+| t=0 | Planning starts (unseeded ARC) | local repro |
+| t≈50s | Agents stall, x≈42 m | pose log |
+| t=300s | Race timeout, `both_reached_goal=False` | runner result |
+
+## Analysis (interpretive)
+Unseeded planner RNG produces untrackable paths under physics (~25% fail).
+
+## Fix
+Pin `planner_rng_seed=11` during physics showcase export.
+
+## Verification
+| Trial | Unseeded | Seeded |
+| --- | --- | --- |
+| 8 runs | 6/8 pass (75%) | 8/8 pass (100%) |
+
+![success rate chart](artifacts/03_failure_rate_bars.png)
+
+## Recurrence
+Prior fix (`8b2cf32`) correctly rejected fake clips but exposed underlying flake.
+```
+
+---
+
+## T4 — engineer-grade (full)
+
+Use all sections from T3 plus:
+
+```markdown
+## Mechanism (export transform)
+`_resample_pose_history(full_300s_log, 1050_frames)` maps viewer 35 s → sim 300 s
+(8.6× apparent speedup). Honest gate: reject when `not both_reached_goal`.
+
+## Evidence layers
+1. CI log verbatim (above)
+2. Control variable: same physics, only RNG seed changes
+3. XY trajectories + x(t) plot + viewer-vs-sim clock plot
+4. MuJoCo overview snapshots from `scripts/video.sh` pipeline
+5. Fix chain diagram
+
+## Artifacts
+- `/opt/cursor/artifacts/<topic>/01_trajectory_xy_comparison.png`
+- `/opt/cursor/artifacts/<topic>/02_time_compression_manipulation.png`
+- Repro: `python3 scripts/evidence_<topic>.py`
+
+## Follow-ups
+| Action | Owner | Verb | Outcome | Tracker | Due |
+| --- | --- | --- | --- | --- | --- |
+| Merge seed fix | agent | add | CI render-dubins green | PR #NNN | — |
+| Monitor v1.2.2 tag release | maintainer | verify | both showcase jobs pass | release.yml | tag day |
+
+## What went well
+- Honest failure gate prevented shipping misleading showcase clips.
+```

--- a/.cursor/skills/report-writing/references/sre-principles.md
+++ b/.cursor/skills/report-writing/references/sre-principles.md
@@ -1,0 +1,80 @@
+# SRE / incident-report principles (enrichment)
+
+Condensed from [Google SRE postmortem culture](https://sre.google/sre-book/postmortem-culture/),
+incident postmortem practice guides, and blameless review norms. Apply at **T3+**.
+
+## Evidence over narrative
+
+Every significant claim needs a **citation**:
+
+| Weak | Strong |
+| --- | --- |
+| “Physics was flaky” | “8/8 unseeded runs: 3 timed out at 300 s (`race_duration_s=300.0`)" |
+| “CI failed” | Link + quoted log line with exit code |
+| “Much faster now” | “55.6 s vs 300 s timeout; p50 race duration 56 s over 8 trials” |
+
+Write the **timeline from sources first** (logs, metrics, commands). Write
+**analysis second**. Never mix sourced facts and interpretation in one sentence
+without labeling.
+
+## Blameless, systemic framing
+
+Ask what **conditions** allowed the failure — not who broke it.
+
+- Good: “Export path resampled timeout logs without checking `both_reached_goal`”
+- Bad: “Agent shipped a bad fix”
+
+If root cause lands on a person, keep asking **why the system had no guardrail**
+(honest CI gate, deterministic seed, export validation).
+
+## Recurrence field (mandatory at T3+)
+
+Answer explicitly:
+
+1. Have we seen this failure mode before?
+2. What happened to the last fix?
+3. Did the new fix address **mechanism** or only **symptom**?
+
+Example (Dubins): symptom fix = reject fake clips; mechanism fix = seed planner RNG.
+
+## Action items — five closure fields
+
+Each follow-up needs:
+
+| Field | Example |
+| --- | --- |
+| **Owner** | agent / maintainer / team |
+| **Verb** | add, remove, update, test, deploy — not “investigate” |
+| **Measurable outcome** | “render-dubins job exit 0 on tag push” |
+| **Tracker** | PR #, issue #, Asana task |
+| **Due** | date or release event |
+
+## Root cause depth
+
+Prefer **Five Whys** until you hit a guardrail or design decision:
+
+1. Why did CI fail? → physics race timeout
+2. Why timeout? → untrackable plan
+3. Why untrackable? → unseeded ARC sample tree
+4. Why unseeded in export? → seed only in tests, not render path
+5. Why no guardrail? → export did not require `both_reached_goal` until `8b2cf32`
+
+## When to write a full report
+
+Triggers (adapted from SRE postmortem policy):
+
+- Release / showcase pipeline failure
+- Recurring CI flake after a “fix”
+- Maintainer distrust (“you fixed one problem, created another”)
+- Stochastic or visual correctness (sim, render, ML)
+- Cross-module or multi-PR arc
+
+**Not** required: typos, format-only, single-line deterministic fixes (T0–T1).
+
+## Pre-mortem (optional, T4 refactors)
+
+Before large changes, briefly document:
+
+- What could fail?
+- What metric would prove success?
+- What would a misleading “success” look like? (e.g. time-compressed fake clip)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,21 @@ bash scripts/check/pre_push.sh --skip-ros
 Pushing with formatting or type-check failures is unacceptable at this stage
 of the project.
 
+## Proof reports (mandatory)
+
+Agents must **prove** that work works — not only implement and push. Report
+depth is **proportional** to change size and problem difficulty (trivial tuning
+→ one sentence; release blockers and chronic bugs → metrics, charts, renders).
+
+Load the repo skill [`.cursor/skills/report-writing/SKILL.md`](.cursor/skills/report-writing/SKILL.md)
+whenever you **create or update a PR**, finish a cloud-agent task, or the
+maintainer asks for evidence. Follow its tier table (T0–T4) and layer stack
+for engineer-grade cases.
+
+Minimum: cite commands run and pass/fail results. For flaky CI, stochastic
+sim, or visual/export pipelines, include measured before/after and at least
+one chart or screenshot from the real pipeline.
+
 ## Cursor Cloud specific instructions
 
 Durable, non-obvious notes for cloud agents. The base VM snapshot already has

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -491,7 +491,8 @@ contributor.
 4. **Level 4** — Implement; run `scripts/check/pre_push.sh` (or `--skip-ros` when ROS unavailable).
 5. **PR** — Push only after **at minimum** `scripts/check/formatting.sh` and
    `scripts/check/types.sh` pass locally; ensure CI green; do not claim done
-   while checks fail.
+   while checks fail. Include a proportional **proof report** per the
+   `report-writing` skill (see Communication below).
 
 ### Git safety
 
@@ -504,6 +505,11 @@ contributor.
 
 - Be precise; use code citations when referencing existing code.
 - Keep responses proportional to task complexity.
+- **Proof reports:** When creating or updating a PR, follow the
+  [`report-writing` skill](.cursor/skills/report-writing/SKILL.md) (also
+  [AGENTS.md § Proof reports](AGENTS.md#proof-reports-mandatory)). Report depth
+  scales T0–T4 with diff size and problem difficulty; chronic or visual bugs
+  require measurable evidence, not assertions.
 
 ---
 

--- a/scripts/evidence/README.md
+++ b/scripts/evidence/README.md
@@ -1,0 +1,16 @@
+# Evidence scripts
+
+Optional scripts that generate **T3–T4** proof artifacts (charts, MuJoCo snapshots).
+
+| Script | Purpose |
+| --- | --- |
+| `evidence_dubins_physics_seed.py` | Dubins physics flake vs seeded export; writes PNGs to `/opt/cursor/artifacts/dubins_physics_evidence/` |
+
+Run:
+
+```bash
+export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl
+python3 scripts/evidence_dubins_physics_seed.py
+```
+
+Agents: follow [`.cursor/skills/report-writing/SKILL.md`](../.cursor/skills/report-writing/SKILL.md).

--- a/scripts/evidence_dubins_physics_seed.py
+++ b/scripts/evidence_dubins_physics_seed.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Generate technical evidence images for Dubins physics showcase seeding."""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import mujoco
+import numpy as np
+from matplotlib.gridspec import GridSpec
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from fret.scenario.dubins_race_runner import DubinsRaceRunner
+from fret.scenario.planner_rng import (
+    SHOWCASE_PLANNER_RNG_SEED,
+    deterministic_planner_rng,
+)
+from render_mujoco import (
+    _apply_dubins_poses,
+    _resample_pose_history,
+    resolve_mjcf_path,
+    resolve_scenario_simulation_dt,
+)
+
+OUT = Path("/opt/cursor/artifacts/dubins_physics_evidence")
+MJCF = resolve_mjcf_path("dubins", "dubins_race", None)
+GOAL_XY = (74.0, 74.0)
+NOMINAL_CLIP_S = 35.0
+FPS = 30
+
+
+def _run_physics(*, seed: int | None) -> object:
+    runner = DubinsRaceRunner()
+    kwargs: dict[str, object] = {
+        "record_poses": True,
+        "physics_mode": True,
+    }
+    if seed is not None:
+        kwargs["planner_rng_seed"] = seed
+    return runner.run(**kwargs)
+
+
+def _find_unseeded_failure(max_tries: int = 8) -> object:
+    for _ in range(max_tries):
+        result = _run_physics(seed=None)
+        if not result.both_reached_goal:
+            return result
+    raise RuntimeError("could not sample an unseeded failure within max_tries")
+
+
+def _xy(history: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    return history[:, 0], history[:, 1]
+
+
+def _mujoco_snapshot(
+    rrt: np.ndarray,
+    sst: np.ndarray,
+    dummy: np.ndarray,
+    *,
+    title: str,
+    path: Path,
+) -> None:
+    model = mujoco.MjModel.from_xml_path(str(MJCF))
+    data = mujoco.MjData(model)
+    renderer = mujoco.Renderer(model, height=720, width=1280)
+    cam_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, "overview")
+    _apply_dubins_poses(mujoco, model, data, rrt, sst, dummy)
+    renderer.update_scene(data, camera=cam_id)
+    rgb = renderer.render()
+    renderer.close()
+    plt.figure(figsize=(12.8, 7.2), dpi=100)
+    plt.imshow(rgb)
+    plt.axis("off")
+    plt.title(title, fontsize=14, fontweight="bold", pad=12)
+    plt.tight_layout()
+    plt.savefig(path, bbox_inches="tight", facecolor="white")
+    plt.close()
+
+
+def plot_trajectories(failed: object, seeded: object) -> None:
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6.5), sharex=True, sharey=True)
+    for ax, result, title, subtitle in (
+        (
+            axes[0],
+            failed,
+            "Unseeded planner (CI failure)",
+            f"timeout {failed.race_duration_s:.0f}s · "
+            f"xtrack {failed.max_cross_track_error_m:.1f}m",
+        ),
+        (
+            axes[1],
+            seeded,
+            f"Seeded planner (seed={SHOWCASE_PLANNER_RNG_SEED})",
+            f"finish {max(seeded.rrt_time_to_goal_s, seeded.sst_time_to_goal_s):.1f}s · "
+            f"xtrack {seeded.max_cross_track_error_m:.1f}m",
+        ),
+    ):
+        rrt = np.asarray(result.rrt_pose_history)
+        sst = np.asarray(result.sst_pose_history)
+        dummy = np.asarray(result.dummy_pose_history)
+        ax.plot(*_xy(rrt), color="#4477cc", lw=2.2, label="RRT*")
+        ax.plot(*_xy(sst), color="#44aa66", lw=2.2, label="SST")
+        ax.plot(*_xy(dummy), color="#888888", lw=1.4, ls="--", label="dummy")
+        ax.scatter([rrt[0, 0]], [rrt[0, 1]], c="#4477cc", s=80, zorder=5)
+        ax.scatter([GOAL_XY[0]], [GOAL_XY[1]], c="#cc3333", s=120, marker="*", zorder=5)
+        ax.set_title(f"{title}\n{subtitle}", fontsize=11)
+        ax.set_xlabel("x [m]")
+        ax.set_ylabel("y [m]")
+        ax.set_xlim(0, 80)
+        ax.set_ylim(0, 80)
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.25)
+        ax.legend(loc="lower right", fontsize=9)
+    fig.suptitle(
+        "Same physics controller · different ARC sample trees",
+        fontsize=13,
+        fontweight="bold",
+        y=1.02,
+    )
+    fig.tight_layout()
+    fig.savefig(OUT / "01_trajectory_xy_comparison.png", dpi=150, facecolor="white")
+    plt.close(fig)
+
+
+def plot_time_compression(failed: object) -> None:
+    sim_dt = resolve_scenario_simulation_dt("dubins_race")
+    rrt = np.asarray(failed.rrt_pose_history)
+    t = np.arange(rrt.shape[0]) * sim_dt
+    n_frames = max(2, int(round(NOMINAL_CLIP_S * FPS)))
+
+    fig = plt.figure(figsize=(14, 8))
+    gs = GridSpec(2, 1, height_ratios=[1.2, 1], hspace=0.35)
+
+    ax0 = fig.add_subplot(gs[0])
+    ax0.plot(t, rrt[:, 0], color="#4477cc", lw=2, label="RRT* x(t) — real sim")
+    ax0.axvline(NOMINAL_CLIP_S, color="#cc3333", ls="--", lw=1.5)
+    ax0.axvline(failed.race_duration_s, color="#666666", ls=":", lw=1.5)
+    ax0.annotate(
+        f"nominal clip end ({NOMINAL_CLIP_S:.0f}s)",
+        xy=(NOMINAL_CLIP_S, 8),
+        fontsize=9,
+        color="#cc3333",
+    )
+    ax0.annotate(
+        f"race timeout ({failed.race_duration_s:.0f}s)",
+        xy=(failed.race_duration_s - 35, rrt[-1, 0] - 4),
+        fontsize=9,
+        color="#666666",
+    )
+    ax0.set_xlim(0, failed.race_duration_s)
+    ax0.set_ylim(0, 80)
+    ax0.set_xlabel("simulation time [s]")
+    ax0.set_ylabel("x position [m]")
+    ax0.set_title(
+        "Failed physics run never reaches goal — but pose log keeps growing",
+        fontweight="bold",
+    )
+    ax0.grid(True, alpha=0.25)
+    ax0.legend(loc="lower right")
+
+    ax1 = fig.add_subplot(gs[1])
+    video_t = np.linspace(0, NOMINAL_CLIP_S, n_frames)
+    mapped_sim_t = video_t * (failed.race_duration_s / NOMINAL_CLIP_S)
+    ax1.plot(
+        video_t,
+        mapped_sim_t,
+        color="#aa2222",
+        lw=3,
+        label="old export mapping (resample full log)",
+    )
+    ax1.plot(
+        video_t,
+        video_t,
+        color="#228822",
+        lw=2,
+        ls="--",
+        label="honest mapping (success only)",
+    )
+    ax1.fill_between(
+        video_t,
+        video_t,
+        mapped_sim_t,
+        color="#aa2222",
+        alpha=0.15,
+        label="hidden speedup gap",
+    )
+    speedup = failed.race_duration_s / NOMINAL_CLIP_S
+    ax1.text(
+        18,
+        210,
+        f"{speedup:.1f}× apparent speedup\nwhen 300s log → 35s MP4",
+        fontsize=11,
+        color="#aa2222",
+        bbox=dict(boxstyle="round", facecolor="white", edgecolor="#aa2222"),
+    )
+    ax1.set_xlabel("viewer timeline [s] (MP4 duration)")
+    ax1.set_ylabel("source sim time [s] (pose log index)")
+    ax1.set_title(
+        "Time-compression export: viewer clock ≠ physics clock",
+        fontweight="bold",
+    )
+    ax1.set_xlim(0, NOMINAL_CLIP_S)
+    ax1.set_ylim(0, failed.race_duration_s + 10)
+    ax1.grid(True, alpha=0.25)
+    ax1.legend(loc="upper left", fontsize=9)
+
+    fig.savefig(OUT / "02_time_compression_manipulation.png", dpi=150, facecolor="white")
+    plt.close(fig)
+
+
+def plot_failure_rate() -> None:
+    trials = 8
+    unseeded_ok = 0
+    for _ in range(trials):
+        if _run_physics(seed=None).both_reached_goal:
+            unseeded_ok += 1
+    seeded_ok = 0
+    for _ in range(trials):
+        if _run_physics(seed=SHOWCASE_PLANNER_RNG_SEED).both_reached_goal:
+            seeded_ok += 1
+
+    labels = ["unseeded\n(release path)", f"seed={SHOWCASE_PLANNER_RNG_SEED}\n(PR #102)"]
+    success = [unseeded_ok / trials * 100, seeded_ok / trials * 100]
+    colors = ["#cc5544", "#44aa66"]
+
+    fig, ax = plt.subplots(figsize=(8, 5.5))
+    bars = ax.bar(labels, success, color=colors, width=0.55)
+    ax.set_ylim(0, 105)
+    ax.set_ylabel("physics race success rate [%]")
+    ax.set_title(
+        f"Dubins physics both_reached_goal over {trials} runs each",
+        fontweight="bold",
+    )
+    ax.axhline(100, color="#888888", ls=":", lw=1)
+    for bar, pct in zip(bars, success, strict=True):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + 2,
+            f"{pct:.0f}%",
+            ha="center",
+            fontweight="bold",
+        )
+    ax.grid(axis="y", alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(OUT / "03_failure_rate_bars.png", dpi=150, facecolor="white")
+    plt.close(fig)
+
+
+def render_snapshots(failed: object, seeded: object) -> None:
+    sim_dt = resolve_scenario_simulation_dt("dubins_race")
+    n_frames = max(2, int(round(NOMINAL_CLIP_S * FPS)))
+
+    def _hist(result: object) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        return (
+            np.asarray(result.rrt_pose_history),
+            np.asarray(result.sst_pose_history),
+            np.asarray(result.dummy_pose_history),
+        )
+
+    fail_rrt, fail_sst, fail_dummy = _hist(failed)
+    seed_rrt, seed_sst, seed_dummy = _hist(seeded)
+
+    # Honest t=35s sample during failed run (agents barely moved).
+    idx_fail_real = min(fail_rrt.shape[0] - 1, int(round(NOMINAL_CLIP_S / sim_dt)))
+    _mujoco_snapshot(
+        fail_rrt[idx_fail_real],
+        fail_sst[idx_fail_real],
+        fail_dummy[idx_fail_real],
+        title=(
+            f"FAILED run at real t={NOMINAL_CLIP_S:.0f}s sim "
+            f"(x≈{fail_rrt[idx_fail_real,0]:.0f}m — not at goal)"
+        ),
+        path=OUT / "04_snapshot_failed_real_t35.png",
+    )
+
+    # Dishonest last frame if we resample the full 300s log into 35s MP4.
+    resampled_rrt = _resample_pose_history(fail_rrt, n_frames)
+    resampled_sst = _resample_pose_history(fail_sst, n_frames)
+    resampled_dummy = _resample_pose_history(fail_dummy, n_frames)
+    _mujoco_snapshot(
+        resampled_rrt[-1],
+        resampled_sst[-1],
+        resampled_dummy[-1],
+        title=(
+            "OLD export: last MP4 frame = t=300s poses squeezed into 35s clip "
+            f"(x≈{resampled_rrt[-1,0]:.0f}m — looks like progress)"
+        ),
+        path=OUT / "05_snapshot_failed_compressed_last_frame.png",
+    )
+
+    seed_frames = _resample_pose_history(seed_rrt, n_frames)
+    _mujoco_snapshot(
+        seed_frames[-1],
+        _resample_pose_history(seed_sst, n_frames)[-1],
+        _resample_pose_history(seed_dummy, n_frames)[-1],
+        title=(
+            f"SEEDED success: last MP4 frame after real finish "
+            f"(x≈{seed_frames[-1,0]:.0f}m — both agents at goal)"
+        ),
+        path=OUT / "06_snapshot_seeded_success_last_frame.png",
+    )
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    print("Sampling unseeded failure …")
+    failed = _find_unseeded_failure()
+    print(
+        f"  failed: duration={failed.race_duration_s:.1f}s "
+        f"xtrack={failed.max_cross_track_error_m:.1f}m"
+    )
+    print("Running seeded success …")
+    seeded = _run_physics(seed=SHOWCASE_PLANNER_RNG_SEED)
+    assert seeded.both_reached_goal
+    print(
+        f"  seeded: duration={seeded.race_duration_s:.1f}s "
+        f"xtrack={seeded.max_cross_track_error_m:.1f}m"
+    )
+
+    plot_trajectories(failed, seeded)
+    plot_time_compression(failed)
+    print("Measuring failure rates (16 physics runs) …")
+    plot_failure_rate()
+    print("Rendering MuJoCo overview snapshots …")
+    render_snapshots(failed, seeded)
+    print(f"Wrote evidence to {OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Repo-local **Cursor skill** `report-writing` (v1.1) plus agent policy so agents deliver **proportional proof reports** — from one sentence (T0) to engineer-grade evidence (T4).

## What's included

### Skill (`.cursor/skills/report-writing/`)

- **`SKILL.md`** — mandatory triggers, T0–T4 rubric, escalation rules, 5 evidence layers, Dubins T4 exemplar, anti-patterns, FRET commands, maintainer tutorial
- **`references/report-template.md`** — copy-paste PR bodies per tier
- **`references/sre-principles.md`** — Google/SRE enrichment: evidence over narrative, timeline vs analysis, blameless framing, recurrence, Five Whys, 5-field action items

### Policy wiring

- `AGENTS.md` — Proof reports (mandatory)
- `CONTRIBUTING.md` — PR step + Communication

### Exemplar tooling

- `scripts/evidence_dubins_physics_seed.py` — reproduces charts/snapshots from the Dubins physics investigation
- `scripts/evidence/README.md`

## How agents load it

- Auto-discovery from `.cursor/skills/` via `description` matching
- Mandatory on PR create/update per `AGENTS.md`
- Manual: `/report-writing` or `@report-writing`
- Optional automation: Cursor **PR opened** trigger (documented in skill)

## Verification

Markdown + exemplar script only; no product code changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a43558e-1b37-458a-995a-b0630a2da239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a43558e-1b37-458a-995a-b0630a2da239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

