### PR TITLE
Remove race beacons; disable agent–agent collisions

### DIFF
--- a/docs/robots/dubins.md
+++ b/docs/robots/dubins.md
@@ -8,15 +8,19 @@
 ## Overview
 
 The Dubins vehicle is a **car-like mobile robot** constrained to forward motion with a
-minimum turning radius. v1.1 features **two robots racing** from A to B through a
-warehouse structure forest (RRT* vs SST).
+minimum turning radius. The showcase races **three TurtleBot3 Burgers** from A to B
+through a warehouse maze (RRT* vs SST vs straight-line dummy), stepped concurrently.
 
 State: `q = (x, y, θ)` in SE(2).
 
 | Agent | Planner | Visual identity |
 |---|---|---|
-| Car 1 | ARCO RRT* | Blue chassis + marker **1** |
-| Car 2 | ARCO SST | Green chassis + marker **2** |
+| Car 1 | ARCO RRT* | Blue chassis |
+| Car 2 | ARCO SST | Green chassis |
+| Car 3 | Straight start→goal (foil) | Grey chassis |
+
+Agent–agent contacts are disabled in MJCF so racers may overlap; they still collide
+with warehouse structures.
 
 ---
 

--- a/src/fret/mjcf/dubins_race.xml
+++ b/src/fret/mjcf/dubins_race.xml
@@ -8,7 +8,9 @@
                 scripts/generate_dubins_race_mjcf.py).
     Agents: real-scale TurtleBot3 Burger (RRT* blue, SST green, dummy grey)
             with Menagerie wheel actuators (±6.67 rad/s).
-    Dummy follows a straight start→goal line and collides (showcase foil).
+    All three are stepped in the same physics tick (true concurrent race).
+    Agent–agent contacts are disabled; shells still hit warehouse structures.
+    Dummy Pure-Pursuits the straight start→goal line (showcase foil).
   -->
   <!-- meshdir="." so TB3 can resolve the Menagerie submodule and AWS OBJs. -->
   <compiler angle="radian" coordinate="local"
@@ -30,8 +32,8 @@
       <geom group="3" type="mesh" contype="0" conaffinity="0" density="0"/>
     </default>
     <default class="agent_shell">
-      <!-- Structure contacts only (bit 2) — never the floor. -->
-      <geom type="box" contype="2" conaffinity="2" rgba="0 0 0 0"/>
+      <!-- Structures only (bit 2). conaffinity=0 → no agent–agent shell hits. -->
+      <geom type="box" contype="2" conaffinity="0" rgba="0 0 0 0"/>
     </default>
     <default class="structure_col">
       <geom type="box" contype="2" conaffinity="2" rgba="0 0 0 0"/>
@@ -154,11 +156,6 @@
       <freejoint name="rrt_base_joint"/>
       <!-- Raised so the box does not skid on the floor (wheels provide contact). -->
       <geom name="rrt_collision" class="agent_shell" pos="-0.032 0 0.12" size="0.14 0.12 0.06"/>
-      <!-- Tall non-colliding marker: real TB3 is ~0.2 m and disappears in top-down. -->
-      <geom name="rrt_marker" type="cylinder" size="0.18 0.35" pos="0 0 0.45"
-            rgba="0.15 0.40 0.95 1" contype="0" conaffinity="0" group="0"/>
-      <geom name="rrt_marker_cap" type="sphere" size="0.22" pos="0 0 0.85"
-            rgba="0.25 0.55 1 1" contype="0" conaffinity="0" group="0"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" material="car_rrt" class="tb3_visual"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" class="tb3_chassis_collision"/>
       <geom size="0.005" pos="-0.081 0 0.005" type="sphere" material="wheel"
@@ -190,10 +187,6 @@
       <inertial pos="-0.032 0 0.03" mass="0.9" diaginertia="0.005 0.005 0.003"/>
       <freejoint name="sst_base_joint"/>
       <geom name="sst_collision" class="agent_shell" pos="-0.032 0 0.12" size="0.14 0.12 0.06"/>
-      <geom name="sst_marker" type="cylinder" size="0.18 0.35" pos="0 0 0.45"
-            rgba="0.10 0.75 0.30 1" contype="0" conaffinity="0" group="0"/>
-      <geom name="sst_marker_cap" type="sphere" size="0.22" pos="0 0 0.85"
-            rgba="0.20 0.90 0.40 1" contype="0" conaffinity="0" group="0"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" material="car_sst" class="tb3_visual"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" class="tb3_chassis_collision"/>
       <geom size="0.005" pos="-0.081 0 0.005" type="sphere" material="wheel"
@@ -225,10 +218,6 @@
       <inertial pos="-0.032 0 0.03" mass="0.9" diaginertia="0.005 0.005 0.003"/>
       <freejoint name="dummy_base_joint"/>
       <geom name="dummy_collision" class="agent_shell" pos="-0.032 0 0.12" size="0.14 0.12 0.06"/>
-      <geom name="dummy_marker" type="cylinder" size="0.18 0.35" pos="0 0 0.45"
-            rgba="0.55 0.56 0.58 0.90" contype="0" conaffinity="0" group="0"/>
-      <geom name="dummy_marker_cap" type="sphere" size="0.22" pos="0 0 0.85"
-            rgba="0.65 0.66 0.68 1" contype="0" conaffinity="0" group="0"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" material="car_dummy" class="tb3_visual"/>
       <geom pos="-0.032 0 0.01" mesh="burger_base" class="tb3_chassis_collision"/>
       <geom size="0.005" pos="-0.081 0 0.005" type="sphere" material="wheel"
@@ -286,5 +275,21 @@
     <exclude body1="car_sst" body2="sst_wheel_right"/>
     <exclude body1="car_dummy" body2="dummy_wheel_left"/>
     <exclude body1="car_dummy" body2="dummy_wheel_right"/>
+    <!-- Agent–agent pass-through (bodies + wheels; shell filter alone is not enough). -->
+    <exclude body1="car_rrt" body2="car_sst"/>
+    <exclude body1="car_rrt" body2="car_dummy"/>
+    <exclude body1="car_sst" body2="car_dummy"/>
+    <exclude body1="rrt_wheel_left" body2="sst_wheel_left"/>
+    <exclude body1="rrt_wheel_left" body2="sst_wheel_right"/>
+    <exclude body1="rrt_wheel_right" body2="sst_wheel_left"/>
+    <exclude body1="rrt_wheel_right" body2="sst_wheel_right"/>
+    <exclude body1="rrt_wheel_left" body2="dummy_wheel_left"/>
+    <exclude body1="rrt_wheel_left" body2="dummy_wheel_right"/>
+    <exclude body1="rrt_wheel_right" body2="dummy_wheel_left"/>
+    <exclude body1="rrt_wheel_right" body2="dummy_wheel_right"/>
+    <exclude body1="sst_wheel_left" body2="dummy_wheel_left"/>
+    <exclude body1="sst_wheel_left" body2="dummy_wheel_right"/>
+    <exclude body1="sst_wheel_right" body2="dummy_wheel_left"/>
+    <exclude body1="sst_wheel_right" body2="dummy_wheel_right"/>
   </contact>
 </mujoco>

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -254,6 +254,7 @@ class DubinsRaceSimulation:
                 lookahead_distance=self.vehicle_cfg.lookahead_distance,
                 occupancy=self.occupancy,
             )
+        # Concurrent race: blue / green / grey command + step in one physics tick.
         commands = np.array([*rrt_cmd, *sst_cmd, *dummy_cmd], dtype=np.float64)
         bridge.step_physics(commands)
         _sync_vehicle_pose(self.rrt_vehicle, bridge.get_rrt_pose())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dedicated PR for the Dubins warehouse race visuals/physics filters:

1. **Remove** the tall blue/green/grey cylinder+sphere beacons on the three TurtleBot3s.
2. **Confirm concurrent race** — RRT* (blue), SST (green), and dummy (grey) command and `mj_step` in the same physics tick.
3. **Disable agent–agent contacts** so robots pass through each other (still collide with shelves/floor).

## Regenerated showcase (marker-free)

Physics-mode, 1280×720, 30 fps, 75 s, `--no-tracking` — overview / follow / topdown:

<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_overview.mp4"><img src="https://cursor.com/artifacts/c/art-f3779e87-662c-4b35-80a9-add0a45c909c" alt="dubins_race_overview.mp4" /></a>
<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_follow.mp4"><img src="https://cursor.com/artifacts/c/art-7fbbb451-4ada-4286-b755-eb9f64e503e1" alt="dubins_race_follow.mp4" /></a>
<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_topdown.mp4"><img src="https://cursor.com/artifacts/c/art-b6ef1ed4-e25c-44be-bdc7-57bdf9fe62de" alt="dubins_race_topdown.mp4" /></a>

![Topdown start](https://cursor.com/artifacts/c/art-8f88e6f7-31aa-4f13-8d17-1c08871ddd94)
![Topdown mid](https://cursor.com/artifacts/c/art-33143152-36c7-4de9-ad91-0a198ce78685)
![Overview mid](https://cursor.com/artifacts/c/art-7faa57b6-18e4-432f-a96f-f03084b3f69c)
![Follow mid](https://cursor.com/artifacts/c/art-c39209a4-0fcc-4a57-9737-d1f5f60bb348)

## Proof (T1)

| Check | Result |
| --- | --- |
| Marker geoms in MJCF | `0` |
| Overlapped agents → agent–agent contacts | `0` |
| Physics showcase seed race | `both_reached_goal=True`, ~100.3 s |
| `tests/scenario/test_dubins_physics_showcase.py` | **3 passed** |
| `bash scripts/check/formatting.sh` | **PASSED** |
| Showcase MP4s | overview / follow / topdown each 2250 frames @ 30 fps |

## Answers

- **Dedicated PR to remove markers:** this PR.
- **Do blue/green/grey move at the same time?** Yes — one length-9 command vector per tick.
- **Robots do not collide with each other?** Yes — MJCF shell filter + body/wheel `<exclude>` pairs; structure + floor contacts kept.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

