### PR TITLE
2× TB3 race speed + longer Pure Pursuit lookahead

### DIFF
--- a/src/fret/config/controllers/dubins.yml
+++ b/src/fret/config/controllers/dubins.yml
@@ -1,12 +1,13 @@
-# Dubins vehicle + Pure Pursuit — real TurtleBot3 Burger speeds (Menagerie).
-# v_max ≈ ω_wheel_max * r = 6.67 rad/s * 0.033 m ≈ 0.22 m/s.
+# Dubins vehicle + Pure Pursuit — TurtleBot3 Burger race speeds.
+# Showcase runs at 2× nominal Menagerie (ω=13.34 rad/s → v≈0.44 m/s),
+# capped by the race MJCF wheel ctrlrange. Longer lookahead smooths weave.
 
 /**:
   ros__parameters:
-    max_speed: 0.22
+    max_speed: 0.44
     min_speed: 0.0
-    cruise_speed: 0.18
-    lookahead_distance: 0.50
+    cruise_speed: 0.36
+    lookahead_distance: 1.00
     goal_radius: 0.35
     max_turn_rate_deg: 140.0
     max_acceleration: 0.50

--- a/src/fret/config/simulation/mujoco_physics.yml
+++ b/src/fret/config/simulation/mujoco_physics.yml
@@ -1,7 +1,7 @@
 # MuJoCo physics SITL tables (v1.2) — loaded by Python only, not as ROS params.
 #
-# TurtleBot3 race agents: six wheel velocity actuators at Menagerie limits
-# (ctrl ±6.67 rad/s ≈ 0.22 m/s linear).
+# TurtleBot3 race agents: six wheel velocity actuators at 2× Menagerie
+# (ctrl ±13.34 rad/s ≈ 0.44 m/s linear) for clearer showcase motion.
 
 /**:
   ros__parameters:

--- a/src/fret/mjcf/dubins_race.xml
+++ b/src/fret/mjcf/dubins_race.xml
@@ -7,7 +7,7 @@
                 with AWS clutter mesh visuals (regenerate via
                 scripts/generate_dubins_race_mjcf.py).
     Agents: real-scale TurtleBot3 Burger (RRT* blue, SST green, dummy grey)
-            with Menagerie wheel actuators (±6.67 rad/s).
+            with 2× Menagerie wheel actuators (±13.34 rad/s ≈ 0.44 m/s).
     All three are stepped in the same physics tick (true concurrent race).
     Agent–agent contacts are disabled; shells still hit warehouse structures.
     Dummy Pure-Pursuits the straight start→goal line (showcase foil).
@@ -252,19 +252,19 @@
   </worldbody>
 
 <actuator>
-    <!-- Real Menagerie TB3 wheel rates: ±6.67 rad/s ≈ 0.22 m/s. -->
+    <!-- 2× Menagerie TB3 wheel rates: ±13.34 rad/s ≈ 0.44 m/s (showcase). -->
     <velocity name="rrt_wheel_left" joint="rrt_wheel_left" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
     <velocity name="rrt_wheel_right" joint="rrt_wheel_right" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
     <velocity name="sst_wheel_left" joint="sst_wheel_left" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
     <velocity name="sst_wheel_right" joint="sst_wheel_right" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
     <velocity name="dummy_wheel_left" joint="dummy_wheel_left" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
     <velocity name="dummy_wheel_right" joint="dummy_wheel_right" kv="0.2"
-              ctrlrange="-6.67 6.67" ctrllimited="true"/>
+              ctrlrange="-13.34 13.34" ctrllimited="true"/>
   </actuator>
 
 

--- a/src/fret/ros/mujoco_bridge.py
+++ b/src/fret/ros/mujoco_bridge.py
@@ -56,11 +56,12 @@ _DUBINS_BASE_JOINTS: tuple[str, str, str] = (
     _DUMMY_BASE_JOINT,
 )
 
-# Match TurtleBot3 Burger Menagerie geometry / actuator limits (real speed).
+# Match TurtleBot3 Burger Menagerie geometry; race SITL allows 2× nominal
+# Menagerie wheel rate so showcase cruise (0.36 m/s) is reachable.
 _AGENT_BASE_Z_M: float = 0.033
 _WHEEL_RADIUS_M: float = 0.033
 _TRACK_WIDTH_M: float = 0.16
-_WHEEL_CTRL_LIMIT_RAD_S: float = 6.67
+_WHEEL_CTRL_LIMIT_RAD_S: float = 13.34
 
 _DEFAULT_UPDATE_RATE_HZ: float = 50.0
 _DEFAULT_MJCF_TIMESTEP_S: float = 0.002


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Make the Dubins warehouse race move faster and track more smoothly:

- **Speed ×2** (showcase): cruise `0.18→0.36` m/s, max `0.22→0.44` m/s, race wheel `ctrlrange` / bridge clip `±6.67→±13.34` rad/s so the higher setpoints are reachable (capped at that raised actuator max).
- **Lookahead** `0.50→1.00` m for Pure Pursuit so the nose aims further along the path and weaves less.

## Why robots slow near obstacles (unchanged — for discussion)

Physics tracking in `_agent_physics_velocity_command` scales `(vx, vy)` when distance to the nearest obstacle is inside `3 × planning_clearance` (~0.9 m), down to a floor of **38%** of the commanded speed (`_PHYSICS_OBSTACLE_SPEED_FLOOR`). That is intentional cautious driving in tight corridors. Heading-error gating and repulsion can also cut forward speed in sharp corners. We can decide together whether to soften or remove the proximity scale.

## Proof (T1)

| Check | Result |
| --- | --- |
| Physics showcase seed | `both_reached_goal=True`, **42.7 s** (was ~100 s) |
| Mean speed while moving | ~0.28 m/s |
| `tests/scenario/test_dubins_physics_showcase.py` | **3 passed** |
| `bash scripts/check/formatting.sh` | **PASSED** |
| Showcase MP4s | full race ~42.6 s, 1280×720 @ 30 fps |

<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_overview.mp4"><img src="https://cursor.com/artifacts/c/art-ad13b508-b7d6-4516-a99f-4783d8c96f50" alt="dubins_race_overview.mp4" /></a>
<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_follow.mp4"><img src="https://cursor.com/artifacts/c/art-28d2f886-7ea9-431e-9b43-c334e74f2654" alt="dubins_race_follow.mp4" /></a>
<a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdubins_showcase%2Fdubins_race_topdown.mp4"><img src="https://cursor.com/artifacts/c/art-c558b894-ddab-43c1-a182-9fc2cb5fa57d" alt="dubins_race_topdown.mp4" /></a>

![Topdown mid](https://cursor.com/artifacts/c/art-33143152-36c7-4de9-ad91-0a198ce78685)
![Overview mid](https://cursor.com/artifacts/c/art-7faa57b6-18e4-432f-a96f-f03084b3f69c)
![Follow mid](https://cursor.com/artifacts/c/art-c39209a4-0fcc-4a57-9737-d1f5f60bb348)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8f9060b-44a9-49c9-b7ae-ce953bd7e4a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

