### PR TITLE
feat(release): OM-X Γ-maze RRT* vs SST overview videos

### DIFF
--- a/docs/mujoco.md
+++ b/docs/mujoco.md
@@ -245,6 +245,9 @@ Static / tabletop arms export `overview` only. Extra MJCF cameras (`topdown`,
 `finish`, …) remain available via explicit `--camera` but are not release
 artifacts.
 
+OM-X release focus is SC-v13d Γ-wall maze with two planner variants
+(`omx_wall_maze_rrt`, `omx_wall_maze_sst`) and the same JointPathMPC tracking.
+
 Release CI: `scripts/release/render_showcase.py` (matrix over the manifest).
 
 ### Showcase rendering (real-time playback)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -215,7 +215,7 @@ gripper (~3 cm aperture).
 | V13-1 | Empty-cell A→B reaches goal under MuJoCo physics SITL (EE error ≤ 5 mm) |
 | V13-2 | Pick-and-place FSM moves a free ball from green pedestal into the red place cone without drop mid-transfer |
 | V13-3 | Cluttered cell plans a collision-free detour (not a straight joint-space line) |
-| V13-4 | Showcase video: isometric **overview** only (static arm — no follow) |
+| V13-4 | Showcase videos: Γ-maze isometric **overview** for RRT* and SST (same MPC tracking; no follow) |
 | V13-5 | Robot from Menagerie; pick object is a plain MuJoCo ball; place is a cone funnel |
 | V13-6 | Γ-wall maze path retracts and climbs over the cap before placing |
 
@@ -316,7 +316,12 @@ Canonical matrix: [`src/fret/config/release/showcase.yml`](../src/fret/config/re
 | Robot class | Scenarios (today) | Required cameras |
 |---|---|---|
 | **mobile** | `dubins_race` (TB3); future mobile robots | `overview` (isometric) **and** `follow` (split-screen chase) |
-| **static** | `omx_reach`, `omx_pick_place`, `omx_desk_clutter`, `omx_wall_maze` | `overview` only |
+| **static** | SC-v13d Γ-maze only: `omx_wall_maze_rrt` + `omx_wall_maze_sst` | `overview` only |
+
+OM-X release clips share the same Γ-wall geometry and JointPathMPC / joint
+control tracking; they differ only in the transfer planner (**RRT\*** vs
+**SST**). Simpler OM-X demos (`omx_reach`, pick-place, desk clutter) stay in
+the repo for development but are not release artifacts.
 
 **Rules:**
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -94,10 +94,10 @@ GitHub Actions artifact backup. Camera policy (see
 | Scenario | Model | Class | Cameras |
 |---|---|---|---|
 | `dubins_race` | Dubins / TB3 | mobile | `overview` + split-screen `follow` |
-| `omx_reach` | OpenMANIPULATOR-X | static | `overview` |
-| `omx_pick_place` | OpenMANIPULATOR-X | static | `overview` |
-| `omx_desk_clutter` | OpenMANIPULATOR-X | static | `overview` |
-| `omx_wall_maze` | OpenMANIPULATOR-X | static | `overview` |
+| `omx_wall_maze_rrt` | OpenMANIPULATOR-X (Γ maze, RRT*) | static | `overview` |
+| `omx_wall_maze_sst` | OpenMANIPULATOR-X (Γ maze, SST) | static | `overview` |
+
+Same maze + MPC tracking for both OM-X clips; only the transfer planner changes.
 
 ### Download from R2 (WSL-friendly — no MuJoCo rendering needed)
 
@@ -110,7 +110,8 @@ sudo apt install awscli # if needed
 ./scripts/download_showcase.sh
 ./scripts/download_showcase.sh --tag v1.2.3 --all
 ./scripts/download_showcase.sh --scenario dubins_race --camera follow
-./scripts/download_showcase.sh --scenario omx_wall_maze --camera overview
+./scripts/download_showcase.sh --scenario omx_wall_maze_rrt --camera overview
+./scripts/download_showcase.sh --scenario omx_wall_maze_sst --camera overview
 ```
 
 Default output: `artifacts/r2/dubins_race_latest.mp4` (also gitignored).

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -53,8 +53,20 @@ _OMX_DESK_CLUTTER_SCENARIOS: frozenset[str] = frozenset(
     {"omx_desk_clutter", "desk_clutter"}
 )
 _OMX_WALL_MAZE_SCENARIOS: frozenset[str] = frozenset(
-    {"omx_wall_maze", "wall_maze"}
+    {
+        "omx_wall_maze",
+        "wall_maze",
+        # Release planner variants (same Γ maze, RRT* vs SST transfer plan).
+        "omx_wall_maze_rrt",
+        "omx_wall_maze_sst",
+    }
 )
+_OMX_WALL_MAZE_SCENARIO_YAML: dict[str, str] = {
+    "omx_wall_maze": "omx_wall_maze.yml",
+    "wall_maze": "omx_wall_maze.yml",
+    "omx_wall_maze_rrt": "omx_wall_maze_rrt.yml",
+    "omx_wall_maze_sst": "omx_wall_maze_sst.yml",
+}
 _OMX_CLUTTER_SCENARIOS: frozenset[str] = (
     _OMX_DESK_CLUTTER_SCENARIOS | _OMX_WALL_MAZE_SCENARIOS
 )
@@ -1073,8 +1085,7 @@ def render_omx_desk_clutter_showcase_videos(
     scenario_yaml = {
         "omx_desk_clutter": "omx_desk_clutter.yml",
         "desk_clutter": "omx_desk_clutter.yml",
-        "omx_wall_maze": "omx_wall_maze.yml",
-        "wall_maze": "omx_wall_maze.yml",
+        **_OMX_WALL_MAZE_SCENARIO_YAML,
     }.get(scenario, "omx_desk_clutter.yml")
     scenario_path = Path("src/fret/config/scenarios") / scenario_yaml
     model_probe = mujoco.MjModel.from_xml_path(str(mjcf_path))
@@ -1439,10 +1450,12 @@ def render_showcase_videos(
         )
     if scenario in _OMX_WALL_MAZE_SCENARIOS:
         _ = physics_mode
+        # Keep showcase id (…_rrt / …_sst) so output MP4 names distinguish
+        # planner variants; YAML still sets scenario_id=omx_wall_maze.
         return render_omx_desk_clutter_showcase_videos(
             mjcf_path,
             output_dir,
-            scenario="omx_wall_maze",
+            scenario=scenario,
             cameras=cameras,
             output_names=output_names,
             duration_s=duration_s,

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -6,6 +6,9 @@
 #   * follow   — required for mobile robots only (split-screen chase).
 #     Static/tabletop arms must NOT export follow on release.
 #
+# OM-X release focus: SC-v13d Γ-wall maze only, twice — RRT* vs SST transfer
+# planning, same JointPathMPC / joint-control tracking pipeline.
+#
 # Regenerate clips via scripts/release/render_showcase.py or release.yml.
 
 fps: 30
@@ -23,42 +26,22 @@ scenarios:
     timing_file: dubins_race_timing.json
     primary_video: dubins_race_overview.mp4
 
-  - id: omx_reach
+  - id: omx_wall_maze_rrt
     model: open_manipulator_x
     robot_class: static
     cameras: [overview]
     physics_mode: false
     planner_algorithm: rrt_star
     collision_backend: mujoco
-    timing_file: omx_reach_timing.json
-    primary_video: omx_reach_overview.mp4
+    timing_file: omx_wall_maze_rrt_timing.json
+    primary_video: omx_wall_maze_rrt_overview.mp4
 
-  - id: omx_pick_place
+  - id: omx_wall_maze_sst
     model: open_manipulator_x
     robot_class: static
     cameras: [overview]
     physics_mode: false
-    planner_algorithm: rrt_star
+    planner_algorithm: sst
     collision_backend: mujoco
-    timing_file: omx_pick_place_timing.json
-    primary_video: omx_pick_place_overview.mp4
-
-  - id: omx_desk_clutter
-    model: open_manipulator_x
-    robot_class: static
-    cameras: [overview]
-    physics_mode: false
-    planner_algorithm: rrt_star
-    collision_backend: mujoco
-    timing_file: omx_desk_clutter_timing.json
-    primary_video: omx_desk_clutter_overview.mp4
-
-  - id: omx_wall_maze
-    model: open_manipulator_x
-    robot_class: static
-    cameras: [overview]
-    physics_mode: false
-    planner_algorithm: rrt_star
-    collision_backend: mujoco
-    timing_file: omx_wall_maze_timing.json
-    primary_video: omx_wall_maze_overview.mp4
+    timing_file: omx_wall_maze_sst_timing.json
+    primary_video: omx_wall_maze_sst_overview.mp4

--- a/src/fret/config/scenarios/omx_wall_maze_rrt.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_rrt.yml
@@ -1,19 +1,14 @@
-# SC-v13d — OpenMANIPULATOR-X Γ-wall maze (back out → climb → place).
+# SC-v13d release variant — Γ-wall maze planned with ARCO RRT*.
 #
-# Same ball / pick pedestal / place cone as SC-v13b/c, plus an inverted-L
-# (letter Γ) obstacle: vertical stem + horizontal roof overhang toward the
-# pick ball (negative Y / "telhadinho"), so lift-and-fly over the stem is
-# blocked and the arm must back out first.
-#
-# Release showcases use planner variants:
-#   omx_wall_maze_rrt.yml  (ARCO RRT*)
-#   omx_wall_maze_sst.yml  (ARCO SST)
-# Both share this geometry and the same JointPathMPC tracking pipeline.
+# Same geometry / FSM / MPC tracking as omx_wall_maze.yml; only the transfer
+# planner differs. Internal scenario_id stays omx_wall_maze so MJCF + maze
+# rate limits resolve correctly.
 
 /**:
   ros__parameters:
     model: open_manipulator_x
     scenario_id: omx_wall_maze
+    showcase_id: omx_wall_maze_rrt
     simulation_dt: 0.02
     duration: 70.0
     planning_timeout: 30.0
@@ -27,9 +22,8 @@
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
     planner_algorithm: rrt_star
-    # Pinned under deterministic_planner_rng (mesh-clear retract+climb).
+    # Pinned under deterministic_planner_rng for mesh-clear retract+climb.
     planner_rng_seed: 204
-    # Stem (mid-cell) + roof overhang toward pick (asymmetric y).
     walls:
       - x_min: 0.25
         x_max: 0.34
@@ -44,14 +38,11 @@
         z_max: 0.265
     wall_inflate_m: 0.025
     occupancy_density: 1200.0
-    # Back-out under the pick-side roof (not a short hover chord).
     max_transfer_radius_m: 0.16
     min_transfer_ee_z_m: 0.145
     min_transfer_peak_ee_z_m: 0.21
     lift_height_m: 0.14
     phase_timeout_s: 60.0
-    # Start folded at center (approach under the roof); retreat on place side
-    # so Joint1 need not drive back through the stem after place.
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
     pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]

--- a/src/fret/config/scenarios/omx_wall_maze_sst.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_sst.yml
@@ -1,19 +1,14 @@
-# SC-v13d — OpenMANIPULATOR-X Γ-wall maze (back out → climb → place).
+# SC-v13d release variant — Γ-wall maze planned with ARCO SST.
 #
-# Same ball / pick pedestal / place cone as SC-v13b/c, plus an inverted-L
-# (letter Γ) obstacle: vertical stem + horizontal roof overhang toward the
-# pick ball (negative Y / "telhadinho"), so lift-and-fly over the stem is
-# blocked and the arm must back out first.
-#
-# Release showcases use planner variants:
-#   omx_wall_maze_rrt.yml  (ARCO RRT*)
-#   omx_wall_maze_sst.yml  (ARCO SST)
-# Both share this geometry and the same JointPathMPC tracking pipeline.
+# Same geometry / FSM / MPC tracking as omx_wall_maze.yml; only the transfer
+# planner differs. Internal scenario_id stays omx_wall_maze so MJCF + maze
+# rate limits resolve correctly.
 
 /**:
   ros__parameters:
     model: open_manipulator_x
     scenario_id: omx_wall_maze
+    showcase_id: omx_wall_maze_sst
     simulation_dt: 0.02
     duration: 70.0
     planning_timeout: 30.0
@@ -26,10 +21,9 @@
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
-    planner_algorithm: rrt_star
-    # Pinned under deterministic_planner_rng (mesh-clear retract+climb).
-    planner_rng_seed: 204
-    # Stem (mid-cell) + roof overhang toward pick (asymmetric y).
+    planner_algorithm: sst
+    # Pinned under deterministic_planner_rng for mesh-clear retract+climb.
+    planner_rng_seed: 7
     walls:
       - x_min: 0.25
         x_max: 0.34
@@ -44,14 +38,11 @@
         z_max: 0.265
     wall_inflate_m: 0.025
     occupancy_density: 1200.0
-    # Back-out under the pick-side roof (not a short hover chord).
     max_transfer_radius_m: 0.16
     min_transfer_ee_z_m: 0.145
     min_transfer_peak_ee_z_m: 0.21
     lift_height_m: 0.14
     phase_timeout_s: 60.0
-    # Start folded at center (approach under the roof); retreat on place side
-    # so Joint1 need not drive back through the stem after place.
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
     pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]

--- a/src/fret/control/pick_place_clutter_sim.py
+++ b/src/fret/control/pick_place_clutter_sim.py
@@ -338,6 +338,8 @@ def plan_transfer_path(
         for a in alphas
     )
 
+    from fret.scenario.planner_rng import deterministic_planner_rng
+
     last_err: str | None = None
     # Γ maze needs more RNG draws: roof overhang + mesh-clear reject many.
     attempt_budget = 60 if peak_z > 0.0 else 24
@@ -357,14 +359,17 @@ def plan_transfer_path(
             planner_algorithm=algo,  # type: ignore[arg-type]
             scenario=scenario_id,
         )
-        result = planner.plan(
-            PlanningRequest(
-                start_configuration=np.asarray(start, dtype=np.float64),
-                goal_configuration=np.asarray(goal, dtype=np.float64),
-                planning_timeout=timeout,
-                scenario_id=scenario_id,
+        # ARCO RRT*/SST call unseeded default_rng(); pin so planner variants
+        # (and release showcase seeds) are reproducible.
+        with deterministic_planner_rng(seed):
+            result = planner.plan(
+                PlanningRequest(
+                    start_configuration=np.asarray(start, dtype=np.float64),
+                    goal_configuration=np.asarray(goal, dtype=np.float64),
+                    planning_timeout=timeout,
+                    scenario_id=scenario_id,
+                )
             )
-        )
         if result.status != PlanningStatus.SUCCESS or len(result.path) < 2:
             last_err = (
                 f"status={result.status.name} code={result.error_code.name}"

--- a/tests/release/test_showcase_manifest.py
+++ b/tests/release/test_showcase_manifest.py
@@ -14,19 +14,27 @@ from showcase_manifest import (  # noqa: E402
 )
 
 
-def test_manifest_loads_all_product_scenarios() -> None:
+def test_manifest_loads_release_focus_scenarios() -> None:
     manifest = load_showcase_manifest()
     ids = {item.id for item in manifest.scenarios}
     assert ids == {
         "dubins_race",
-        "omx_reach",
-        "omx_pick_place",
-        "omx_desk_clutter",
-        "omx_wall_maze",
+        "omx_wall_maze_rrt",
+        "omx_wall_maze_sst",
     }
     assert manifest.fps == 30
     assert manifest.width == 1280
     assert manifest.height == 720
+
+
+def test_omx_release_variants_differ_only_by_planner() -> None:
+    manifest = load_showcase_manifest()
+    rrt = manifest.by_id("omx_wall_maze_rrt")
+    sst = manifest.by_id("omx_wall_maze_sst")
+    assert rrt.robot_class == sst.robot_class == "static"
+    assert rrt.cameras == sst.cameras == ("overview",)
+    assert rrt.planner_algorithm == "rrt_star"
+    assert sst.planner_algorithm == "sst"
 
 
 def test_mobile_requires_follow_static_overview_only() -> None:

--- a/tests/release/test_write_showcase_meta.py
+++ b/tests/release/test_write_showcase_meta.py
@@ -31,10 +31,8 @@ def test_write_showcase_meta_all_scenarios(tmp_path: Path) -> None:
     clips: list[tuple[str, str, str]] = [
         ("dubins_race", "overview", "dubins_race_timing.json"),
         ("dubins_race", "follow", "dubins_race_timing.json"),
-        ("omx_reach", "overview", "omx_reach_timing.json"),
-        ("omx_pick_place", "overview", "omx_pick_place_timing.json"),
-        ("omx_desk_clutter", "overview", "omx_desk_clutter_timing.json"),
-        ("omx_wall_maze", "overview", "omx_wall_maze_timing.json"),
+        ("omx_wall_maze_rrt", "overview", "omx_wall_maze_rrt_timing.json"),
+        ("omx_wall_maze_sst", "overview", "omx_wall_maze_sst_timing.json"),
     ]
     timing_by_file: dict[str, list[dict[str, object]]] = {}
     for scenario, camera, timing_name in clips:
@@ -61,14 +59,17 @@ def test_write_showcase_meta_all_scenarios(tmp_path: Path) -> None:
 
     assert meta["git_ref"] == "v1.2.3"
     assert meta["partial"] is False
-    assert len(meta["showcases"]) == 5
+    assert len(meta["showcases"]) == 3
     assert meta["release_cameras"] == {
         "mobile": ["overview", "follow"],
         "static": ["overview"],
     }
     assert meta["primary_videos"]["dubins_race"] == "dubins_race_overview.mp4"
-    assert meta["primary_videos"]["omx_wall_maze"] == (
-        "omx_wall_maze_overview.mp4"
+    assert meta["primary_videos"]["omx_wall_maze_rrt"] == (
+        "omx_wall_maze_rrt_overview.mp4"
+    )
+    assert meta["primary_videos"]["omx_wall_maze_sst"] == (
+        "omx_wall_maze_sst_overview.mp4"
     )
     assert (tmp_path / "meta.json").is_file()
 

--- a/tests/simulation/test_render_mujoco.py
+++ b/tests/simulation/test_render_mujoco.py
@@ -64,7 +64,20 @@ def test_robot_class_release_camera_policy() -> None:
         "overview",
         "follow",
     )
-    assert rm.release_cameras_for_scenario("omx_wall_maze") == ("overview",)
+    assert rm.release_cameras_for_scenario("omx_wall_maze_rrt") == (
+        "overview",
+    )
+    assert rm.release_cameras_for_scenario("omx_wall_maze_sst") == (
+        "overview",
+    )
+
+
+def test_resolve_mjcf_omx_wall_maze_planner_variants() -> None:
+    for scenario in ("omx_wall_maze_rrt", "omx_wall_maze_sst"):
+        path = rm.resolve_mjcf_path("open_manipulator_x", scenario, None)
+        assert path.is_file()
+        cameras = rm.list_showcase_cameras(path, scenario=scenario)
+        assert cameras == ["overview"]
 
 
 def test_dubins_race_mjcf_loads() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release OM-X focus is now only the hardest case — SC-v13d Γ-wall maze — rendered **twice**:

| Scenario | Planner | Tracking |
|---|---|---|
| `omx_wall_maze_rrt` | ARCO **RRT\*** | same JointPathMPC + joint control |
| `omx_wall_maze_sst` | ARCO **SST** | same JointPathMPC + joint control |

Release matrix: `dubins_race` (overview + follow) + those two OM-X overviews. Simpler OM-X demos stay in-tree but are not release artifacts.

Also pins ARCO planner RNG in transfer planning so release seeds are reproducible.

## Proof

| Check | Result |
| --- | --- |
| Local `render_showcase.py` for both maze variants | **OK** (~13 s clips, ~76 s wall) |
| `pytest` release + render + wall_maze | **27 passed** |
| PR CI (Tests / Formatting / Type Check) | **green** |

Artifacts: `/opt/cursor/artifacts/release_maze_planners/omx_wall_maze_{rrt,sst}_overview.mp4`

## Test plan
- [x] Unit / maze tests
- [x] Local dual overview renders
- [x] PR CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7ec4618-ac9f-413b-aedf-45acb9215f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7ec4618-ac9f-413b-aedf-45acb9215f8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

