### PR TITLE
chore(release): bump Python package to 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ renders use `--physics-mode` by default for mobile scenarios.
 The Dubins showcase ships with headless render scripts, pure-Python E2E tests (no ROS
 required for CI validation), and optional ROS 2 SITL launch files.
 
-**Coming next:** 6-DOF Menagerie arm challenge (v1.2.4), then hardware HITL (v1.3).
-See [docs/roadmap.md](docs/roadmap.md) and [docs/releases.md](docs/releases.md).
+**Coming next:** tag **v1.2.4** (6-DOF Menagerie OMY showcase), then **v1.3** hardware
+HITL — last milestone before computer vision. Python package on `main` is already
+**1.3.0** for that development line. See [docs/roadmap.md](docs/roadmap.md) and
+[docs/releases.md](docs/releases.md).
 
 ---
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -287,7 +287,8 @@ and trajectory execution in a cluttered environment — the simulation capstone 
 
 Close the loop from FRET's ROS 2 stack to a **physical prototype**: Raspberry Pi 5 high-level
 control, Arduino Mega low-level actuation, Micro-ROS serial bridge, and encoder feedback.
-Ships after simulation milestones (v1.2.4) are debugged and stable.
+Ships after simulation milestones (v1.2.4) are debugged and stable. This is the **last
+product milestone before computer vision** (vision / dynamic replanning stay post-v1.3).
 
 ### Scope (high level)
 
@@ -318,9 +319,13 @@ Ships after simulation milestones (v1.2.4) are debugged and stable.
 | `v1.1.0` | Dubins dual race — **first product showcase** | T11-* |
 | `v1.1.x` | Physics-bridge iterations (v1.1 → v1.2); no new robots | See [§ v1.1.x retrospective](#v11x--v12-retrospective) below |
 | `v1.2.0` | MuJoCo physics SITL (Dubins) | T12-* ✅ |
-| `v1.2.3` | OpenMANIPULATOR-X tabletop showcase (mobile + OM-X videos) — **current** | T123-* ✅ |
-| `v1.2.4` | 6-DOF challenge | T124-* |
-| `v1.3.0` | Hardware HITL | T13-* |
+| `v1.2.3` | OpenMANIPULATOR-X tabletop showcase (mobile + OM-X videos) | T123-* ✅ |
+| `v1.2.4` | 6-DOF challenge (OMY) — **next product tag** | T124-* |
+| `v1.3.0` | Hardware HITL (last milestone before vision) | T13-* |
+
+Python package version in `pyproject.toml` is **1.3.0** once the post-v1.2.4
+development line opens (HITL). Product showcase tags remain `v1.2.4` then
+`v1.3.0`; vision work stays post-v1.3 (see [roadmap.md](roadmap.md)).
 
 ### v1.1.x → v1.2.0 retrospective
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fret"
-version = "1.2.3"
+version = "1.3.0"
 description = "Full-stack Robotic Effector Trajectories Framework"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
After the v1.2.4 OMY showcase, development should track the v1.3 HITL line (last milestone before computer vision). The Python package was still `1.2.3`.

## Fix
- `pyproject.toml`: `1.2.3` → `1.3.0`
- README / `docs/releases.md`: clarify product tag **v1.2.4** (OMY) vs package **1.3.0** (post-1.2.4 / HITL), vision stays post-v1.3

## Verification
- `bash scripts/check/formatting.sh` — pass
- `bash scripts/check/types.sh` — pass

## Note for maintainer
Merge **#116** first, tag **`v1.2.4`**, then land this bump (or merge after the tag) so the showcase tag is not confused with package `1.3.0` if you prefer matching SemVer at tag time. If you want the tag commit itself to carry `1.2.4` in `pyproject.toml`, say so and we can split the bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48bbf5e6-d25c-4869-aa69-c85c2b8a50f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48bbf5e6-d25c-4869-aa69-c85c2b8a50f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

