### PR TITLE
fix(release): repair OMY clutter detour for v1.2.5 showcase

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -321,11 +321,12 @@ product milestone before computer vision** (vision / dynamic replanning stay pos
 | `v1.2.0` | MuJoCo physics SITL (Dubins) | T12-* ✅ |
 | `v1.2.3` | OpenMANIPULATOR-X tabletop showcase (mobile + OM-X videos) | T123-* ✅ |
 | `v1.2.4` | 6-DOF challenge (OMY) — **next product tag** | T124-* |
+| `v1.2.5` | Patch: OMY clutter showcase detour (failed `v1.2.4` release CI) | T124-* |
 | `v1.3.0` | Hardware HITL (last milestone before vision) | T13-* |
 
 Python package version in `pyproject.toml` is **1.3.0** once the post-v1.2.4
-development line opens (HITL). Product showcase tags remain `v1.2.4` then
-`v1.3.0`; vision work stays post-v1.3 (see [roadmap.md](roadmap.md)).
+development line opens (HITL). Product showcase tags remain `v1.2.4`, patch
+`v1.2.5`, then `v1.3.0`; vision work stays post-v1.3 (see [roadmap.md](roadmap.md)).
 
 ### v1.1.x → v1.2.0 retrospective
 

--- a/src/fret/config/scenarios/omy_clutter.yml
+++ b/src/fret/config/scenarios/omy_clutter.yml
@@ -35,7 +35,7 @@
     place_hover_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
     place_grasp_configuration: [0.7097, 0.4824, 1.2992, -0.4434, 1.8866, -2.1730]
     retreat_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
-    transfer_detour_configuration: [-0.0027, 0.5722, 0.9689, -0.6246, 2.1629, 0.6124]
+    transfer_detour_configuration: [-0.3867, -0.3588, 0.817, -1.3093, 1.3634, -2.012]
     pick_xy: [0.40, -0.28]
     place_xy: [0.40, 0.28]
     walls:

--- a/src/fret/config/scenarios/omy_clutter_rrt.yml
+++ b/src/fret/config/scenarios/omy_clutter_rrt.yml
@@ -35,7 +35,7 @@
     place_hover_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
     place_grasp_configuration: [0.7097, 0.4824, 1.2992, -0.4434, 1.8866, -2.1730]
     retreat_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
-    transfer_detour_configuration: [-0.0027, 0.5722, 0.9689, -0.6246, 2.1629, 0.6124]
+    transfer_detour_configuration: [-0.3867, -0.3588, 0.817, -1.3093, 1.3634, -2.012]
     pick_xy: [0.40, -0.28]
     place_xy: [0.40, 0.28]
     walls:

--- a/src/fret/config/scenarios/omy_clutter_sst.yml
+++ b/src/fret/config/scenarios/omy_clutter_sst.yml
@@ -35,7 +35,7 @@
     place_hover_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
     place_grasp_configuration: [0.7097, 0.4824, 1.2992, -0.4434, 1.8866, -2.1730]
     retreat_configuration: [0.6358, 0.3743, 1.4507, -0.7379, 2.0765, -2.3714]
-    transfer_detour_configuration: [-0.0027, 0.5722, 0.9689, -0.6246, 2.1629, 0.6124]
+    transfer_detour_configuration: [-0.3867, -0.3588, 0.817, -1.3093, 1.3634, -2.012]
     pick_xy: [0.40, -0.28]
     place_xy: [0.40, 0.28]
     walls:

--- a/tests/control/test_kinematics_open_manipulator_y.py
+++ b/tests/control/test_kinematics_open_manipulator_y.py
@@ -94,6 +94,39 @@ def test_omy_pick_place_physics_smoke() -> None:
     assert float(np.linalg.norm(box_pos[:2] - place_xy)) < 0.08
 
 
+def test_omy_clutter_transfer_detour_is_collision_free() -> None:
+    """Release detour must clear the mid-cell wall (v1.2.5 regression)."""
+    from fret.control.pick_place_planning import walls_from_scenario
+    from fret.control.pick_place_sim import waypoints_from_scenario
+    from fret.planning.cspace_checker import make_cspace_checker
+    from fret.scene.occupancy_adapter import OccupancyAdapter
+    from fret.interfaces import OccupancyUpdatePayload
+
+    params = load_scenario_parameters(_CLUTTER)
+    wp = waypoints_from_scenario(_CLUTTER)
+    mid = np.asarray(params["transfer_detour_configuration"], dtype=np.float64)
+    detour = [wp.lift_hover, mid, wp.place_hover]
+
+    walls = walls_from_scenario(_CLUTTER, inflate=False)
+    kin = Kinematics("omy")
+    rng = np.random.default_rng(int(params.get("planner_rng_seed", 3)))
+    from fret.control.pick_place_planning import _sample_walls
+
+    pts = _sample_walls(walls, float(params["occupancy_density"]), rng)
+    adapter = OccupancyAdapter()
+    adapter.update(
+        OccupancyUpdatePayload(
+            obstacle_points=pts, timestamp=0.0, frame_id="world"
+        )
+    )
+    checker = make_cspace_checker(kin, adapter.get_occupancy())
+    for i, q in enumerate(detour):
+        assert checker.is_collision_free(q), f"detour waypoint {i} collides"
+    for i in range(len(detour) - 1):
+        edge_mid = 0.5 * (detour[i] + detour[i + 1])
+        assert checker.is_collision_free(edge_mid), f"detour segment {i} collides"
+
+
 @pytest.mark.slow
 def test_omy_clutter_pick_place_smoke() -> None:
     from fret.control.omy_clutter_sim import run_omy_clutter_pick_place


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

[v1.2.4 release workflow #99](https://github.com/alexandrelheinen/fret/actions/runs/29704577973) failed on the two OMY clutter showcase jobs:

- `render (omy_clutter_rrt)` — exit code 1
- `render (omy_clutter_sst)` — exit code 1

Four other scenarios rendered and uploaded successfully (`dubins_race`, `omx_wall_maze_*`, `omy_pick_place`). The publish step never ran.

Root cause: `transfer_detour_configuration` in the OMY clutter YAMLs no longer clears the mid-cell wall after the pad-mid carry geometry retune (commit `c7b5af9`). Segment 1 midpoint (`lift_hover → detour → place_hover`) collides, so `plan_arm_transfer_path` exhausts retries with `NO_PATH_FOUND` and `render_omy_clutter_showcase_videos` raises because the FSM never reaches `DONE`.

## Fix

Retune `transfer_detour_configuration` in:

- `omy_clutter.yml`
- `omy_clutter_rrt.yml`
- `omy_clutter_sst.yml`

Add `test_omy_clutter_transfer_detour_is_collision_free` to catch this before the next tag. Document `v1.2.5` as the patch tag in `docs/releases.md`.

## Verification

| Command | Result |
| --- | --- |
| `pytest tests/control/test_kinematics_open_manipulator_y.py::test_omy_clutter_transfer_detour_is_collision_free` | PASS |
| `pytest tests/control/test_kinematics_open_manipulator_y.py::test_omy_clutter_pick_place_smoke` | PASS |
| `simulate_omy_clutter_pick_place` for `omy_clutter_rrt.yml` / `omy_clutter_sst.yml` | both `DONE` |
| `python3 scripts/release/render_showcase.py --scenario omy_clutter_rrt` | wrote `omy_clutter_rrt_overview.mp4` (12 s, rtf=1.0) |
| `bash scripts/check/formatting.sh` | PASS |
| `bash scripts/check/types.sh` | PASS |

## After merge

Tag **`v1.2.5`** on the merge commit to re-run `release.yml` and publish the full six-scenario showcase set.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b88d6fc-0d1e-4498-b510-a61c9c07bb57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b88d6fc-0d1e-4498-b510-a61c9c07bb57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

