### PR TITLE
Adapt Dubins race MPC to ARCO progress-first contouring (arco#147)

### DIFF
--- a/docs/arco.md
+++ b/docs/arco.md
@@ -34,7 +34,7 @@ Bootstrap arm (MS-1–5) also uses `KDTreeOccupancy`, `SSTPlanner`, and
 |---|---|
 | Occupancy (`KDTreeOccupancy`) | ARCO |
 | Planner (SST, RRT*) | ARCO |
-| Dubins vehicle + path-following MPC | ARCO (≥ v0.3.2) |
+| Dubins vehicle + path-following MPC | ARCO (≥ v0.3.2; progress-first contouring via arco#147 on main) |
 | Joint-space MPC (OMX pick-and-place) | ARCO (≥ v0.3.2) |
 | Scene acquisition, TF | FRET |
 | Per-robot kinematics | FRET |
@@ -86,6 +86,29 @@ Reuse ARCO race infrastructure:
 - `DubinsVehicle` + `DubinsPathFollowingMPC` for RRT*/SST execution
   (grey foil retains Pure Pursuit)
 - Extend environment with 3-D columns (MuJoCo visual)
+
+### Progress-first contouring (arco#147)
+
+Global planners ignore vehicle dynamics, so forcing the online MPC to
+zero-fit their polylines stalls / orbits at sharp kinks. FRET’s Dubins
+race trackers therefore consume ARCO’s progress-first fields:
+
+| YAML key (`dubins.yml` → `mpc`) | ARCO config field | Role |
+|---|---|---|
+| `weight_lag` | `weight_lag` | Penalty on lagging `s0 + v_cruise·t` |
+| `contour_deadzone` | `contour_deadzone` | Free lateral band (m); contour cost on `(|e_lat| − deadzone)_+²` |
+
+Wired in `fret.scenario.dubins_race_runner._mpc_config` via
+`PathFollowingMPCConfig.with_weight_overrides(...)`. Race agents keep
+`occupancy=None` (planner owns avoidance).
+
+**Lab scale, not city scale.** ARCO city demos use ~8 m deadzone / 14 m/s
+cruise; FRET’s warehouse aisles are ≈1.6 m with TurtleBot half-size
+≈0.09 m and cruise ≈0.36 m/s, so `dubins.yml` uses
+`contour_deadzone: 0.10` m and softer contour/heading weights. Setting
+`contour_deadzone: 0` restores classic contouring. Always-on ARCO
+behavior even at zero lag/deadzone: no reverse progress
+(`ṡ = v · max(cos e_ψ, 0)`) and geometric projection never rewinds `s`.
 
 ---
 

--- a/docs/modules/control.md
+++ b/docs/modules/control.md
@@ -116,7 +116,13 @@ rate_hz: 50.0
 ```
 
 Dubins MPC / vehicle limits live in `src/fret/config/controllers/dubins.yml`.
-OMX joint-space MPC helpers live in `src/fret/control/joint_mpc.py`.
+RRT*/SST agents use ARCO `DubinsPathFollowingMPC` with progress-first
+weights (`weight_lag`, `contour_deadzone`) loaded by
+`fret.scenario.dubins_race_runner._mpc_config`. The free lateral band is
+lab-scaled (~chassis half-width), not ARCO city meters — see
+[arco.md](../arco.md#progress-first-contouring-arco147).
+OMX joint-space MPC helpers live in `src/fret/control/joint_mpc.py`
+(unaffected by progress-first contouring).
 
 ---
 

--- a/docs/robots/dubins.md
+++ b/docs/robots/dubins.md
@@ -36,11 +36,13 @@ Uses ARCO directly:
 | Grey foil tracker | `arco.control.pure_pursuit.PurePursuitController` |
 
 RRT*/SST plan in 2D against warehouse occupancy (topological corridor).
-They then track that polyline with path-following MPC (contour + heading +
-cruise). Track-time occupancy barriers stay off so the MPC does not
-re-throttle on already-cleared corridors; avoidance remains a planner
-responsibility. The grey dummy stays on Pure Pursuit with no repulsion so
-it collides on the naive diagonal.
+They then track that polyline with **progress-first** path-following MPC
+(ARCO arco#147): lag weight + lab-scaled contour deadzone (~0.10 m)
+prefer arc-length progress over hugging infeasible planner kinks.
+Track-time occupancy barriers stay off so the MPC does not re-throttle
+on already-cleared corridors; avoidance remains a planner responsibility.
+The grey dummy stays on Pure Pursuit with no repulsion so it collides on
+the naive diagonal. See [arco.md § Progress-first contouring](../arco.md#progress-first-contouring-arco147).
 
 FRET adapter: `fret.control.kinematics_dubins.DubinsKinematics`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.26",
     "pyyaml>=6.0",
-    "arco[mpc] @ git+https://github.com/alexandrelheinen/arco.git@v0.3.2",
+    # Pin includes arco#147 progress-first contouring (weight_lag,
+    # contour_deadzone). Bump to a release tag when ARCO cuts one past v0.3.3.
+    "arco[mpc] @ git+https://github.com/alexandrelheinen/arco.git@5ad245a2f41ae7cdf5ca9fdf77711fc37d8f7500",
 ]
 
 [project.optional-dependencies]

--- a/src/fret/config/controllers/dubins.yml
+++ b/src/fret/config/controllers/dubins.yml
@@ -5,11 +5,15 @@
 # Planner agents (blue RRT* / green SST):
 #   1) RRT*/SST plan in 2D with full warehouse occupancy → topological
 #      corridor (pass here, then there). That is the obstacle avoidance.
-#   2) DubinsPathFollowingMPC tracks that polyline (contour + heading +
-#      cruise). Trackers use occupancy=None so the old preview-cruise
-#      taper / soft barriers cannot throttle on already-cleared corridors
-#      (that was the stop-and-go). Safety still sits in the planner path
-#      plus the post-hoc collision monitor in physics mode.
+#   2) DubinsPathFollowingMPC tracks that polyline with progress-first
+#      contouring (ARCO ≥ arco#147): prefer arc-length progress over
+#      zero-fitting stiff planner kinks. Trackers use occupancy=None so
+#      preview-cruise taper / soft barriers cannot throttle on already-
+#      cleared corridors. Safety still sits in the planner path plus the
+#      post-hoc collision monitor in physics mode.
+#   3) Lab-scale weights (aisles ≈1.6 m, chassis half-width ≈0.09 m,
+#      cruise ≈0.36 m/s) — do NOT copy ARCO city meters (8 m deadzone /
+#      14 m/s). Set contour_deadzone: 0 to restore classic contouring.
 # The grey dummy keeps Pure Pursuit without repulsion so it collides on
 # the naive diagonal as a foil.
 #
@@ -28,18 +32,21 @@
     curvature_gain: 0.9
     repulsion_gain: 0.0
     update_rate: 20.0
-    # Path-following MPC. Physical horizon T=N·dt = 1.2 s ≈ 0.43 m at
-    # cruise (~3× R_min) — a bit longer than the old 1.0 s / 0.36 m window
-    # so bends are anticipated without blowing up the IPOPT NLP size.
+    # Path-following MPC (progress-first). Physical horizon T=N·dt = 1.2 s
+    # ≈ 0.43 m at cruise (~3× R_min). weight_lag pulls s forward; contour
+    # cost applies only outside contour_deadzone so the tracker may widen
+    # infeasible polyline kinks while arc-length keeps advancing.
     mpc:
       horizon_step_count: 24
       dt: 0.05
-      weight_contour: 25.0
-      weight_heading: 10.0
-      weight_progress: 4.0
-      weight_control: 0.05
+      weight_contour: 4.0          # excess only (outside deadzone)
+      weight_heading: 3.0
+      weight_progress: 3.0
+      weight_lag: 12.0             # prefer advancing s
+      contour_deadzone: 0.10       # [m] ~chassis half-width scale
+      weight_control: 0.2
       weight_obstacle: 0.0
       obstacle_barrier_power: 2.0
-      weight_terminal: 40.0
+      weight_terminal: 8.0
       weight_slack: 1.0
       max_solver_iter_count: 40

--- a/src/fret/config/controllers/dubins.yml
+++ b/src/fret/config/controllers/dubins.yml
@@ -13,7 +13,9 @@
 #      post-hoc collision monitor in physics mode.
 #   3) Lab-scale weights (aisles ≈1.6 m, chassis half-width ≈0.09 m,
 #      cruise ≈0.36 m/s) — do NOT copy ARCO city meters (8 m deadzone /
-#      14 m/s). Set contour_deadzone: 0 to restore classic contouring.
+#      14 m/s). Tuned so RRT*/SST finish warehouse bends without stalling
+#      (issue-suggested contour=4/lag=12 stalled SST on showcase seed).
+#      Set contour_deadzone: 0 to restore classic contouring.
 # The grey dummy keeps Pure Pursuit without repulsion so it collides on
 # the naive diagonal as a foil.
 #
@@ -39,14 +41,14 @@
     mpc:
       horizon_step_count: 24
       dt: 0.05
-      weight_contour: 4.0          # excess only (outside deadzone)
-      weight_heading: 3.0
+      weight_contour: 8.0          # excess only (outside deadzone)
+      weight_heading: 4.0
       weight_progress: 3.0
-      weight_lag: 12.0             # prefer advancing s
+      weight_lag: 10.0             # prefer advancing s
       contour_deadzone: 0.10       # [m] ~chassis half-width scale
-      weight_control: 0.2
+      weight_control: 0.15
       weight_obstacle: 0.0
       obstacle_barrier_power: 2.0
-      weight_terminal: 8.0
+      weight_terminal: 12.0
       weight_slack: 1.0
       max_solver_iter_count: 40

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -513,39 +513,52 @@ def _vehicle_config(ctrl: dict[str, Any]) -> VehicleConfig:
 
 
 def _mpc_config(ctrl: dict[str, Any]) -> PathFollowingMPCConfig:
-    """Load path-following MPC weights; cruise comes from vehicle config."""
+    """Load path-following MPC weights; cruise comes from vehicle config.
+
+    Forwards progress-first fields (``weight_lag``, ``contour_deadzone``)
+    from ``ctrl["mpc"]``. Race trackers still pass ``occupancy=None`` at
+    construction — avoidance remains a planner responsibility.
+    """
     base = PathFollowingMPCConfig.create_from_config(
         cruise_speed=float(ctrl["cruise_speed"])
     )
     mpc = ctrl.get("mpc")
     if not isinstance(mpc, dict):
         return base
-    return PathFollowingMPCConfig(
-        horizon_step_count=int(
-            mpc.get("horizon_step_count", base.horizon_step_count)
-        ),
-        dt=float(mpc.get("dt", base.dt)),
-        cruise_speed=float(ctrl["cruise_speed"]),
-        weight_contour=float(mpc.get("weight_contour", base.weight_contour)),
-        weight_heading=float(mpc.get("weight_heading", base.weight_heading)),
-        weight_progress=float(
-            mpc.get("weight_progress", base.weight_progress)
-        ),
-        weight_control=float(mpc.get("weight_control", base.weight_control)),
-        weight_obstacle=float(
-            mpc.get("weight_obstacle", base.weight_obstacle)
-        ),
-        obstacle_barrier_power=float(
-            mpc.get("obstacle_barrier_power", base.obstacle_barrier_power)
-        ),
-        weight_terminal=float(
-            mpc.get("weight_terminal", base.weight_terminal)
-        ),
-        weight_slack=float(mpc.get("weight_slack", base.weight_slack)),
-        max_solver_iter_count=int(
-            mpc.get("max_solver_iter_count", base.max_solver_iter_count)
-        ),
+
+    def _opt_float(key: str) -> float | None:
+        return float(mpc[key]) if key in mpc else None
+
+    def _opt_int(key: str) -> int | None:
+        return int(mpc[key]) if key in mpc else None
+
+    cfg = base.with_horizon_overrides(
+        step_count=_opt_int("horizon_step_count"),
+        dt=_opt_float("dt"),
+    ).with_weight_overrides(
+        contour=_opt_float("weight_contour"),
+        heading=_opt_float("weight_heading"),
+        progress=_opt_float("weight_progress"),
+        lag=_opt_float("weight_lag"),
+        control=_opt_float("weight_control"),
+        obstacle=_opt_float("weight_obstacle"),
+        terminal=_opt_float("weight_terminal"),
+        slack=_opt_float("weight_slack"),
+        contour_deadzone=_opt_float("contour_deadzone"),
     )
+    barrier = _opt_float("obstacle_barrier_power")
+    max_iter = _opt_int("max_solver_iter_count")
+    if barrier is not None or max_iter is not None:
+        cfg = replace(
+            cfg,
+            obstacle_barrier_power=(
+                barrier if barrier is not None else cfg.obstacle_barrier_power
+            ),
+            max_solver_iter_count=(
+                max_iter if max_iter is not None else cfg.max_solver_iter_count
+            ),
+        )
+    return cfg
 
 
 def _straight_line_heading(

--- a/tests/scenario/test_dubins_mpc_config.py
+++ b/tests/scenario/test_dubins_mpc_config.py
@@ -1,0 +1,48 @@
+"""Unit tests for Dubins race MPC config wiring (progress-first fields)."""
+
+from __future__ import annotations
+
+import pathlib
+
+from fret.config_loader import load_ros_parameters_yaml
+from fret.scenario.dubins_race_runner import _mpc_config
+
+_DUBINS_CTRL = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / "src"
+    / "fret"
+    / "config"
+    / "controllers"
+    / "dubins.yml"
+)
+
+
+def test_mpc_config_forwards_progress_first_fields_from_yaml() -> None:
+    """``_mpc_config`` must round-trip weight_lag / contour_deadzone."""
+    ctrl = load_ros_parameters_yaml(_DUBINS_CTRL)
+    cfg = _mpc_config(ctrl)
+    assert cfg.weight_lag == 12.0
+    assert cfg.contour_deadzone == 0.10
+    assert cfg.weight_contour == 4.0
+    assert cfg.weight_heading == 3.0
+    assert cfg.weight_progress == 3.0
+    assert cfg.weight_terminal == 8.0
+    assert cfg.horizon_step_count == 24
+    assert cfg.dt == 0.05
+    assert cfg.cruise_speed == float(ctrl["cruise_speed"])
+
+
+def test_mpc_config_defaults_progress_first_when_keys_absent() -> None:
+    """Missing lag/deadzone keys must not invent non-default values."""
+    ctrl = {
+        "cruise_speed": 0.36,
+        "mpc": {
+            "horizon_step_count": 10,
+            "weight_contour": 1.0,
+        },
+    }
+    cfg = _mpc_config(ctrl)
+    assert cfg.horizon_step_count == 10
+    assert cfg.weight_contour == 1.0
+    assert cfg.weight_lag == 0.0
+    assert cfg.contour_deadzone == 0.0

--- a/tests/scenario/test_dubins_mpc_config.py
+++ b/tests/scenario/test_dubins_mpc_config.py
@@ -21,12 +21,12 @@ def test_mpc_config_forwards_progress_first_fields_from_yaml() -> None:
     """``_mpc_config`` must round-trip weight_lag / contour_deadzone."""
     ctrl = load_ros_parameters_yaml(_DUBINS_CTRL)
     cfg = _mpc_config(ctrl)
-    assert cfg.weight_lag == 12.0
+    assert cfg.weight_lag == 10.0
     assert cfg.contour_deadzone == 0.10
-    assert cfg.weight_contour == 4.0
-    assert cfg.weight_heading == 3.0
+    assert cfg.weight_contour == 8.0
+    assert cfg.weight_heading == 4.0
     assert cfg.weight_progress == 3.0
-    assert cfg.weight_terminal == 8.0
+    assert cfg.weight_terminal == 12.0
     assert cfg.horizon_step_count == 24
     assert cfg.dt == 0.05
     assert cfg.cruise_speed == float(ctrl["cruise_speed"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #120.

## Summary

Global planners ignore vehicle dynamics; stiff contouring on their polylines can stall/orbit at sharp warehouse kinks. This PR consumes ARCO’s progress-first contouring from [arco#147](https://github.com/alexandrelheinen/arco/pull/147) at **lab scale**.

## Changes

1. **ARCO pin** (`pyproject.toml`) → merge commit `5ad245a` (includes `weight_lag` / `contour_deadzone`; no ARCO release past v0.3.3 yet)
2. **`_mpc_config`** forwards new fields via `with_horizon_overrides` / `with_weight_overrides` (race trackers still `occupancy=None`)
3. **`dubins.yml`** lab-scaled progress-first weights (retuned with E2E evidence — see below)
4. **Docs** — `docs/arco.md`, `docs/robots/dubins.md`, `docs/modules/control.md`
5. **Unit test** — `_mpc_config` round-trips lag/deadzone from YAML

## Out of scope

- `JointSpaceMPC` / OMX pick-and-place
- Re-enabling occupancy inside race MPC trackers
- Copying ARCO city meters (8 m deadzone / 14 m/s)

## Problem (verbatim)

Issue sketch weights (`contour=4`, `lag=12`, `deadzone=0.10`) left SST stuck mid-warehouse on the showcase seed:

`both_reached_goal=False`, `rrt_time_to_goal_s≈44`, `sst_time_to_goal_s=None`, race timeout 300 s, final SST pose ≈(5.43, 7.59), `dgoal≈3.59 m`.

## Analysis

Progress-first is correct for planner polylines, but FRET’s lab-scale TurtleBot needs enough contour/heading stiffness that SST does not wander off-corridor. Issue-sketch contour=4 was too soft for this warehouse seed; stiff old weights still finish under the new ARCO always-on progress semantics.

## Fix (tuned weights)

```yaml
weight_contour: 8.0
weight_heading: 4.0
weight_progress: 3.0
weight_lag: 10.0
contour_deadzone: 0.10   # m, chassis half-width scale
weight_control: 0.15
weight_terminal: 12.0
```

## Verification

| Check | Result |
| --- | --- |
| `bash scripts/check/formatting.sh` | pass |
| `bash scripts/check/types.sh` | pass |
| `tests/scenario/test_dubins_mpc_config.py` | 2 passed |
| `tests/scenario/test_dubins_race_e2e.py` | 5 passed |
| `tests/scenario/test_dubins_collision_monitor.py` | 6 passed |
| kinematic showcase export (`test_kinematic_showcase_export_reaches_goal_for_both_agents`) | pass |

| Config | both | RRT TTG | SST TTG | max CTE |
| --- | --- | --- | --- | --- |
| stiff (lag=0, dz=0) | True | 44.9 s | 63.1 s | 0.087 m |
| issue sketch (c=4, lag=12) | **False** | 44.0 s | — | 0.252 m |
| **PF lab (shipped)** | True | 45.1 s | 86.3 s | 0.079 m |

Grey Pure Pursuit foil still collides on the naive diagonal (`test_dummy_straight_line_collides_before_goal` pass).

![stiff vs lab progress-first XY / s(t) / e_lat](https://cursor.com/artifacts/c/art-5c0e7432-c49d-45a2-b9ff-7b5d1559bb76)

## Acceptance criteria

1. [x] FRET installs an ARCO revision that includes arco#147 (`5ad245a`)
2. [x] `_mpc_config` forwards `weight_lag` + `contour_deadzone`
3. [x] `dubins.yml` enables lab-scaled progress-first weights; comments explain why
4. [x] Dubins race E2E / smoke pass; agents do not stall at sharp planner kinks
5. [x] Docs updated; JointSpaceMPC paths untouched

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0af00c2-d09b-4a42-8c91-7505c66d7498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0af00c2-d09b-4a42-8c91-7505c66d7498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

