### PR TITLE
Cut Dubins release CI under ~10 min (A/B/C + defer follow)

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -369,7 +369,7 @@ Canonical matrix: [`src/fret/config/release/showcase.yml`](../src/fret/config/re
 
 | Robot class | Scenarios (today) | Required cameras |
 |---|---|---|
-| **mobile** | `dubins_race` (TB3); future mobile robots | `overview` (isometric) **and** `follow` (split-screen chase) |
+| **mobile** | `dubins_race` (TB3); future mobile robots | `overview` (isometric); `follow` optional / local |
 | **static** | OM-X Γ-maze: `omx_wall_maze_rrt` + `omx_wall_maze_sst`; OMY pick-place `omy_pick_place` + clutter `omy_clutter_rrt` + `omy_clutter_sst` | `overview` only |
 
 OM-X and OMY clutter release clips share the same wall geometry and joint
@@ -381,8 +381,10 @@ repo for development but are not release artifacts.
 
 - **Overview** must frame the robots and ideally start + goal (tune zoom /
   azimuth per scenario MJCF / runtime camera constants).
-- **Follow** is mandatory for every **mobile** robot showcase, including future
-  mobile platforms. Static / tabletop arms must **not** export follow on release.
+- **Follow** is optional for mobile release jobs (CI encode budget). Dubins
+  ships overview-only at `fps: 20`, `clip_duration_s: 30` (~600 frames).
+  Render follow locally with `scripts/video.sh --camera follow` when needed.
+  Static / tabletop arms must **not** export follow on release.
 - Dubins race uses `--physics-mode`; OM-X clips step MuJoCo actuators.
 - Only clean semver tags (`vX.Y.Z`) update `latest/`. Suffixed tags
   (`-dev`, probes, …) upload under `releases/<tag>/` only.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -381,9 +381,20 @@ repo for development but are not release artifacts.
 
 - **Overview** must frame the robots and ideally start + goal (tune zoom /
   azimuth per scenario MJCF / runtime camera constants).
-- **Follow** is optional for mobile release jobs (CI encode budget). Dubins
-  ships overview-only at `fps: 20`, `clip_duration_s: 30` (~600 frames).
-  Render follow locally with `scripts/video.sh --camera follow` when needed.
+- **Follow** is optional for mobile and **not** on the blocking release path.
+  Dubins ships overview-only at `fps: 20`, `clip_duration_s: 30` (~600 frames)
+  so the encode job stays under ~10 min. A separate non-blocking follow job
+  was considered and **deferred**: a second 720p camera at the same clip
+  length roughly doubles encode wall time and would push the Dubins leg back
+  over budget on current runners. Render follow locally when needed:
+
+  ```bash
+  ./scripts/video.sh --model dubins --scenario dubins_race \
+    --camera follow --duration 30 --fps 20 --physics-mode \
+    --collision-backend mujoco --planner-algorithm sst \
+    -o /tmp/dubins_race_follow.mp4
+  ```
+
   Static / tabletop arms must **not** export follow on release.
 - Dubins showcase sims early-stop at `clip_duration_s` (`max_sim_time_s`) so
   a slow finisher cannot stretch the encode job; full-race acceptance stays in

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -382,23 +382,23 @@ repo for development but are not release artifacts.
 - **Overview** must frame the robots and ideally start + goal (tune zoom /
   azimuth per scenario MJCF / runtime camera constants).
 - **Follow** is optional for mobile and **not** on the blocking release path.
-  Dubins ships overview-only at `fps: 20`, `clip_duration_s: 30` (~600 frames)
-  so the encode job stays under ~10 min. A separate non-blocking follow job
-  was considered and **deferred**: a second 720p camera at the same clip
-  length roughly doubles encode wall time and would push the Dubins leg back
-  over budget on current runners. Render follow locally when needed:
+  Dubins ships overview-only at `fps: 20`, `960×540`, `clip_scale: 1.25`
+  (full race + 25% hold after finish; ~950 frames) so the encode job stays
+  under ~10 min. A separate non-blocking follow job was considered and
+  **deferred**: a second camera roughly doubles encode wall time. Render
+  follow locally when needed:
 
   ```bash
   ./scripts/video.sh --model dubins --scenario dubins_race \
-    --camera follow --duration 30 --fps 20 --physics-mode \
+    --camera follow --full-duration --clip-scale 1.25 --fps 20 \
+    --width 960 --height 540 --physics-mode \
     --collision-backend mujoco --planner-algorithm sst \
     -o /tmp/dubins_race_follow.mp4
   ```
 
   Static / tabletop arms must **not** export follow on release.
-- Dubins showcase sims early-stop at `clip_duration_s` (`max_sim_time_s`) so
-  a slow finisher cannot stretch the encode job; full-race acceptance stays in
-  pytest (both agents must still reach goal under physics).
+- Dubins may use `clip_duration_s` (early-stop) or `clip_scale` (full race ×
+  scale with hold). Full-race acceptance stays in pytest.
 - Dubins race uses `--physics-mode`; OM-X clips step MuJoCo actuators.
 - Only clean semver tags (`vX.Y.Z`) update `latest/`. Suffixed tags
   (`-dev`, probes, …) upload under `releases/<tag>/` only.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -385,6 +385,9 @@ repo for development but are not release artifacts.
   ships overview-only at `fps: 20`, `clip_duration_s: 30` (~600 frames).
   Render follow locally with `scripts/video.sh --camera follow` when needed.
   Static / tabletop arms must **not** export follow on release.
+- Dubins showcase sims early-stop at `clip_duration_s` (`max_sim_time_s`) so
+  a slow finisher cannot stretch the encode job; full-race acceptance stays in
+  pytest (both agents must still reach goal under physics).
 - Dubins race uses `--physics-mode`; OM-X clips step MuJoCo actuators.
 - Only clean semver tags (`vX.Y.Z`) update `latest/`. Suffixed tags
   (`-dev`, probes, …) upload under `releases/<tag>/` only.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -382,23 +382,24 @@ repo for development but are not release artifacts.
 - **Overview** must frame the robots and ideally start + goal (tune zoom /
   azimuth per scenario MJCF / runtime camera constants).
 - **Follow** is optional for mobile and **not** on the blocking release path.
-  Dubins ships overview-only at `fps: 20`, `960×540`, `clip_scale: 1.25`
-  (full race + 25% hold after finish; ~950 frames) so the encode job stays
-  under ~10 min. A separate non-blocking follow job was considered and
+  Dubins ships overview-only at `fps: 20`, `960×540`, `clip_duration_s: 40`
+  (full ~38 s race + short hold → 40 s video; 800 frames) so the encode job
+  stays under ~10 min. A separate non-blocking follow job was considered and
   **deferred**: a second camera roughly doubles encode wall time. Render
   follow locally when needed:
 
   ```bash
   ./scripts/video.sh --model dubins --scenario dubins_race \
-    --camera follow --full-duration --clip-scale 1.25 --fps 20 \
+    --camera follow --full-duration --video-duration 40 --fps 20 \
     --width 960 --height 540 --physics-mode \
     --collision-backend mujoco --planner-algorithm sst \
     -o /tmp/dubins_race_follow.mp4
   ```
 
   Static / tabletop arms must **not** export follow on release.
-- Dubins may use `clip_duration_s` (early-stop) or `clip_scale` (full race ×
-  scale with hold). Full-race acceptance stays in pytest.
+- Dubins release uses `clip_duration_s` as the **video** length (full race +
+  hold/trim). Optional `clip_scale` remains for scale×sim_time clips.
+  Full-race acceptance stays in pytest.
 - Dubins race uses `--physics-mode`; OM-X clips step MuJoCo actuators.
 - Only clean semver tags (`vX.Y.Z`) update `latest/`. Suffixed tags
   (`-dev`, probes, …) upload under `releases/<tag>/` only.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -93,7 +93,7 @@ GitHub Actions artifact backup. Camera policy (see
 
 | Scenario | Model | Class | Cameras |
 |---|---|---|---|
-| `dubins_race` | Dubins / TB3 | mobile | `overview` + split-screen `follow` |
+| `dubins_race` | Dubins / TB3 | mobile | `overview` (follow optional / local) |
 | `omx_wall_maze_rrt` | OpenMANIPULATOR-X (Γ maze, RRT*) | static | `overview` |
 | `omx_wall_maze_sst` | OpenMANIPULATOR-X (Γ maze, SST) | static | `overview` |
 | `omy_pick_place` | OpenMANIPULATOR-Y (floor ball → cone) | static | `overview` |

--- a/scripts/release/render_showcase.py
+++ b/scripts/release/render_showcase.py
@@ -37,9 +37,9 @@ def _video_argv(
         "--fps",
         str(scenario.effective_fps(manifest.fps)),
         "--width",
-        str(manifest.width),
+        str(scenario.effective_width(manifest.width)),
         "--height",
-        str(manifest.height),
+        str(scenario.effective_height(manifest.height)),
         "--collision-backend",
         scenario.collision_backend,
         "--planner-algorithm",
@@ -51,6 +51,8 @@ def _video_argv(
         argv.extend(["--duration", str(scenario.clip_duration_s)])
     else:
         argv.append("--full-duration")
+        if scenario.clip_scale is not None:
+            argv.extend(["--clip-scale", str(scenario.clip_scale)])
     if scenario.physics_mode:
         argv.append("--physics-mode")
     return argv

--- a/scripts/release/render_showcase.py
+++ b/scripts/release/render_showcase.py
@@ -30,13 +30,12 @@ def _video_argv(
         scenario.model,
         "--scenario",
         scenario.id,
-        "--all-cameras",
         "--output-dir",
         str(output_dir),
         "--timing-json",
         str(output_dir / scenario.timing_file),
         "--fps",
-        str(manifest.fps),
+        str(scenario.effective_fps(manifest.fps)),
         "--width",
         str(manifest.width),
         "--height",
@@ -45,8 +44,13 @@ def _video_argv(
         scenario.collision_backend,
         "--planner-algorithm",
         scenario.planner_algorithm,
-        "--full-duration",
     ]
+    for camera in scenario.cameras:
+        argv.extend(["--camera", camera])
+    if scenario.clip_duration_s is not None:
+        argv.extend(["--duration", str(scenario.clip_duration_s)])
+    else:
+        argv.append("--full-duration")
     if scenario.physics_mode:
         argv.append("--physics-mode")
     return argv

--- a/scripts/release/render_showcase.py
+++ b/scripts/release/render_showcase.py
@@ -47,12 +47,13 @@ def _video_argv(
     ]
     for camera in scenario.cameras:
         argv.extend(["--camera", camera])
+    # Always simulate the full race for release; clip_* only sizes the video
+    # (hold after finish or trim), so a ~38 s race becomes a clean 40 s clip.
+    argv.append("--full-duration")
     if scenario.clip_duration_s is not None:
-        argv.extend(["--duration", str(scenario.clip_duration_s)])
-    else:
-        argv.append("--full-duration")
-        if scenario.clip_scale is not None:
-            argv.extend(["--clip-scale", str(scenario.clip_scale)])
+        argv.extend(["--video-duration", str(scenario.clip_duration_s)])
+    elif scenario.clip_scale is not None:
+        argv.extend(["--clip-scale", str(scenario.clip_scale)])
     if scenario.physics_mode:
         argv.append("--physics-mode")
     return argv

--- a/scripts/release/showcase_manifest.py
+++ b/scripts/release/showcase_manifest.py
@@ -31,10 +31,17 @@ class ShowcaseScenario:
     collision_backend: str
     timing_file: str
     primary_video: str
+    fps: int | None = None
+    clip_duration_s: float | None = None
 
     @property
     def requires_follow(self) -> bool:
-        return self.robot_class == "mobile"
+        """True when this entry lists a follow camera (optional for mobile)."""
+        return "follow" in self.cameras
+
+    def effective_fps(self, default_fps: int) -> int:
+        """Return per-scenario fps override or the manifest default."""
+        return int(self.fps) if self.fps is not None else int(default_fps)
 
 
 @dataclass(frozen=True)
@@ -64,14 +71,12 @@ def _parse_scenario(raw: dict[str, Any]) -> ShowcaseScenario:
         raise ValueError(
             f"scenario {raw.get('id')!r} must include overview camera"
         )
-    if robot_class == "mobile" and "follow" not in cameras:
-        raise ValueError(
-            f"mobile scenario {raw.get('id')!r} must include follow camera"
-        )
     if robot_class == "static" and "follow" in cameras:
         raise ValueError(
             f"static scenario {raw.get('id')!r} must not export follow"
         )
+    fps_raw = raw.get("fps")
+    clip_raw = raw.get("clip_duration_s")
     return ShowcaseScenario(
         id=str(raw["id"]),
         model=str(raw["model"]),
@@ -82,6 +87,10 @@ def _parse_scenario(raw: dict[str, Any]) -> ShowcaseScenario:
         collision_backend=str(raw.get("collision_backend", "mujoco")),
         timing_file=str(raw["timing_file"]),
         primary_video=str(raw["primary_video"]),
+        fps=int(fps_raw) if fps_raw is not None else None,
+        clip_duration_s=(
+            float(clip_raw) if clip_raw is not None else None
+        ),
     )
 
 
@@ -108,9 +117,12 @@ def load_showcase_manifest(
 def release_cameras_for_robot_class(
     robot_class: RobotClass,
 ) -> tuple[str, ...]:
-    """Return the required release camera set for a robot class."""
-    if robot_class == "mobile":
-        return ("overview", "follow")
+    """Return the CI-required release camera set for a robot class.
+
+    Follow is optional for mobile (local / optional workflow only) so the
+    Dubins encode budget stays under ~10 minutes.
+    """
+    _ = robot_class
     return ("overview",)
 
 
@@ -154,6 +166,8 @@ def main(argv: list[str] | None = None) -> int:
                     "collision_backend": s.collision_backend,
                     "timing_file": s.timing_file,
                     "primary_video": s.primary_video,
+                    "fps": s.fps,
+                    "clip_duration_s": s.clip_duration_s,
                 }
                 for s in manifest.scenarios
             ],

--- a/scripts/release/showcase_manifest.py
+++ b/scripts/release/showcase_manifest.py
@@ -32,7 +32,10 @@ class ShowcaseScenario:
     timing_file: str
     primary_video: str
     fps: int | None = None
+    width: int | None = None
+    height: int | None = None
     clip_duration_s: float | None = None
+    clip_scale: float | None = None
 
     @property
     def requires_follow(self) -> bool:
@@ -42,6 +45,20 @@ class ShowcaseScenario:
     def effective_fps(self, default_fps: int) -> int:
         """Return per-scenario fps override or the manifest default."""
         return int(self.fps) if self.fps is not None else int(default_fps)
+
+    def effective_width(self, default_width: int) -> int:
+        """Return per-scenario width override or the manifest default."""
+        return (
+            int(self.width) if self.width is not None else int(default_width)
+        )
+
+    def effective_height(self, default_height: int) -> int:
+        """Return per-scenario height override or the manifest default."""
+        return (
+            int(self.height)
+            if self.height is not None
+            else int(default_height)
+        )
 
 
 @dataclass(frozen=True)
@@ -76,7 +93,20 @@ def _parse_scenario(raw: dict[str, Any]) -> ShowcaseScenario:
             f"static scenario {raw.get('id')!r} must not export follow"
         )
     fps_raw = raw.get("fps")
+    width_raw = raw.get("width")
+    height_raw = raw.get("height")
     clip_raw = raw.get("clip_duration_s")
+    scale_raw = raw.get("clip_scale")
+    if clip_raw is not None and scale_raw is not None:
+        raise ValueError(
+            f"scenario {raw.get('id')!r} cannot set both "
+            "clip_duration_s and clip_scale"
+        )
+    if scale_raw is not None and float(scale_raw) <= 0.0:
+        raise ValueError(
+            f"scenario {raw.get('id')!r} clip_scale must be > 0 "
+            f"(got {scale_raw!r})"
+        )
     return ShowcaseScenario(
         id=str(raw["id"]),
         model=str(raw["model"]),
@@ -88,9 +118,12 @@ def _parse_scenario(raw: dict[str, Any]) -> ShowcaseScenario:
         timing_file=str(raw["timing_file"]),
         primary_video=str(raw["primary_video"]),
         fps=int(fps_raw) if fps_raw is not None else None,
+        width=int(width_raw) if width_raw is not None else None,
+        height=int(height_raw) if height_raw is not None else None,
         clip_duration_s=(
             float(clip_raw) if clip_raw is not None else None
         ),
+        clip_scale=(float(scale_raw) if scale_raw is not None else None),
     )
 
 
@@ -167,7 +200,10 @@ def main(argv: list[str] | None = None) -> int:
                     "timing_file": s.timing_file,
                     "primary_video": s.primary_video,
                     "fps": s.fps,
+                    "width": s.width,
+                    "height": s.height,
                     "clip_duration_s": s.clip_duration_s,
+                    "clip_scale": s.clip_scale,
                 }
                 for s in manifest.scenarios
             ],

--- a/scripts/release/write_showcase_meta.py
+++ b/scripts/release/write_showcase_meta.py
@@ -118,7 +118,8 @@ def write_showcase_meta(
     if not showcases:
         raise SystemExit("No showcase clips found for any scenario")
 
-    mobile_cameras = ["overview", "follow"]
+    # CI-required cameras (follow is optional for mobile; see showcase.yml).
+    mobile_cameras = ["overview"]
     static_cameras = ["overview"]
     meta: dict[str, object] = {
         "repo": repo,

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -639,14 +639,25 @@ def simulate_dubins_race_poses(
 def _assert_dubins_race_moves(
     rrt_poses: npt.NDArray[np.float64],
     sst_poses: npt.NDArray[np.float64],
+    *,
+    min_east_span_m: float = 5.0,
 ) -> None:
-    """Fail fast when a release clip would show static agents."""
+    """Fail fast when a release clip would show static agents.
+
+    Full-race exports keep a 5 m easting bar (warehouse A→B ≈ 7.6 m).
+    Clipped showcase exports (``clip_duration_s``) use a lower bar so a
+    30 s window of a live race is not rejected when SST is still mid-map.
+    """
     rrt_span = rrt_poses.max(axis=0) - rrt_poses.min(axis=0)
     sst_span = sst_poses.max(axis=0) - sst_poses.min(axis=0)
-    if float(rrt_span[0]) < 5.0 or float(sst_span[0]) < 5.0:
+    if (
+        float(rrt_span[0]) < min_east_span_m
+        or float(sst_span[0]) < min_east_span_m
+    ):
         raise RuntimeError(
             "Dubins race clip lacks horizontal transit "
-            f"(RRT* span={rrt_span[:2]}, SST span={sst_span[:2]})"
+            f"(min_east_span_m={min_east_span_m}, "
+            f"RRT* span={rrt_span[:2]}, SST span={sst_span[:2]})"
         )
 
 
@@ -773,7 +784,13 @@ def render_dubins_race_showcase_videos(
         telemetry_output_dir=output_dir,
         telemetry_csv_basename=f"{scenario}_overview",
     )
-    _assert_dubins_race_moves(rrt_poses, sst_poses)
+    # Clipped exports (release budget) only need a few metres of transit.
+    min_span = (
+        5.0
+        if duration_s is None
+        else min(5.0, max(2.5, 0.10 * float(duration_s)))
+    )
+    _assert_dubins_race_moves(rrt_poses, sst_poses, min_east_span_m=min_span)
     render_duration_s = float(len(rrt_poses)) / float(fps)
     timing = showcase_playback_timing(
         wall_sim_time_s=sim_time_s,

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -2047,12 +2047,19 @@ def _validate_render_cli(
             missing.append("--output-dir")
         if args.output is not None:
             parser.error("--output cannot be used with --all-cameras")
-    elif args.cameras and len(args.cameras) > 1:
-        if args.output_dir is None:
+    elif args.cameras:
+        # One or more explicit cameras: prefer --output-dir (release matrix);
+        # single-camera callers may still use -o/--output.
+        if args.output_dir is None and args.output is None:
+            missing.append("--output-dir (or -o/--output for one camera)")
+        if (
+            args.output_dir is None
+            and args.output is not None
+            and len(args.cameras) > 1
+        ):
             missing.append("--output-dir")
     elif args.output is None:
         missing.append("-o/--output")
-    elif not args.cameras:
         missing.append("--camera")
 
     if missing:
@@ -2104,9 +2111,8 @@ def main(argv: list[str] | None = None) -> int:
 
     cameras = args.cameras
     assert cameras is not None
-    if len(cameras) == 1:
+    if len(cameras) == 1 and args.output is not None:
         output = args.output
-        assert output is not None
         result = render_video(
             mjcf_path,
             output,
@@ -2128,6 +2134,8 @@ def main(argv: list[str] | None = None) -> int:
             f"rtf={timing.real_time_factor:.3f}, "
             f"mean={result.frame_mean:.1f})"
         )
+        if args.timing_json is not None:
+            write_showcase_timing_json([result], args.timing_json)
         return 0
 
     assert args.output_dir is not None
@@ -2154,6 +2162,8 @@ def main(argv: list[str] | None = None) -> int:
             f"sim={timing.sim_time_s:.1f}s, "
             f"rtf={timing.real_time_factor:.3f})"
         )
+    if args.timing_json is not None:
+        write_showcase_timing_json(results, args.timing_json)
     return 0
 
 

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -569,6 +569,9 @@ def simulate_dubins_race_poses(
     from fret.scenario.dubins_race_runner import DubinsRaceRunner
     from fret.scenario.planner_rng import SHOWCASE_PLANNER_RNG_SEED
 
+    # Showcase clips may request a fixed duration; stop the sim at that
+    # horizon instead of waiting for both agents to finish (Layer B).
+    early_stop_s = float(duration_s) if duration_s is not None else None
     result = DubinsRaceRunner().run(
         record_poses=True,
         physics_mode=physics_mode,
@@ -577,12 +580,21 @@ def simulate_dubins_race_poses(
         telemetry_output_dir=telemetry_output_dir,
         telemetry_csv_basename=telemetry_csv_basename
         or f"{scenario}_overview",
+        max_sim_time_s=early_stop_s,
     )
-    if not result.both_reached_goal:
+    if early_stop_s is None and not result.both_reached_goal:
         raise RuntimeError(
             "Dubins race simulation failed before both agents reached goal "
             f"(race_duration_s={result.race_duration_s:.1f}, "
             f"max_cross_track_error_m={result.max_cross_track_error_m:.2f})"
+        )
+    if early_stop_s is not None and result.race_duration_s + 1e-6 < min(
+        early_stop_s, 1.0
+    ):
+        raise RuntimeError(
+            "Dubins showcase early-stop produced a near-empty trajectory "
+            f"(race_duration_s={result.race_duration_s:.2f}, "
+            f"max_sim_time_s={early_stop_s:.2f})"
         )
     if physics_mode and result.min_obstacle_clearance_m < 0.0:
         raise RuntimeError(

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -545,6 +545,26 @@ def _resample_pose_history(
     )
 
 
+def _resample_pose_history_with_hold(
+    history: npt.NDArray[np.float64],
+    *,
+    race_frames: int,
+    total_frames: int,
+) -> npt.NDArray[np.float64]:
+    """Resample the race in real time, then hold the final pose.
+
+    Used when ``clip_scale > 1`` so the video shows the finish and a short
+    dwell without time-compressing the race itself.
+    """
+    race_n = max(2, int(race_frames))
+    total_n = max(race_n, int(total_frames))
+    race = _resample_pose_history(history, race_n)
+    if total_n == race_n:
+        return race
+    hold = np.repeat(race[-1:], total_n - race_n, axis=0)
+    return np.vstack([race, hold])
+
+
 def simulate_dubins_race_poses(
     scenario: str = "dubins_race",
     *,
@@ -554,6 +574,7 @@ def simulate_dubins_race_poses(
     telemetry_enabled: bool | None = None,
     telemetry_output_dir: Path | None = None,
     telemetry_csv_basename: str | None = None,
+    clip_scale: float = 1.0,
 ) -> tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
@@ -568,6 +589,9 @@ def simulate_dubins_race_poses(
     _ensure_fret_importable()
     from fret.scenario.dubins_race_runner import DubinsRaceRunner
     from fret.scenario.planner_rng import SHOWCASE_PLANNER_RNG_SEED
+
+    if float(clip_scale) <= 0.0:
+        raise ValueError(f"clip_scale must be > 0 (got {clip_scale!r})")
 
     # Showcase clips may request a fixed duration; stop the sim at that
     # horizon instead of waiting for both agents to finish (Layer B).
@@ -627,11 +651,28 @@ def simulate_dubins_race_poses(
         sim_time_s,
         duration_s,
     )
-    n_frames = max(2, int(round(render_duration_s * fps)))
+    if duration_s is None and float(clip_scale) != 1.0:
+        render_duration_s = float(clip_scale) * float(sim_time_s)
+
+    race_frames = max(2, int(round(float(sim_time_s) * float(fps))))
+    total_frames = max(2, int(round(float(render_duration_s) * float(fps))))
+    if total_frames > race_frames:
+        return (
+            _resample_pose_history_with_hold(
+                rrt_hist, race_frames=race_frames, total_frames=total_frames
+            ),
+            _resample_pose_history_with_hold(
+                sst_hist, race_frames=race_frames, total_frames=total_frames
+            ),
+            _resample_pose_history_with_hold(
+                dummy_hist, race_frames=race_frames, total_frames=total_frames
+            ),
+            sim_time_s,
+        )
     return (
-        _resample_pose_history(rrt_hist, n_frames),
-        _resample_pose_history(sst_hist, n_frames),
-        _resample_pose_history(dummy_hist, n_frames),
+        _resample_pose_history(rrt_hist, total_frames),
+        _resample_pose_history(sst_hist, total_frames),
+        _resample_pose_history(dummy_hist, total_frames),
         sim_time_s,
     )
 
@@ -763,6 +804,7 @@ def render_dubins_race_showcase_videos(
     height: int = 720,
     realtime_postprocess: bool = True,
     physics_mode: bool = False,
+    clip_scale: float = 1.0,
 ) -> list[RenderResult]:
     """Render dual-agent Dubins race MP4s (V11-2 / V11-4)."""
     mujoco, _iio = _require_mujoco()
@@ -783,8 +825,10 @@ def render_dubins_race_showcase_videos(
         telemetry_enabled=True,
         telemetry_output_dir=output_dir,
         telemetry_csv_basename=f"{scenario}_overview",
+        clip_scale=clip_scale,
     )
-    # Clipped exports (release budget) only need a few metres of transit.
+    # Clipped exports (fixed duration) only need a few metres of transit;
+    # full-race / clip_scale exports keep the warehouse 5 m easting bar.
     min_span = (
         5.0
         if duration_s is None
@@ -792,10 +836,19 @@ def render_dubins_race_showcase_videos(
     )
     _assert_dubins_race_moves(rrt_poses, sst_poses, min_east_span_m=min_span)
     render_duration_s = float(len(rrt_poses)) / float(fps)
-    timing = showcase_playback_timing(
-        wall_sim_time_s=sim_time_s,
-        render_duration_s=render_duration_s,
-    )
+    if render_duration_s > sim_time_s + 0.02:
+        # Hold-after-finish (clip_scale > 1): keep RTF=1 so ffmpeg does not
+        # compress away the dwell; stash true race time in wall_sim_time_s.
+        timing = ShowcaseTiming(
+            sim_time_s=render_duration_s,
+            render_duration_s=render_duration_s,
+            wall_sim_time_s=sim_time_s,
+        )
+    else:
+        timing = showcase_playback_timing(
+            wall_sim_time_s=sim_time_s,
+            render_duration_s=render_duration_s,
+        )
 
     model = mujoco.MjModel.from_xml_path(str(mjcf_path))
     data = mujoco.MjData(model)
@@ -1783,6 +1836,7 @@ def render_showcase_videos(
     use_tracking: bool = True,
     realtime_postprocess: bool = True,
     physics_mode: bool = False,
+    clip_scale: float = 1.0,
 ) -> list[RenderResult]:
     """Render one MP4 per showcase camera in a single simulation pass.
 
@@ -1802,6 +1856,7 @@ def render_showcase_videos(
             height=height,
             realtime_postprocess=realtime_postprocess,
             physics_mode=physics_mode,
+            clip_scale=clip_scale,
         )
     if scenario in _OMX_REACH_SCENARIOS:
         _ = physics_mode  # OM-X showcase always steps position actuators.
@@ -1977,6 +2032,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Render the full simulated motion at real-time speed",
     )
     parser.add_argument(
+        "--clip-scale",
+        type=float,
+        default=1.0,
+        help=(
+            "With --full-duration, set video length to scale×sim_time "
+            "(scale>1 holds the final pose after the finish)"
+        ),
+    )
+    parser.add_argument(
         "--fps",
         type=int,
         required=True,
@@ -2109,6 +2173,10 @@ def main(argv: list[str] | None = None) -> int:
     realtime_postprocess = not args.no_realtime_postprocess
     physics_mode = bool(args.physics_mode) and not args.kinematic_mode
 
+    clip_scale = float(args.clip_scale)
+    if duration_s is not None and abs(clip_scale - 1.0) > 1e-9:
+        parser.error("--clip-scale requires --full-duration")
+
     if args.all_cameras:
         cameras = list_showcase_cameras(mjcf_path, scenario=args.scenario)
         results = render_showcase_videos(
@@ -2125,6 +2193,7 @@ def main(argv: list[str] | None = None) -> int:
             use_tracking=use_tracking,
             realtime_postprocess=realtime_postprocess,
             physics_mode=physics_mode,
+            clip_scale=clip_scale,
         )
         for result in results:
             timing = result.timing
@@ -2182,6 +2251,7 @@ def main(argv: list[str] | None = None) -> int:
         use_tracking=use_tracking,
         realtime_postprocess=realtime_postprocess,
         physics_mode=physics_mode,
+        clip_scale=clip_scale,
     )
     for result in results:
         timing = result.timing

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -575,6 +575,7 @@ def simulate_dubins_race_poses(
     telemetry_output_dir: Path | None = None,
     telemetry_csv_basename: str | None = None,
     clip_scale: float = 1.0,
+    video_duration_s: float | None = None,
 ) -> tuple[
     npt.NDArray[np.float64],
     npt.NDArray[np.float64],
@@ -592,9 +593,17 @@ def simulate_dubins_race_poses(
 
     if float(clip_scale) <= 0.0:
         raise ValueError(f"clip_scale must be > 0 (got {clip_scale!r})")
+    if video_duration_s is not None and float(video_duration_s) <= 0.0:
+        raise ValueError(
+            f"video_duration_s must be > 0 (got {video_duration_s!r})"
+        )
+    if video_duration_s is not None and abs(float(clip_scale) - 1.0) > 1e-9:
+        raise ValueError(
+            "video_duration_s and clip_scale are mutually exclusive"
+        )
 
-    # Showcase clips may request a fixed duration; stop the sim at that
-    # horizon instead of waiting for both agents to finish (Layer B).
+    # Optional early-stop (Layer B / --duration). Release clips that only set
+    # --video-duration keep a full race so the finish is on screen.
     early_stop_s = float(duration_s) if duration_s is not None else None
     result = DubinsRaceRunner().run(
         record_poses=True,
@@ -651,7 +660,9 @@ def simulate_dubins_race_poses(
         sim_time_s,
         duration_s,
     )
-    if duration_s is None and float(clip_scale) != 1.0:
+    if video_duration_s is not None:
+        render_duration_s = float(video_duration_s)
+    elif duration_s is None and float(clip_scale) != 1.0:
         render_duration_s = float(clip_scale) * float(sim_time_s)
 
     race_frames = max(2, int(round(float(sim_time_s) * float(fps))))
@@ -805,6 +816,7 @@ def render_dubins_race_showcase_videos(
     realtime_postprocess: bool = True,
     physics_mode: bool = False,
     clip_scale: float = 1.0,
+    video_duration_s: float | None = None,
 ) -> list[RenderResult]:
     """Render dual-agent Dubins race MP4s (V11-2 / V11-4)."""
     mujoco, _iio = _require_mujoco()
@@ -826,6 +838,7 @@ def render_dubins_race_showcase_videos(
         telemetry_output_dir=output_dir,
         telemetry_csv_basename=f"{scenario}_overview",
         clip_scale=clip_scale,
+        video_duration_s=video_duration_s,
     )
     # Clipped exports (fixed duration) only need a few metres of transit;
     # full-race / clip_scale exports keep the warehouse 5 m easting bar.
@@ -1837,6 +1850,7 @@ def render_showcase_videos(
     realtime_postprocess: bool = True,
     physics_mode: bool = False,
     clip_scale: float = 1.0,
+    video_duration_s: float | None = None,
 ) -> list[RenderResult]:
     """Render one MP4 per showcase camera in a single simulation pass.
 
@@ -1857,6 +1871,7 @@ def render_showcase_videos(
             realtime_postprocess=realtime_postprocess,
             physics_mode=physics_mode,
             clip_scale=clip_scale,
+            video_duration_s=video_duration_s,
         )
     if scenario in _OMX_REACH_SCENARIOS:
         _ = physics_mode  # OM-X showcase always steps position actuators.
@@ -2041,6 +2056,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--video-duration",
+        type=float,
+        default=None,
+        help=(
+            "With --full-duration, set absolute video length in seconds "
+            "(hold after finish or trim; does not early-stop the sim)"
+        ),
+    )
+    parser.add_argument(
         "--fps",
         type=int,
         required=True,
@@ -2174,8 +2198,17 @@ def main(argv: list[str] | None = None) -> int:
     physics_mode = bool(args.physics_mode) and not args.kinematic_mode
 
     clip_scale = float(args.clip_scale)
+    video_duration_s = (
+        float(args.video_duration)
+        if args.video_duration is not None
+        else None
+    )
     if duration_s is not None and abs(clip_scale - 1.0) > 1e-9:
         parser.error("--clip-scale requires --full-duration")
+    if duration_s is not None and video_duration_s is not None:
+        parser.error("--video-duration requires --full-duration")
+    if video_duration_s is not None and abs(clip_scale - 1.0) > 1e-9:
+        parser.error("--video-duration and --clip-scale are mutually exclusive")
 
     if args.all_cameras:
         cameras = list_showcase_cameras(mjcf_path, scenario=args.scenario)
@@ -2194,6 +2227,7 @@ def main(argv: list[str] | None = None) -> int:
             realtime_postprocess=realtime_postprocess,
             physics_mode=physics_mode,
             clip_scale=clip_scale,
+            video_duration_s=video_duration_s,
         )
         for result in results:
             timing = result.timing
@@ -2252,6 +2286,7 @@ def main(argv: list[str] | None = None) -> int:
         realtime_postprocess=realtime_postprocess,
         physics_mode=physics_mode,
         clip_scale=clip_scale,
+        video_duration_s=video_duration_s,
     )
     for result in results:
         timing = result.timing

--- a/src/fret/config/controllers/dubins.yml
+++ b/src/fret/config/controllers/dubins.yml
@@ -16,6 +16,11 @@
 #      14 m/s). Tuned so RRT*/SST finish warehouse bends without stalling
 #      (issue-suggested contour=4/lag=12 stalled SST on showcase seed).
 #      Set contour_deadzone: 0 to restore classic contouring.
+#   4) FRET builds the MPC tracker via ``_build_vehicle_mpc_sim`` so
+#      weight_lag / contour_deadzone survive into the live NLP. ARCO's
+#      ``build_vehicle_mpc_sim`` currently rebuilds PathFollowingMPCConfig
+#      without those fields (silent drop → lag=0), which made SST crawl
+#      (~141 s). With lag preserved, showcase seed finishes ~38 s.
 # The grey dummy keeps Pure Pursuit without repulsion so it collides on
 # the naive diagonal as a foil.
 #

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -1,10 +1,15 @@
 # Release showcase matrix (v1.2.3+).
 #
 # Camera policy:
-#   * overview — isometric top view for EVERY scenario (frame robots +
-#     start/goal). Tune zoom/azimuth per MJCF / runtime camera constants.
-#   * follow   — required for mobile robots only (split-screen chase).
+#   * overview — required for EVERY scenario (frame robots + start/goal).
+#   * follow   — optional for mobile robots (split-screen chase). Omitted from
+#     the Dubins release job so encode stays under ~10 min CI budget; render
+#     locally with scripts/video.sh --camera follow when needed.
 #     Static/tabletop arms must NOT export follow on release.
+#
+# Per-scenario overrides (optional):
+#   * fps              — encode frame rate (default: top-level fps)
+#   * clip_duration_s  — fixed clip length via --duration (omit → --full-duration)
 #
 # Static release focus:
 #   * OM-X SC-v13d Γ-wall maze — RRT* vs SST (v1.2.3)
@@ -20,7 +25,10 @@ scenarios:
   - id: dubins_race
     model: dubins
     robot_class: mobile
-    cameras: [overview, follow]
+    cameras: [overview]
+    # CI budget: 30 s × 20 fps × 1 cam ≈ 600 frames (encode << 10 min).
+    fps: 20
+    clip_duration_s: 30.0
     physics_mode: true
     planner_algorithm: sst
     collision_backend: mujoco

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -10,9 +10,9 @@
 # Per-scenario overrides (optional):
 #   * fps              — encode frame rate (default: top-level fps)
 #   * width / height   — encode resolution (default: top-level)
-#   * clip_duration_s  — fixed clip length via --duration (early-stops sim)
-#   * clip_scale       — with --full-duration, video length = scale × sim_time
-#                        (scale > 1 holds the final pose after the finish)
+#   * clip_duration_s  — fixed video length (s); full race + hold/trim to fit
+#   * clip_scale       — video length = scale × sim_time (hold if scale > 1)
+#                        Mutually exclusive with clip_duration_s.
 #
 # Static release focus:
 #   * OM-X SC-v13d Γ-wall maze — RRT* vs SST (v1.2.3)
@@ -29,12 +29,12 @@ scenarios:
     model: dubins
     robot_class: mobile
     cameras: [overview]
-    # Full race (~38 s) × 1.25 hold-after-finish ≈ 47 s video.
-    # 960×540 @ 20 fps ≈ 950 frames; fewer pixels keep encode << 10 min.
+    # Full race (~38 s) + short hold → fixed 40 s video.
+    # 960×540 @ 20 fps = 800 frames; keeps encode << 10 min.
     fps: 20
     width: 960
     height: 540
-    clip_scale: 1.25
+    clip_duration_s: 40.0
     physics_mode: true
     planner_algorithm: sst
     collision_backend: mujoco

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -9,7 +9,10 @@
 #
 # Per-scenario overrides (optional):
 #   * fps              — encode frame rate (default: top-level fps)
-#   * clip_duration_s  — fixed clip length via --duration (omit → --full-duration)
+#   * width / height   — encode resolution (default: top-level)
+#   * clip_duration_s  — fixed clip length via --duration (early-stops sim)
+#   * clip_scale       — with --full-duration, video length = scale × sim_time
+#                        (scale > 1 holds the final pose after the finish)
 #
 # Static release focus:
 #   * OM-X SC-v13d Γ-wall maze — RRT* vs SST (v1.2.3)
@@ -26,9 +29,12 @@ scenarios:
     model: dubins
     robot_class: mobile
     cameras: [overview]
-    # CI budget: 30 s × 20 fps × 1 cam ≈ 600 frames (encode << 10 min).
+    # Full race (~38 s) × 1.25 hold-after-finish ≈ 47 s video.
+    # 960×540 @ 20 fps ≈ 950 frames; fewer pixels keep encode << 10 min.
     fps: 20
-    clip_duration_s: 30.0
+    width: 960
+    height: 540
+    clip_scale: 1.25
     physics_mode: true
     planner_algorithm: sst
     collision_backend: mujoco

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -21,13 +21,19 @@ from typing import Any, Literal, Mapping, cast
 
 import numpy as np
 import numpy.typing as npt
-from arco.control.mpc import MPCTrackingLoop, PathFollowingMPCConfig
+from arco.control.mpc import (
+    DubinsPathFollowingMPC,
+    DubinsVehicleLimits,
+    MPCTrackingLoop,
+    PathFollowingMPCConfig,
+)
 from arco.control.tracking import TrackingLoop
+from arco.guidance.vehicle import DubinsVehicle
 from arco.planning.continuous import RRTPlanner, SSTPlanner, TrajectoryPruner
 from arco.simulator.sim.tracking import (
     VehicleConfig,
-    build_vehicle_mpc_sim,
     build_vehicle_sim,
+    initial_heading,
 )
 
 from fret.config_loader import (
@@ -616,6 +622,50 @@ def _vehicle_config(ctrl: dict[str, Any]) -> VehicleConfig:
         curvature_gain=float(ctrl["curvature_gain"]),
         repulsion_gain=float(ctrl["repulsion_gain"]),
     )
+
+
+def _build_vehicle_mpc_sim(
+    waypoints: list[tuple[float, float]],
+    cfg: VehicleConfig,
+    mpc_cfg: PathFollowingMPCConfig,
+    *,
+    occupancy: Any = None,
+) -> tuple[Any, MPCTrackingLoop]:
+    """Build Dubins + path-following MPC without dropping progress-first fields.
+
+    ARCO's ``build_vehicle_mpc_sim`` rebuilds :class:`PathFollowingMPCConfig`
+    and omits ``weight_lag`` / ``contour_deadzone`` (silently → 0). FRET keeps
+    the caller's full config and only overrides ``cruise_speed`` from
+    :class:`VehicleConfig`.
+    """
+    x0, y0 = waypoints[0]
+    theta0 = initial_heading(waypoints)
+    vehicle = DubinsVehicle(
+        x=x0,
+        y=y0,
+        heading=theta0,
+        max_speed=cfg.max_speed,
+        min_speed=cfg.min_speed,
+        max_turn_rate=cfg.max_turn_rate,
+        max_acceleration=cfg.max_acceleration,
+        max_turn_rate_dot=cfg.max_turn_rate_dot,
+    )
+    limits = DubinsVehicleLimits(
+        max_speed=cfg.max_speed,
+        min_speed=cfg.min_speed,
+        max_turn_rate=cfg.max_turn_rate,
+        max_acceleration=cfg.max_acceleration,
+        max_turn_rate_dot=cfg.max_turn_rate_dot,
+    )
+    effective = replace(mpc_cfg, cruise_speed=cfg.cruise_speed)
+    tracker = DubinsPathFollowingMPC(
+        vehicle_limits=limits,
+        config=effective,
+        occupancy=occupancy,
+    )
+    tracker.set_reference(waypoints)
+    loop = MPCTrackingLoop(vehicle, tracker, cruise_speed=cfg.cruise_speed)
+    return vehicle, loop
 
 
 def _mpc_config(ctrl: dict[str, Any]) -> PathFollowingMPCConfig:
@@ -1218,10 +1268,10 @@ class DubinsRaceRunner:
         # avoidance in the warehouse occupancy; feeding that same map into
         # DubinsPathFollowingMPC re-opens preview-cruise taper + soft
         # barriers and recreates stop-and-go on free segments.
-        rrt_vehicle, rrt_loop = build_vehicle_mpc_sim(
+        rrt_vehicle, rrt_loop = _build_vehicle_mpc_sim(
             rrt_path, vehicle_cfg, mpc_cfg, occupancy=None
         )
-        sst_vehicle, sst_loop = build_vehicle_mpc_sim(
+        sst_vehicle, sst_loop = _build_vehicle_mpc_sim(
             sst_path, vehicle_cfg, mpc_cfg, occupancy=None
         )
 

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -1267,11 +1267,29 @@ class DubinsRaceRunner:
         telemetry_enabled: bool | None = None,
         telemetry_output_dir: pathlib.Path | None = None,
         telemetry_csv_basename: str | None = None,
+        max_sim_time_s: float | None = None,
     ) -> DubinsRaceRunResult:
-        """Execute dual planning, simultaneous tracking, and race metrics."""
+        """Execute dual planning, simultaneous tracking, and race metrics.
+
+        Args:
+            max_sim_time_s: Optional early-stop wall for showcase clip export.
+                When set, the loop ends at this sim time even if both agents
+                have not reached the goal yet (full-race tests leave this
+                ``None`` and still wait for ``session.finished`` / timeout).
+        """
         params = self.load_parameters()
         race_timeout = float(params["race_timeout"])
-        max_steps = int(race_timeout / float(params["simulation_dt"]))
+        dt = float(params["simulation_dt"])
+        if max_sim_time_s is not None:
+            if float(max_sim_time_s) <= 0.0:
+                raise ValueError(
+                    f"max_sim_time_s must be > 0 (got {max_sim_time_s!r})"
+                )
+            # Cap by race_timeout so callers cannot exceed scenario policy.
+            stop_s = min(float(max_sim_time_s), race_timeout)
+            max_steps = int(stop_s / dt) + 1
+        else:
+            max_steps = int(race_timeout / dt)
         scenario_id = str(params.get("scenario_id", "dubins_race"))
 
         rng_ctx = (
@@ -1368,6 +1386,11 @@ class DubinsRaceRunner:
                     bridge.set_sst_pose(session.sst_vehicle.pose)
                     bridge.set_dummy_pose(session.dummy_pose)
             if session.finished:
+                break
+            if (
+                max_sim_time_s is not None
+                and session.sim_time_s + 1e-9 >= float(max_sim_time_s)
+            ):
                 break
 
         result = session.to_result(

--- a/tests/release/test_showcase_manifest.py
+++ b/tests/release/test_showcase_manifest.py
@@ -30,6 +30,17 @@ def test_manifest_loads_release_focus_scenarios() -> None:
     assert manifest.height == 720
 
 
+def test_dubins_release_is_overview_only_with_clip_budget() -> None:
+    """Dubins CI encode budget: overview @ 20 fps × 30 s (no follow)."""
+    dubins = load_showcase_manifest().by_id("dubins_race")
+    assert dubins.cameras == ("overview",)
+    assert dubins.requires_follow is False
+    assert dubins.fps == 20
+    assert dubins.clip_duration_s == 30.0
+    assert dubins.effective_fps(30) == 20
+    assert dubins.physics_mode is True
+
+
 def test_omy_release_variants_differ_only_by_planner() -> None:
     manifest = load_showcase_manifest()
     rrt = manifest.by_id("omy_clutter_rrt")
@@ -50,17 +61,15 @@ def test_omx_release_variants_differ_only_by_planner() -> None:
     assert sst.planner_algorithm == "sst"
 
 
-def test_mobile_requires_follow_static_overview_only() -> None:
+def test_overview_required_follow_optional_for_mobile() -> None:
     manifest = load_showcase_manifest()
     for item in manifest.scenarios:
-        if item.robot_class == "mobile":
-            assert item.cameras == ("overview", "follow")
-            assert item.requires_follow is True
-        else:
-            assert item.cameras == ("overview",)
+        assert "overview" in item.cameras
+        if item.robot_class == "static":
+            assert "follow" not in item.cameras
             assert item.requires_follow is False
 
 
 def test_release_cameras_for_robot_class() -> None:
-    assert release_cameras_for_robot_class("mobile") == ("overview", "follow")
+    assert release_cameras_for_robot_class("mobile") == ("overview",)
     assert release_cameras_for_robot_class("static") == ("overview",)

--- a/tests/release/test_showcase_manifest.py
+++ b/tests/release/test_showcase_manifest.py
@@ -31,15 +31,15 @@ def test_manifest_loads_release_focus_scenarios() -> None:
 
 
 def test_dubins_release_shows_finish_with_hold_and_lower_res() -> None:
-    """Dubins: full race × 1.25 hold @ 960×540 / 20 fps (no follow)."""
+    """Dubins: full race → fixed 40 s video @ 960×540 / 20 fps (no follow)."""
     dubins = load_showcase_manifest().by_id("dubins_race")
     assert dubins.cameras == ("overview",)
     assert dubins.requires_follow is False
     assert dubins.fps == 20
     assert dubins.width == 960
     assert dubins.height == 540
-    assert dubins.clip_scale == 1.25
-    assert dubins.clip_duration_s is None
+    assert dubins.clip_duration_s == 40.0
+    assert dubins.clip_scale is None
     assert dubins.effective_fps(30) == 20
     assert dubins.effective_width(1280) == 960
     assert dubins.effective_height(720) == 540

--- a/tests/release/test_showcase_manifest.py
+++ b/tests/release/test_showcase_manifest.py
@@ -30,14 +30,19 @@ def test_manifest_loads_release_focus_scenarios() -> None:
     assert manifest.height == 720
 
 
-def test_dubins_release_is_overview_only_with_clip_budget() -> None:
-    """Dubins CI encode budget: overview @ 20 fps × 30 s (no follow)."""
+def test_dubins_release_shows_finish_with_hold_and_lower_res() -> None:
+    """Dubins: full race × 1.25 hold @ 960×540 / 20 fps (no follow)."""
     dubins = load_showcase_manifest().by_id("dubins_race")
     assert dubins.cameras == ("overview",)
     assert dubins.requires_follow is False
     assert dubins.fps == 20
-    assert dubins.clip_duration_s == 30.0
+    assert dubins.width == 960
+    assert dubins.height == 540
+    assert dubins.clip_scale == 1.25
+    assert dubins.clip_duration_s is None
     assert dubins.effective_fps(30) == 20
+    assert dubins.effective_width(1280) == 960
+    assert dubins.effective_height(720) == 540
     assert dubins.physics_mode is True
 
 

--- a/tests/release/test_write_showcase_meta.py
+++ b/tests/release/test_write_showcase_meta.py
@@ -30,7 +30,6 @@ def test_write_showcase_meta_all_scenarios(tmp_path: Path) -> None:
 
     clips: list[tuple[str, str, str]] = [
         ("dubins_race", "overview", "dubins_race_timing.json"),
-        ("dubins_race", "follow", "dubins_race_timing.json"),
         ("omx_wall_maze_rrt", "overview", "omx_wall_maze_rrt_timing.json"),
         ("omx_wall_maze_sst", "overview", "omx_wall_maze_sst_timing.json"),
         ("omy_pick_place", "overview", "omy_pick_place_timing.json"),
@@ -64,7 +63,7 @@ def test_write_showcase_meta_all_scenarios(tmp_path: Path) -> None:
     assert meta["partial"] is False
     assert len(meta["showcases"]) == 6
     assert meta["release_cameras"] == {
-        "mobile": ["overview", "follow"],
+        "mobile": ["overview"],
         "static": ["overview"],
     }
     assert meta["primary_videos"]["dubins_race"] == "dubins_race_overview.mp4"

--- a/tests/scenario/test_dubins_mpc_config.py
+++ b/tests/scenario/test_dubins_mpc_config.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import pathlib
 
 from fret.config_loader import load_ros_parameters_yaml
-from fret.scenario.dubins_race_runner import _mpc_config
+from fret.scenario.dubins_race_runner import (
+    _build_vehicle_mpc_sim,
+    _mpc_config,
+    _vehicle_config,
+)
 
 _DUBINS_CTRL = (
     pathlib.Path(__file__).resolve().parents[2]
@@ -46,3 +50,21 @@ def test_mpc_config_defaults_progress_first_when_keys_absent() -> None:
     assert cfg.weight_contour == 1.0
     assert cfg.weight_lag == 0.0
     assert cfg.contour_deadzone == 0.0
+
+
+def test_build_vehicle_mpc_sim_preserves_progress_first_fields() -> None:
+    """Live tracker must keep lag/deadzone (ARCO factory drops them)."""
+    ctrl = load_ros_parameters_yaml(_DUBINS_CTRL)
+    vehicle_cfg = _vehicle_config(ctrl)
+    mpc_cfg = _mpc_config(ctrl)
+    _vehicle, loop = _build_vehicle_mpc_sim(
+        [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0)],
+        vehicle_cfg,
+        mpc_cfg,
+        occupancy=None,
+    )
+    live = loop.tracker.config
+    assert live.weight_lag == mpc_cfg.weight_lag == 10.0
+    assert live.contour_deadzone == mpc_cfg.contour_deadzone == 0.10
+    assert live.weight_contour == mpc_cfg.weight_contour
+    assert live.cruise_speed == vehicle_cfg.cruise_speed

--- a/tests/scenario/test_dubins_physics_showcase.py
+++ b/tests/scenario/test_dubins_physics_showcase.py
@@ -39,6 +39,11 @@ def test_physics_pose_history_non_negative_clearance() -> None:
     )
     assert result.both_reached_goal is True
     assert result.min_obstacle_clearance_m >= 0.0
+    # Progress-first lag must stay live; without it SST crawls (~141 s) and
+    # the release encode job blows the 10 min budget even with a 30 s clip.
+    assert result.race_duration_s < 90.0
+    assert result.sst_time_to_goal_s is not None
+    assert result.sst_time_to_goal_s < 90.0
 
 
 def test_physics_agents_finish_without_lateral_skid() -> None:

--- a/tests/scenario/test_dubins_showcase_early_stop.py
+++ b/tests/scenario/test_dubins_showcase_early_stop.py
@@ -1,0 +1,36 @@
+"""Showcase early-stop: clip export must not wait for both agents at goal."""
+
+from __future__ import annotations
+
+from fret.scenario.dubins_race_runner import DubinsRaceRunner
+from fret.scenario.planner_rng import SHOWCASE_PLANNER_RNG_SEED
+
+
+def test_max_sim_time_stops_before_race_timeout() -> None:
+    """``max_sim_time_s`` ends the loop even when agents are still racing."""
+    result = DubinsRaceRunner().run(
+        record_poses=True,
+        physics_mode=False,
+        planner_rng_seed=SHOWCASE_PLANNER_RNG_SEED,
+        max_sim_time_s=1.0,
+    )
+    assert result.race_duration_s <= 1.0 + 1e-6
+    assert len(result.rrt_pose_history) >= 2
+    assert len(result.sst_pose_history) >= 2
+    # Full warehouse race is far longer than 1 s; early-stop must not finish.
+    assert result.both_reached_goal is False
+
+
+def test_simulate_dubins_poses_honours_duration_early_stop() -> None:
+    """``simulate_dubins_race_poses(duration_s=…)`` must not run to goal."""
+    import scripts.render_mujoco as rm
+
+    rrt, sst, _dummy, sim_time_s = rm.simulate_dubins_race_poses(
+        "dubins_race",
+        duration_s=2.0,
+        fps=20,
+        physics_mode=False,
+    )
+    assert sim_time_s <= 2.0 + 1e-6
+    assert len(rrt) == max(2, int(round(2.0 * 20)))
+    assert len(sst) == len(rrt)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Dubins `release.yml` render job was taking **~30–60 min** and hitting the 60 min timeout. Root cause was not telemetry: a long physics race (~141 s after progress-first) × dual 720p encode (overview + follow).

## Fix (rollout order commits)

| Layer | Change |
|---|---|
| **A** | Overview-only budget path |
| **B** | `max_sim_time_s` for fixed-duration early-stop (kept for tools/tests) |
| **C** | Preserve `weight_lag`/`contour_deadzone` → race **~38 s** |
| **D** | Follow deferred (≈2× encode) |
| **+** | Fixed **40 s** overview @ **960×540** / 20 fps (full race + short hold) |

## Clip policy

- Run **full** physics race (~38 s)
- Video length fixed at **40 s** (`--video-duration 40`; hold after finish)
- Encode **960×540 @ 20 fps**, overview only (800 frames)

## Verification

| Check | Result |
|---|---|
| formatting / types | pass |
| release + early-stop + MPC tests | pass |
| Physics `race_duration_s < 90` | pass (~38 s) |
| Argv | `--full-duration --video-duration 40.0 --width 960 --height 540 --fps 20` |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0af00c2-d09b-4a42-8c91-7505c66d7498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0af00c2-d09b-4a42-8c91-7505c66d7498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

