### PR TITLE
docs: CV simulation line (v1.3–v1.5) and hardware era (v2.x)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,7 +323,7 @@ down to the test that proves it, and from any test back to the criterion.
 | --- | --- | --- |
 | `FR-<LAYER>-<NN>` | [docs/requirements.md](docs/requirements.md) | `FR-CTL-02` |
 | `SC-<NN>` | [docs/scenarios.md](docs/scenarios.md) | `SC-01` |
-| Release | [docs/releases.md](docs/releases.md) | v1.0 |
+| Release | [docs/releases.md](docs/releases.md) | v1.x / v2.x / v3.0 |
 
 **Rules:**
 
@@ -528,7 +528,7 @@ When an external guide conflicts with this file or [docs/guidelines.md](docs/gui
 | [docs/interfaces.md](docs/interfaces.md) | Level 2 — typed contracts, QoS, FSMs |
 | [docs/mujoco.md](docs/mujoco.md) | Level 2 — MuJoCo simulation integration |
 | [docs/simulation.md](docs/simulation.md) | User guide — MuJoCo modes and quick start |
-| [docs/releases.md](docs/releases.md) | Release specification v1.0–v1.3 |
+| [docs/releases.md](docs/releases.md) | Release specification (v1.x sim/CV, v2.x hardware, v3.0 north-star) |
 | [docs/mujoco_physics_v1.2.md](docs/mujoco_physics_v1.2.md) | v1.2 physics SITL engineering spec |
 | [docs/guidelines.md](docs/guidelines.md) | Coding standards and formatting |
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ connects the [ARCO](https://github.com/alexandrelheinen/arco) motion-planning st
 MuJoCo simulation. Algorithm code lives in pure Python; a thin ROS 2 layer handles
 topics, actions, and simulator I/O.
 
-**Current release: v1.2.6** — dual-agent Dubins race, **MuJoCo physics SITL**,
-OM-X / OMY tabletop showcases, plus **PlotJuggler telemetry** CSV/JSON beside
-release videos on R2. Mobile showcase renders use `--physics-mode` by default.
+**Current release: v1.2.7** — dual-agent Dubins race (TB3 case study),
+**MuJoCo physics SITL**, OM-X / OMY tabletop showcases, PlotJuggler telemetry
+beside release videos on R2. Mobile showcase renders use `--physics-mode`.
 
 <br clear="left">
 
@@ -17,21 +17,18 @@ release videos on R2. Mobile showcase renders use `--physics-mode` by default.
 
 ## What FRET provides
 
-| Capability | v1.1 Dubins race | v1.2 physics SITL |
+| Capability | Mobile (TB3 / Dubins) | Manipulators (OM-X / OMY) |
 |---|---|---|
-| Robot model | Two SE(2) car-like agents (`dubins`) | Actuator-driven Dubins |
-| Scenario | Independent RRT* vs SST race A→B | SC-v11 under `physics_mode` |
-| Planning | ARCO RRT* + SST in 2-D with structure occupancy | Same planners; contacts during execution |
-| Control | ARCO Pure Pursuit + DubinsVehicle | Velocity actuators → `mj_step` |
-| Visual backend | MuJoCo MJCF (`dubins_race.xml`) | Physics-integrated motion in release MP4s |
-| Showcase output | Split-screen follow + overview MP4 | Real-time physics showcase (release CI) |
+| Role | ARCO SE(2) → MuJoCo physics case study | Tabletop pick-and-place (+ CV from v1.4) |
+| Planning | RRT* / SST in SE(2) | Joint-space RRT* / SST + FSM |
+| Control | Path-following MPC | JointSpaceMPC |
+| Computer vision | **Not used** | Pipeline in v1.3; integrated v1.4–v1.5 |
+| Sim | MuJoCo physics SITL | MuJoCo physics + (v1.4) cameras |
 
-The Dubins showcase ships with headless render scripts, pure-Python E2E tests (no ROS
-required for CI validation), and optional ROS 2 SITL launch files.
-
-**Coming next:** tag **v1.2.4** (6-DOF Menagerie OMY showcase), then **v1.3** hardware
-HITL — last milestone before computer vision. Python package on `main` is already
-**1.3.0** for that development line. See [docs/roadmap.md](docs/roadmap.md) and
+**Coming next (still simulation):** **v1.3** computer-vision pipeline and
+algorithm selection → **v1.4** CV↔manipulation → **v1.5** dynamic ball /
+industrial place. **Hardware is v2.x**, not v1.3. Package on `main` is
+**1.3.0** for the open CV line. See [docs/roadmap.md](docs/roadmap.md) and
 [docs/releases.md](docs/releases.md).
 
 ---
@@ -45,13 +42,16 @@ src/fret/
 ├── scenario/          # Pure-Python E2E orchestrators (Dubins race)
 ├── telemetry/         # Opt-in PlotJuggler CSV logger + layouts (FR-SIM-12)
 ├── scene/             # Scene acquisition → occupancy adapter
+├── vision/            # Ball CV pipeline (scaffold from v1.3)
 ├── ros/               # MuJoCo bridge, perception bridge, race node
 ├── validation/        # Metrics and quality gates
+├── hardware/          # HITL bridge stub (v2.x)
 ├── config/
 │   ├── scenarios/     # Run definitions (start/goal, duration, config refs)
 │   ├── planning/      # Algorithm tunables (clearance, trajectory, replanning)
 │   ├── controllers/   # Per-model gains (dubins.yml, …)
 │   ├── worlds/        # Obstacle layouts + Dubins vehicle/planner tuning
+│   ├── vision/        # CV thresholds + camera extrinsics (from v1.3)
 │   └── simulation/    # MuJoCo bridge settings
 ├── mjcf/              # MuJoCo scenes (primary visual backend)
 ├── launch/            # sitl.py, mujoco.py
@@ -59,8 +59,8 @@ src/fret/
 ```
 
 **Asset policy:** product robots and props load from git submodules (Menagerie + AWS).
-codebase and CI for shared planning/control primitives; it is not a product release
-target.
+Bootstrap planning primitives remain in the codebase for CI; they are not product
+showcase targets.
 
 ---
 
@@ -71,14 +71,18 @@ target.
 - **ROS 2** is the runtime middleware (topics, services, actions, parameters).
 - **ARCO** is a synchronous library inside planner nodes — not a separate ROS node.
 - **C-space** is the planning domain for manipulators; **SE(2)** for Dubins agents.
-- **MuJoCo** is the simulation engine for physics, contacts, rendering, and SITL.
-  v1.2 ships **physics SITL** by default (`mj_step`, velocity actuators, contact
-  dynamics). Kinematic mirroring remains for fast regression (`physics_mode:=false`
-  or `--kinematic-mode`).
+- **MuJoCo** is the simulation engine for physics, contacts, rendering, cameras,
+  and SITL. v1.2 ships **physics SITL** by default (`mj_step`, velocity
+  actuators, contact dynamics). Kinematic mirroring remains for fast regression
+  (`physics_mode:=false` or `--kinematic-mode`).
+- **Computer vision** (`fret.vision`, from v1.3) serves **manipulators only**;
+  TB3 / Dubins never consumes ball tracking. Place/dispenser poses stay known
+  scenario parameters. Architecture: [docs/vision/](docs/vision/).
+- **Hardware HITL** is a **v2.x** era — not part of v1.3–v1.5.
 - **Simulator-specific code** lives only in `fret.ros` and `launch/`.
 - **Configuration over code:** every tunable algorithm parameter (planning clearance,
   controller gains, trajectory limits, replanning thresholds, Dubins vehicle
-  margins, and similar) **must live in YAML under `src/fret/config/`**.
+  margins, vision HSV ranges, and similar) **must live in YAML under `src/fret/config/`**.
   Python and MJCF must not embed numeric defaults for those values — missing keys
   fail at load time. Rendering-only constants (camera presets, mesh colours, UI
   layout) may stay hardcoded. Full reference: [docs/config.md](docs/config.md).
@@ -414,6 +418,7 @@ Example from a validated Dubins / TB3 race (RRT* blue, SST green, dummy grey):
 | Topic | Document |
 |---|---|
 | Telemetry + PlotJuggler layouts | [docs/modules/telemetry.md](docs/modules/telemetry.md) §5.3 |
+| Computer vision (v1.3–v1.5) | [docs/vision/README.md](docs/vision/README.md) |
 | v1.2 physics implementation spec | [docs/mujoco_physics_v1.2.md](docs/mujoco_physics_v1.2.md) |
 | Configuration reference | [docs/config.md](docs/config.md) |
 | Scenario catalogue | [docs/scenarios.md](docs/scenarios.md) |
@@ -430,8 +435,8 @@ Example from a validated Dubins / TB3 race (RRT* blue, SST green, dummy grey):
 
 | Topic | Document |
 |---|---|
-| Release specification (v1.1–v1.3) | [docs/releases.md](docs/releases.md) |
-| Roadmap & milestones | [docs/roadmap.md](docs/roadmap.md) |
+| Release specification (v1.x / v2.x / v3.0) | [docs/releases.md](docs/releases.md) |
+| Roadmap & eras | [docs/roadmap.md](docs/roadmap.md) |
 | Contributing & V-cycle | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Coding guidelines | [docs/guidelines.md](docs/guidelines.md) |
 

--- a/docs/arco.md
+++ b/docs/arco.md
@@ -21,7 +21,8 @@ ARCO repository: `https://github.com/alexandrelheinen/arco`
 | **v1.1** Dubins | `SSTPlanner`, `DubinsVehicle`, path-following MPC (`DubinsPathFollowingMPC`) | `map/vehicle.yml` / `map/city.yml` |
 | **v1.2** | *(physics upgrade — no new ARCO scenario)* | — |
 | **v1.2.3** manipulator | `KDTreeOccupancy`, `SSTPlanner`, `JointSpaceMPC` | `map/rrp.yml`, `map/ppp.yml` |
-| **v1.2.4** 6-DOF | `SSTPlanner`, `KDTreeOccupancy` | *(new)* |
+| **v1.2.4** 6-DOF | `SSTPlanner`, `KDTreeOccupancy`, `JointSpaceMPC` | OMY clutter / pick-place |
+| **v1.3+** Vision | *(FRET `fret.vision` — not ARCO)* | Ball track for manipulators |
 
 Bootstrap arm (MS-1–5) also uses `KDTreeOccupancy`, `SSTPlanner`, and
 `TrajectoryPruner` for regression CI.

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,8 +8,11 @@ simulation values must not be hardcoded in Python or MJCF (see
 | --- | --- |
 | `config/scenarios/` | Per-run definitions (start/goal, timeouts, physics flags) |
 | `config/controllers/` | Closed-loop gains (`ros__parameters` format) |
+| `config/planning/` | Trajectory / replanning tunables per model |
 | `config/worlds/` | Static obstacle layouts, Dubins vehicle/planner tuning |
 | `config/simulation/` | MuJoCo bridge and physics SITL (v1.2+) |
+| `config/vision/` | Ball CV thresholds + camera extrinsics (from v1.3) |
+| `config/release/` | Showcase matrix for release encode jobs |
 
 Scenario schema: [scenarios.md](scenarios.md#scenario-yaml-schema).
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -337,4 +337,65 @@ print('ARCO API surface OK')
 **Version pinning:** ARCO is co-developed with FRET. No version pin is enforced.
 The CI checkout step is responsible for obtaining a compatible ARCO snapshot.
 The CI job that requires ARCO must check out `../arco/` before installing it.
+
+---
+
+## Vision → Manipulation Boundary (v1.3+)
+
+Typed contracts for `fret.vision`. Full architecture:
+[vision/architecture.md](vision/architecture.md).
+
+### `CameraFrame`
+
+```python
+@dataclass(frozen=True)
+class CameraFrame:
+    camera_id: str
+    image: np.ndarray          # HxWx3 uint8 RGB (or gray HxW)
+    timestamp: float           # POSIX seconds or sim time
+    intrinsics_id: str         # key into vision camera YAML
+```
+
+### `BallDetection`
+
+```python
+@dataclass(frozen=True)
+class BallDetection:
+    camera_id: str
+    centre_px: tuple[float, float]  # (u, v)
+    radius_px: float
+    confidence: float               # [0, 1]
+```
+
+### `BallObservation`
+
+```python
+@dataclass(frozen=True)
+class BallObservation:
+    position_world: np.ndarray  # shape (3,), metres
+    covariance: np.ndarray | None  # optional 3x3
+    radius_m: float
+    pickable: bool | None       # None until v1.5 classifier exists
+    timestamp: float
+    source: str                 # e.g. "hsv_plane", "stereo"
+```
+
+**Invariants:**
+
+- `position_world` is in the `world` frame (same policy as occupancy).
+- `pickable is False` ⇒ manipulators must not start GRASP (v1.5+).
+- Missing detection ⇒ pipeline returns `None` (no fabricated pose).
+
+### `PlaceTarget` (scenario parameter — not from CV)
+
+```python
+@dataclass(frozen=True)
+class PlaceTarget:
+    position_world: np.ndarray  # shape (3,)
+    frame_id: str               # must be "world"
+```
+
+Loaded from scenario YAML (dispenser / container). Vision shall not be required
+to detect this fixture for v1.4–v1.5 acceptance.
+
 The exact CI checkout configuration is tracked in `.github/workflows/tests.yml`.

--- a/docs/modules/control.md
+++ b/docs/modules/control.md
@@ -4,9 +4,9 @@
 **Source:** `src/fret/control/`  
 **Tests:** `tests/control/`
 
-> **Release roadmap:** v1.1 uses ARCO Dubins path-following MPC; v1.2 enables
-> MuJoCo physics actuators; v1.2.3 OMX pick-and-place uses ``JointSpaceMPC``;
-> v1.2.4 adds 6-DOF numerical IK. See [releases.md](../releases.md).
+> **Release roadmap:** v1.1 ARCO Dubins path-following MPC; v1.2 MuJoCo physics;
+> v1.2.3 OMX `JointSpaceMPC` + FSM; v1.2.4 OMY 6-DOF; v1.4+ ball pose from
+> `fret.vision`. See [releases.md](../releases.md).
 
 ---
 

--- a/docs/modules/hardware.md
+++ b/docs/modules/hardware.md
@@ -8,19 +8,21 @@
 
 ## Responsibility
 
-The hardware module provides the serial communication bridge between the ROS 2
-high-level controller (Raspberry Pi 5) and the low-level actuator controller
-(Arduino Mega). It is a **v1.3 deliverable** and is currently implemented as
-a stub.
+Serial / Micro-ROS bridge between the ROS 2 high-level stack (e.g. Raspberry Pi
+5) and low-level actuation (e.g. Arduino Mega). This is a **v2.x** deliverable.
 
 ---
 
 ## Status
 
-> **v1.3 — Not yet implemented.**
-> The `bridge_node.py` stub exists to define the interface and maintain the
-> architecture structure. Hardware integration begins after simulation milestones
-> (v1.2.4) are debugged and stable.
+> **v2.x — Not yet implemented.**  
+> The `bridge_node.py` stub defines the interface. Hardware integration starts
+> **after** the simulation CV line (**v1.5**) is validated.  
+> See [releases.md § v2.x](../releases.md#v2x--hardware-integration-line) and
+> [roadmap.md](../roadmap.md).
+
+**v1.3–v1.5 are simulation-only** (including computer vision). Do not schedule
+HITL work under those tags.
 
 ---
 
@@ -39,37 +41,40 @@ Future ROS 2 node that will:
 
 ---
 
-## Planned Serial Protocol
+## Target stack (indicative)
 
 ```
 RPi 5 (ROS 2)  ──[USB/UART]──  Arduino Mega (Micro-ROS)
-    │                                    │
-    │  /joint_commands ──► BridgeNode ──► serial frame ──► motor drivers
-    │                                    │
-    │  /joint_states  ◄── BridgeNode ◄── encoder data ◄── encoders
+                                      │
+                                 motor drivers / encoders
 ```
 
-The protocol will be finalized during v1.3. Micro-ROS is the preferred
-transport; a custom ASCII protocol is the fallback.
+Protocol details are finalized when **v2.0** planning opens. Micro-ROS is the
+preferred transport; a custom ASCII fallback may exist.
 
----
-
-## Hardware Targets
-
-| Component | Target |
-|---|---|
-| High-level controller | Raspberry Pi 5 (Ubuntu 24.04) |
-| Low-level controller | Arduino Mega |
+| Item | Guidance |
+| --- | --- |
 | Communication | USB serial or UART (Micro-ROS) |
-| Actuators | Nema 17 stepper class |
-| Drivers | TMC series (e.g., TMC2209) |
+| Command rate | Match control (≥ 50 Hz when closed-loop) |
+| Feedback | Encoders → `/joint_states` ≥ 50 Hz |
 
 ---
 
-## Satisfies Requirements (v1.3)
+## Modular v2.x steps
+
+| Tag | Focus |
+| --- | --- |
+| v2.0 | Bridge + encoder loop |
+| v2.1 | Real cameras → same `fret.vision` contracts |
+| v2.2 | Real arm actuation |
+| v2.3 | Full HITL pick-and-place |
+
+---
+
+## Satisfies Requirements (v2.x)
 
 | Requirement | Description |
 |---|---|
 | FR-HW-01 | Relay `/joint_commands` to Arduino via Micro-ROS |
-| FR-HW-02 | Publish encoder feedback to `/joint_states` at ≥ 50 Hz |
-| FR-HW-03 | Validate message integrity before forwarding commands |
+| FR-HW-02 | Publish encoder feedback on `/joint_states` ≥ 50 Hz |
+| FR-HW-03 | Validate message integrity before actuation |

--- a/docs/modules/ros_nodes.md
+++ b/docs/modules/ros_nodes.md
@@ -66,6 +66,7 @@ Supported obstacle types (configured in `perception.yaml`):
 - `cylinder` — samples lateral surface and top-cap points
 
 This node provides the obstacle cloud that feeds `SceneAcquisition`.
+It is **not** the ball computer-vision pipeline (`fret.vision` / v1.3+).
 
 **Configuration:** `src/fret/config/perception.yaml`
 

--- a/docs/modules/vision.md
+++ b/docs/modules/vision.md
@@ -1,0 +1,72 @@
+# Vision Module
+
+**Package:** `fret.vision` *(target — scaffold in v1.3)*  
+**Source:** `src/fret/vision/`  
+**Tests:** `tests/vision/`  
+**Program docs:** [vision/README.md](../vision/README.md)
+
+> **Release:** v1.3 pipeline · v1.4 MuJoCo integration · v1.5 pickability.  
+> See [releases.md](../releases.md).
+
+---
+
+## Responsibility
+
+Detect and track a graspable **ball** in camera images and lift detections to a
+world-frame `BallObservation` for manipulator pick-and-place. Does **not**
+detect the place dispenser (known scenario parameter). Does **not** serve TB3.
+
+This module is distinct from `PerceptionBridgeNode` (YAML obstacle clouds for
+occupancy).
+
+---
+
+## Components (Level 3 stubs — v1.3)
+
+### `types` — contracts
+
+See [interfaces.md § Vision](../interfaces.md#vision--manipulation-boundary-v13).
+
+### `pipeline.BallVisionPipeline`
+
+```python
+class BallVisionPipeline:
+    def __init__(self, config: VisionConfig) -> None: ...
+
+    def process(
+        self, frames: Sequence[CameraFrame]
+    ) -> BallObservation | None:
+        """Detect (+ optional track) and lift to world frame."""
+        ...
+```
+
+### `detect` — algorithm plugins
+
+Common interface; **primary** implementation is HSV + circularity
+([algorithm-selection.md](../vision/algorithm-selection.md)).
+
+### `geometry` — pixel → world
+
+Table/floor plane intersection for monocular Z; optional stereo triangulation.
+
+---
+
+## Configuration
+
+All thresholds and camera extrinsics live under `src/fret/config/vision/`
+(created with the v1.3 implementation). No magic numbers in Python for tunables.
+
+---
+
+## ROS boundary (v1.4+)
+
+`fret.ros.vision_bridge` (name TBD) adapts sensor messages ↔ pipeline. Core
+vision code remains ROS-free.
+
+---
+
+## Satisfies requirements
+
+| Requirement | Description |
+|---|---|
+| FR-VIS-01–… | See [requirements.md](../requirements.md#computer-vision-v13v15) |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,43 +1,67 @@
-# FRET Release Specification (v1.0 → v1.3)
+# FRET Release Specification
 
-> **Authoritative product roadmap.** All requirements, scenarios, and milestones trace
-> to this document.
+> **Authoritative product roadmap.** All requirements, scenarios, and milestones
+> trace to this document. High-level eras: [roadmap.md](roadmap.md).
 >
-> **Related:** [roadmap.md](roadmap.md) ·
-> [requirements.md](requirements.md) ·
-> [mujoco.md](mujoco.md) · [scenarios.md](scenarios.md) ·
-> [README § Architecture](../README.md#architecture)
+> **Related:** [requirements.md](requirements.md) ·
+> [scenarios.md](scenarios.md) · [vision/README.md](vision/README.md) ·
+> [mujoco.md](mujoco.md) · [README § Architecture](../README.md#architecture)
 
 ---
 
 ## Product vision
 
-FRET is a **ROS 2 full-stack robotics framework** that connects the **ARCO** motion-
-planning library to simulation and (eventually) hardware. Each minor release adds one
-robot class, one showcase scenario, and one article-ready visual demo.
+FRET is a **ROS 2 full-stack robotics framework** that connects **ARCO** planning
+and control to MuJoCo simulation, then (from **v2.x**) to hardware. Releases are
+grouped by era:
 
-| Release | Robot | Scenario | Simulator |
+| Era | Versions | What ships |
+| --- | --- | --- |
+| **Simulation & algorithms** | **v1.x** | Planners, controllers, MuJoCo SITL, computer vision *in simulation* |
+| **Hardware integration** | **v2.x** | Modular HITL (bridge → real cameras → real arm → full loop) |
+| **Product** | **v3.0+** | Definitive integrated system (north-star only in this doc) |
+
+### Release matrix (simulation line)
+
+| Release | Robot / focus | Scenario theme | Backend |
 |---|---|---|---|
-| **v1.0** | *(superseded)* | Bootstrap iteration — not a product showcase | — |
-| **v1.1** | Dubins mobile × 2 | Dual-robot race A→B through column forest | MuJoCo |
-| **v1.2** | Dubins (physics upgrade) | Actuator-driven SITL with contact dynamics | MuJoCo |
-| **v1.2.3** | OpenMANIPULATOR-X (4-DOF) | Tabletop A→B → pick-place → Γ-wall maze | MuJoCo |
-| **v1.2.4** | 6-DOF manipulator | Cluttered-cell C-space planning + execution | MuJoCo |
-| **v1.3** | Hardware HITL | Micro-ROS bridge + physical prototype | Pi 5 + Arduino |
+| **v1.0** | *(superseded)* | Bootstrap — not a product showcase | — |
+| **v1.1** | Dubins / TB3 × 2 | Dual-robot race A→B (ARCO → MuJoCo case study) | MuJoCo |
+| **v1.2** | Dubins physics | Actuator-driven SITL with contacts | MuJoCo |
+| **v1.2.3** | OpenMANIPULATOR-X | Tabletop reach → pick-place → Γ-wall maze | MuJoCo |
+| **v1.2.4** | OpenMANIPULATOR-Y | 6-DOF reach → pick-place → clutter | MuJoCo |
+| **v1.3** | Vision algorithms | Ball track pipeline + **algorithm selection** | Fixtures (+ optional MuJoCo frames) |
+| **v1.4** | OM-X / OMY + CV | MuJoCo cameras → replace hardcoded ball pose | MuJoCo + CV |
+| **v1.5** | Dynamic manipulation | Rolling ball, pickability, industrial place | MuJoCo + CV |
 
-**Platform stack (all releases):**
+**TB3 / Dubins** never consumes CV — it exists to prove ARCO SE(2) racing under
+MuJoCo. **Only manipulators** use vision (they interact with graspable objects).
 
-- **Planning:** ARCO (RRT*, SST, KDTree occupancy, trajectory pruner)
+**Platform stack (v1.x):**
+
+- **Planning / control:** ARCO (RRT*, SST, occupancy, path-following + joint MPC)
 - **Middleware:** ROS 2 Jazzy
-- **Simulation:** MuJoCo (physics, contacts, rendering, SITL)
+- **Simulation:** MuJoCo (physics, contacts, cameras, rendering, SITL)
+- **Vision (from v1.3):** `fret.vision` — pure-Python pipeline; ROS I/O thin
 
 ---
 
 ## Engineering foundation
 
 Early bootstrap work validated the planning/control pipeline. Product robots are
-drawn from the **ROBOTIS MuJoCo Menagerie** submodule (TurtleBot3, OpenMANIPULATOR-X,
-…). Legacy SCARA/RRP assets are retired.
+drawn from the **ROBOTIS MuJoCo Menagerie** submodule (TurtleBot3,
+OpenMANIPULATOR-X/Y, …). Legacy SCARA/RRP assets are retired.
+
+**Decisions already locked for the CV line** (detail in
+[vision/](vision/README.md)):
+
+| Topic | Decision |
+| --- | --- |
+| CV consumers | Manipulators only (`open_manipulator_x`, `omy`) |
+| Ball pose | From vision (v1.4+); no hardcoded ball / `pick_xy` in release paths |
+| Place / dispenser | **Known scenario parameter** (fixed fixture) — not required from CV |
+| v1.3 primary algorithm | Colour (HSV) blob + circular contour; table-plane lift for Z; dual-cam optional — see [algorithm-selection.md](vision/algorithm-selection.md) |
+| v1.5 ball cadence (provisional) | **One ball at a time** for the release scenario; multi-ball deferred |
 
 ---
 
@@ -238,8 +262,9 @@ gripper (~3 cm aperture).
 
 ### Goal
 
-A **6-DOF revolute manipulator** (Menagerie OpenMANIPULATOR-Y preferred) performs C-space planning
-and trajectory execution in a cluttered environment — the simulation capstone before hardware.
+A **6-DOF revolute manipulator** (Menagerie OpenMANIPULATOR-Y) performs C-space
+planning and trajectory execution in a cluttered environment — the last
+**pre-vision** manipulator showcase on the v1.2.x line. *(Shipped.)*
 
 ### Scope (high level)
 
@@ -281,33 +306,187 @@ and trajectory execution in a cluttered environment — the simulation capstone 
 
 ---
 
-## v1.3 — Hardware HITL
+## v1.3 — Computer vision pipeline
 
 ### Goal
 
-Close the loop from FRET's ROS 2 stack to a **physical prototype**: Raspberry Pi 5 high-level
-control, Arduino Mega low-level actuation, Micro-ROS serial bridge, and encoder feedback.
-Ships after simulation milestones (v1.2.4) are debugged and stable. This is the **last
-product milestone before computer vision** (vision / dynamic replanning stay post-v1.3).
+Ship a **pure-Python computer-vision pipeline** that can track a graspable ball
+in images from **one or more cameras**, with unit tests, written specs, and an
+**explicit algorithm selection** for that goal. No manipulation closed loop and
+no requirement for production MJCF camera mounts in this tag — those are v1.4.
 
-### Scope (high level)
+Architecture: [vision/architecture.md](vision/architecture.md).  
+Selection ADR: [vision/algorithm-selection.md](vision/algorithm-selection.md).
+
+### Scope
 
 | Item | Detail |
 |---|---|
-| Bridge | `hardware/bridge_node.py` — `/joint_commands` → serial → motor drivers |
-| Feedback | Encoder data → `/joint_states` at ≥ 50 Hz |
-| Transport | Micro-ROS preferred; custom ASCII fallback |
-| Targets | Pi 5 + Arduino Mega + Nema 17 class steppers |
+| Package | `fret.vision` (algorithm layer; no ROS imports in core) |
+| Goal | Detect / track ball centre; lift to metric pose when calibration + geometry allow |
+| Cameras | API supports N≥1; selection must justify mono vs multi-view |
+| Consumers | Spec’d for manipulators; **TB3 out of scope** |
+| Place pose | Out of scope (known parameter later) |
+| Tests | Synthetic fixtures + recorded frames under `tests/vision/` |
+
+### Scenario IDs
+
+| ID | Description |
+|---|---|
+| SC-v15 | Vision unit / fixture scenarios (algorithm gates; not a robot showcase) |
 
 ### Acceptance criteria
 
 | # | Criterion |
 |---|---|
-| V13-1 | Bridge relays validated joint commands without corruption |
-| V13-2 | Encoder feedback published at ≥ 50 Hz |
-| V13-3 | End-to-end HITL smoke on at least one manipulator joint |
+| V13-1 | `FR-VIS-*` requirements and `docs/modules/vision.md` API stubs published |
+| V13-2 | Algorithm selection document records candidates, metrics, and **chosen primary** |
+| V13-3 | Unit tests: ball centre error ≤ threshold on fixtures (see selection doc) |
+| V13-4 | Pipeline runs without ROS; optional thin ROS wrapper may exist but is not required |
+| V13-5 | Multi-camera interface is defined even if the primary algo starts monocular |
 
-*Detailed task breakdown (T13-*) will be written when v1.2.4 planning starts.*
+### Implementation tasks
+
+| ID | Task |
+|---|---|
+| T13-01 | Scaffold `fret.vision` + typed contracts (`BallObservation`, `CameraFrame`, …) |
+| T13-02 | Candidate implementations behind a common detector/tracker interface |
+| T13-03 | Fixture corpus + unit gates; record selection decision |
+| T13-04 | Module + interface docs; link from roadmap / scenarios |
+
+---
+
+## v1.4 — CV ↔ manipulation integration
+
+### Goal
+
+Connect the v1.3 vision pipeline to **existing OM-X / OMY pick-and-place** so
+release behaviours match today’s physics smoke **without hardcoded ball
+positions**. Simulate cameras in MuJoCo with a **realistic mount**. The
+**place / dispenser** pose remains a known scenario parameter.
+
+### Scope
+
+| Item | Detail |
+|---|---|
+| Robots | `open_manipulator_x`, `omy` |
+| Cameras | MJCF `<camera>` on a portal / gantry (or better mount from selection needs) |
+| Ball pose | From `BallObservation` → FSM / IK / planner entry |
+| Place pose | YAML known parameter (fixed industrial fixture) |
+| Equivalence | Same DONE / cone-place success as pre-CV scenarios on seeded runs |
+
+### Scenario IDs
+
+| ID | File (planned) | Description |
+|---|---|---|
+| SC-v16a | `omx_pick_place_cv.yml` (name TBD) | OM-X pick-place driven by CV ball pose |
+| SC-v16b | `omy_pick_place_cv.yml` (name TBD) | OMY analogue |
+| SC-v16c | clutter variants | Optional: clutter + CV ball (place still known) |
+
+### Acceptance criteria
+
+| # | Criterion |
+|---|---|
+| V14-1 | Scenario MJCF includes calibrated sim cameras with documented extrinsics |
+| V14-2 | Release pick-place paths do not read hardcoded ball / `pick_xy` as ground truth |
+| V14-3 | Place / dispenser pose comes only from scenario parameters |
+| V14-4 | Physics smoke: FSM reaches DONE and ball enters place volume (seeded) |
+| V14-5 | Behaviour parity checklist vs SC-v13b / SC-v14b on shared seeds |
+
+### Implementation tasks
+
+| ID | Task |
+|---|---|
+| T14-01 | Camera mount MJCF + calibration YAML for OM-X / OMY cells |
+| T14-02 | MuJoCo image adapter → `fret.vision` |
+| T14-03 | Replace hardcoded ball pose in runners with vision output |
+| T14-04 | SC-v16 scenarios + tests; update showcase matrix when clips are ready |
+
+---
+
+## v1.5 — Dynamic ball + industrial place
+
+### Goal
+
+Upgrade the manipulation cell toward a more **industrial** workflow: a ball
+**rolls on the floor** and stops at a **random** pose; vision **detects** it and
+labels it **pickable or not**; if pickable, run the existing pipeline into an
+improved **container / dispenser**. Asset research is part of the release.
+
+### Scope
+
+| Item | Detail |
+|---|---|
+| Delivery | Rolling ball → random rest pose (MuJoCo contacts) |
+| Classification | Pickable vs reject (workspace, size, rest stability — exact rules in FR-VIS) |
+| Place geometry | Survey Menagerie / AWS / other assets; ship improved container mesh |
+| Cadence | **Provisional:** one ball per cycle for the release scenario; multi-ball optional stretch |
+| TB3 | Still out of CV scope |
+
+### Scenario IDs
+
+| ID | Description |
+|---|---|
+| SC-v17 | Dynamic ball delivery + pickability + place into improved container |
+
+### Acceptance criteria
+
+| # | Criterion |
+|---|---|
+| V15-1 | Written asset survey (container / dispenser candidates) with chosen mesh |
+| V15-2 | Ball released / rolled; final XY not scripted as the pick target |
+| V15-3 | Vision emits pickability; non-pickable balls do not start grasp |
+| V15-4 | Pickable balls are placed in the improved container under physics |
+| V15-5 | Documented decision: single-ball release vs multi-ball (default: single) |
+
+### Implementation tasks
+
+| ID | Task |
+|---|---|
+| T15-01 | Asset research note under `docs/vision/` + MJCF container upgrade |
+| T15-02 | Ball emitter / roll-out mechanism in MJCF |
+| T15-03 | Pickability classifier + SC-v17 scenario + tests |
+| T15-04 | Cadence decision recorded; multi-ball deferred or stretch-tagged |
+
+---
+
+## v2.x — Hardware integration line
+
+### Goal
+
+After **v1.5** is validated in simulation, bring the same contracts onto
+**physical hardware** in **modular** steps. Each minor tag may ship one layer.
+
+| Step | Focus | Notes |
+|---|---|---|
+| **v2.0** | Low-level target bridge | Micro-ROS / serial; `/joint_commands` ↔ drivers; encoders → `/joint_states` |
+| **v2.1** | Real image pipeline | Same `fret.vision` interfaces; real camera drivers |
+| **v2.2** | Real manipulator actuation | Closed-loop joint tracking on hardware |
+| **v2.3** | Full HITL pick-and-place | Vision + plan + control + hardware together |
+
+Targets (indicative): Raspberry Pi 5 + Arduino Mega + Nema-class actuators;
+exact BOM frozen when v2.0 planning opens.
+
+Module stub today: [modules/hardware.md](modules/hardware.md) (retargeted to v2.x).
+
+### Acceptance criteria (era-level)
+
+| # | Criterion |
+|---|---|
+| V2x-1 | Each step has its own tag, tests, and does not require the next step to merge |
+| V2x-2 | Algorithm packages (`fret.vision`, planning, control) stay simulator-agnostic |
+| V2x-3 | At least one end-to-end hardware pick-place smoke before declaring the era done |
+
+*Detailed T2x-* task lists are written when v1.5 closes.*
+
+---
+
+## v3.0 — Definitive product (north-star)
+
+**v3.0** is the release where simulation-proven algorithms and v2.x hardware
+modules are validated together as the **default product**. After that, work is
+incremental (debugs, features). **No task breakdown for 3.0+ is maintained in
+this repository documentation** — see [roadmap.md](roadmap.md).
 
 ---
 
@@ -315,20 +494,24 @@ product milestone before computer vision** (vision / dynamic replanning stay pos
 
 | Tag | Content | Prerequisite |
 |---|---|---|
-| `v1.0.0` | Superseded bootstrap tag (not a product showcase) | — |
-| `v1.1.0` | Dubins dual race — **first product showcase** | T11-* |
-| `v1.1.x` | Physics-bridge iterations (v1.1 → v1.2); no new robots | See [§ v1.1.x retrospective](#v11x--v12-retrospective) below |
+| `v1.0.0` | Superseded bootstrap tag | — |
+| `v1.1.0` | Dubins dual race — first product showcase | T11-* ✅ |
+| `v1.1.x` | Physics-bridge iterations | See [§ retrospective](#v11x--v12-retrospective) |
 | `v1.2.0` | MuJoCo physics SITL (Dubins) | T12-* ✅ |
-| `v1.2.3` | OpenMANIPULATOR-X tabletop showcase (mobile + OM-X videos) | T123-* ✅ |
-| `v1.2.4` | 6-DOF challenge (OMY) — **next product tag** | T124-* |
-| `v1.2.5` | Patch: OMY clutter showcase detour (failed `v1.2.4` release CI) | T124-* |
-| `v1.2.6` | Patch: PlotJuggler telemetry CSV/JSON beside showcase videos on R2 (FR-SIM-12) | FR-SIM-12 |
-| `v1.3.0` | Hardware HITL (last milestone before vision) | T13-* |
+| `v1.2.3` | OpenMANIPULATOR-X tabletop | T123-* ✅ |
+| `v1.2.4` | OMY 6-DOF challenge | T124-* ✅ |
+| `v1.2.5` | Patch: OMY clutter showcase detour | — ✅ |
+| `v1.2.6` | Patch: telemetry on R2 (FR-SIM-12) | — ✅ |
+| `v1.2.7` | Patch: Dubins showcase encode / clip length | — ✅ |
+| `v1.3.0` | **CV pipeline + algorithm selection** | T13-* |
+| `v1.4.0` | CV ↔ manipulation + MuJoCo cameras | T14-* |
+| `v1.5.0` | Dynamic ball + industrial place | T15-* |
+| `v2.0.0+` | Hardware line (modular) | T2x-* |
+| `v3.0.0` | Definitive product (north-star) | — |
 
-Python package version in `pyproject.toml` is **1.3.0** once the post-v1.2.4
-development line opens (HITL). Product showcase tags remain `v1.2.4`, patches
-`v1.2.5` / `v1.2.6`, then `v1.3.0`; vision work stays post-v1.3
-(see [roadmap.md](roadmap.md)).
+Python package on `main` is **1.3.0** for the open CV development line
+(`pyproject.toml`). Product tags remain `v1.3.0`, `v1.4.0`, `v1.5.0`, then
+`v2.x` / `v3.0.0`.
 
 ### v1.1.x → v1.2.0 retrospective
 
@@ -354,14 +537,13 @@ kinematic behaviour must not regress.
   ~1.73× kinematic on CI.
 - **Release pipeline:** `release.yml` uses `--physics-mode`.
 
-**Deferred to v1.2.4+** (see [mujoco_physics_v1.2.md](mujoco_physics_v1.2.md)):
+**Historical “deferred” items (status today):**
 
-- Race showcase controller RTF / finish-time tuning on true TB3 wheel actuators
-- 6-DOF manipulator (v1.2.4)
-
-**Deferred to v1.3+:**
-
-- Hardware HITL (Micro-ROS bridge)
+| Item | Status |
+|---|---|
+| OMY 6-DOF (was “deferred to v1.2.4+”) | ✅ Shipped |
+| Hardware HITL (was “deferred to v1.3+”) | **Moved to v2.x** — v1.3 is CV |
+| Optional TB3 race finish-time polish | Non-blocking; TB3 accepted as case study |
 
 ### Release showcase videos (v1.2.3+)
 
@@ -437,6 +619,10 @@ uses `--physics-mode`. The real-time post-process step applies in both cases.
 
 See [mujoco.md § Showcase rendering](mujoco.md#showcase-rendering-real-time-playback).
 
+**v1.4+ note:** showcase / SITL **perception cameras** (ball tracking) are
+distinct from release **overview** encode cameras. Perception mounts are
+specified under [vision/camera-layout.md](vision/camera-layout.md).
+
 ---
 
 ## Deprecated / removed
@@ -446,3 +632,5 @@ The following documents and goals are **superseded** by this release spec:
 - MS-6 / MS-7 milestone framing (MuJoCo + TBD showcase)
 - SC-01 – SC-05 bootstrap scenarios (retired with SCARA/RRP purge)
 - Platform study 2026 Q3 dual-demo proposal
+- **v1.3 as Hardware HITL** — hardware moved to **v2.x**; v1.3 is the CV pipeline
+- “Vision post-v1.3” framing in older roadmap copies

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -4,7 +4,7 @@ Requirements trace to [releases.md](releases.md) and [scenarios.md](scenarios.md
 
 Format: `FR-<LAYER>-<NN>`
 
-Layers: `SYS`, `SCN`, `PLN`, `CTL`, `SIM`, `HW`
+Layers: `SYS`, `SCN`, `PLN`, `CTL`, `SIM`, `VIS`, `HW`
 
 ---
 
@@ -14,14 +14,18 @@ Layers: `SYS`, `SCN`, `PLN`, `CTL`, `SIM`, `HW`
 
 **FR-SYS-02:** A scenario YAML fully specifies a reproducible run.
 
-**FR-SYS-03:** Simulation and SITL backends:
+**FR-SYS-03:** Simulation and deployment backends:
 
 | Backend | Role | From |
 |---|---|---|
-| MuJoCo | Physics, contacts, rendering, SITL | v1.1 |
-| HITL | Hardware | v1.3 |
+| MuJoCo | Physics, contacts, cameras, rendering, SITL | v1.1 |
+| HITL | Physical hardware | **v2.x** (not v1.3) |
 
 **FR-SYS-04:** All runtime-significant values in ROS parameters or YAML.
+
+**FR-SYS-05:** Computer vision applies only to **manipulator** models that
+interact with graspable objects. Dubins / TB3 scenarios shall not depend on
+ball vision.
 
 ---
 
@@ -112,13 +116,48 @@ series naming grammar `agent.quantity_frame.component` defined in
 [modules/telemetry.md](modules/telemetry.md). Contact JSONL (FR-SIM-08) remains
 a separate path.
 
+**FR-SIM-13:** (v1.4+) Manipulator CV scenarios shall expose calibrated MuJoCo
+`<camera>` sensors for the vision pipeline (distinct from showcase overview
+cameras).
+
 Full integration specification: [mujoco.md](mujoco.md).
 Telemetry module specification: [modules/telemetry.md](modules/telemetry.md).
 Unit / external model repertoire: [mujoco_models_benchmark.md](mujoco_models_benchmark.md).
 
 ---
 
-## Hardware (v1.3)
+## Computer vision (v1.3–v1.5)
+
+Program overview: [vision/README.md](vision/README.md).
+
+**FR-VIS-01:** A pure-Python package `fret.vision` shall detect a graspable ball
+in one or more camera frames without importing ROS.
+
+**FR-VIS-02:** The pipeline shall accept `N ≥ 1` frames and emit at most one
+primary `BallObservation` per call (plus diagnostics).
+
+**FR-VIS-03:** v1.3 shall record an algorithm selection (candidates + metrics +
+chosen primary) under `docs/vision/algorithm-selection.md`.
+
+**FR-VIS-04:** Unit tests shall gate fixture centre accuracy for the chosen
+primary algorithm (thresholds in the selection doc).
+
+**FR-VIS-05:** (v1.4+) Release manipulator pick-place paths shall use vision for
+**ball** pose; they shall not use hardcoded ball / `pick_xy` as the grasp
+target source of truth.
+
+**FR-VIS-06:** Place / dispenser / container pose shall be supplied as known
+scenario parameters (not required from CV).
+
+**FR-VIS-07:** (v1.5) The system shall classify detections as pickable or not
+before starting grasp.
+
+**FR-VIS-08:** (v1.5) Dynamic delivery: ball rest pose shall not be the scripted
+pick target; vision must observe the settled ball.
+
+---
+
+## Hardware (v2.x)
 
 **FR-HW-01:** Relay `/joint_commands` to Arduino via Micro-ROS.
 
@@ -137,8 +176,9 @@ Unit / external model repertoire: [mujoco_models_benchmark.md](mujoco_models_ben
 | State | (x, y, θ) SE(2) |
 | Agents | 2 |
 | Planner | ARCO SST per agent |
-| Control | ARCO Pure Pursuit |
-| Sim mode | Kinematic mirror |
+| Control | ARCO Pure Pursuit / path-following MPC |
+| Sim mode | Kinematic mirror (physics from v1.2) |
+| CV | None (case study only) |
 
 ### v1.2 — Physics SITL
 
@@ -150,16 +190,30 @@ Unit / external model repertoire: [mujoco_models_benchmark.md](mujoco_models_ben
 
 ### v1.2.3 — OpenMANIPULATOR-X
 
-Tabletop A→B, then pick-and-place FSM, then desk clutter and Γ-wall maze — Menagerie OM-X.
+Tabletop A→B, pick-and-place FSM, desk clutter, Γ-wall maze — Menagerie OM-X.
+Ball pose still hardcoded until v1.4.
 
-### v1.2.4 — 6-DOF
+### v1.2.4 — 6-DOF (OMY)
 
 | Parameter | Value |
 |---|---|
 | Joints | 6 revolute |
-| Planner | ARCO SST |
+| Planner | ARCO RRT* / SST |
 | Planning timeout | 60 s |
 | Sim mode | Physics SITL |
+| CV | None until v1.4 |
+
+### v1.3 — Vision pipeline
+
+Algorithms + unit tests + selection; no manipulation closed loop required.
+
+### v1.4 — CV integration
+
+Manipulator cells with MuJoCo cameras; ball from vision; place parametric.
+
+### v1.5 — Dynamic industrial cell
+
+Rolling ball, pickability, improved container; single-ball cadence provisional.
 
 ---
 
@@ -168,11 +222,16 @@ Tabletop A→B, then pick-and-place FSM, then desk clutter and Γ-wall maze — 
 | Requirement | Release | Validated by |
 |---|---|---|
 | FR-SYS-01–04 | all | Launch smoke tests |
+| FR-SYS-05 | v1.3+ | Vision / scenario review |
 | FR-SCN-01–04 | v1.1+ | `tests/scene/` |
 | FR-PLN-01–07 | v1.1+ | `tests/planning/`, SC-v11+ |
 | FR-CTL-01–06 | v1.1+ | `tests/control/` |
 | FR-SIM-01–06 | v1.1 | MuJoCo launch + MP4 artifact |
 | FR-SIM-07–09 | v1.2 | Physics SITL smoke + integration tests |
 | FR-SIM-11 | v1.2+ | `tests/simulation/test_*_robot_unit.py` |
-| FR-HW-01–03 | v1.3 | — |
-
+| FR-SIM-12 | v1.2.6+ | Telemetry tests / release upload |
+| FR-SIM-13 | v1.4+ | SC-v16 MJCF + adapter tests |
+| FR-VIS-01–04 | v1.3 | `tests/vision/`, selection doc |
+| FR-VIS-05–06 | v1.4 | SC-v16 physics smoke |
+| FR-VIS-07–08 | v1.5 | SC-v17 |
+| FR-HW-01–03 | v2.x | HITL smoke (future) |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,123 +1,151 @@
 # FRET Project Roadmap
 
-> **Release targets:** [releases.md](releases.md) (v1.0 → v1.3)
+> **Authoritative release criteria:** [releases.md](releases.md)  
+> **Vision program (v1.3–v1.5):** [vision/README.md](vision/README.md)
+
+---
+
+## Versioning eras
+
+FRET is organized in three **eras**. Minor versions inside an era share the same
+kind of work; major bumps change the delivery surface.
+
+| Era | Versions | Focus | Hardware? |
+| --- | --- | --- | --- |
+| **Simulation & algorithms** | **v1.x** | Planners, controllers, MuJoCo SITL, CV in sim | No |
+| **Hardware integration** | **v2.x** | Modular HITL: bridge → real cameras → real arm → full stack | Yes |
+| **Product** | **v3.0+** | Definitive integrated system; then incremental features | Yes |
+
+**Rules:**
+
+1. **All of v1.x stays in simulation.** No Micro-ROS, Pi, or physical actuators
+   until the v2.x line.
+2. **TB3 / Dubins** is a **case study**: port ARCO kinematic SE(2) racing into
+   MuJoCo physics. It does **not** consume computer vision — only manipulators
+   interact with graspable scene objects.
+3. **Manipulators (OM-X, OMY)** are the CV consumers: detect / classify balls and
+   drive pick-and-place without hardcoded ball poses (from v1.4 onward).
+4. **v3.0** is a north-star (“everything that works, integrated”). This roadmap
+   only *mentions* it; no task breakdown for 3.0+ is maintained here.
+
+```
+v1.1–v1.2.x   ✅  Mobile + arm MuJoCo showcases (TB3, OM-X, OMY)
+     │
+     ▼
+v1.3   🔲  Computer-vision pipeline (algorithms, unit tests, selection)
+     │
+     ▼
+v1.4   🔲  CV ↔ manipulation integration (MuJoCo cameras, no hardcoded ball)
+     │
+     ▼
+v1.5   🔲  Dynamic ball delivery + industrial place geometry + pickability
+     │
+     ▼
+v2.0+  🔲  Hardware line (modular HITL)
+     │
+     ▼
+v3.0   ○   Definitive product (goal only — no detailed plan yet)
+```
 
 ---
 
 ## Project goals
 
-* **Product:** A ROS 2 full-stack robotics framework connecting **ARCO** planning to
-  simulation and hardware.
+* **Product (long-term):** ROS 2 full-stack framework: ARCO planning + control +
+  vision → simulation, then hardware.
 * **Middleware:** ROS 2 Jazzy.
-* **Planning:** ARCO (SST, KDTree occupancy, trajectory pruner).
-* **Simulation:** MuJoCo — physics, contacts, rendering, and SITL for all releases.
-* **Assets:** ROBOTIS MuJoCo Menagerie + AWS RoboMaker warehouse (git submodules).
-* **Hardware path:** Raspberry Pi 5 + Arduino Mega via Micro-ROS (**v1.3**, after debug).
+* **Planning / control:** ARCO (RRT*, SST, occupancy, path-following and
+  joint-space MPC).
+* **Simulation:** MuJoCo — physics, contacts, cameras, rendering, SITL.
+* **Assets:** ROBOTIS MuJoCo Menagerie + AWS RoboMaker warehouse (submodules).
+* **v1.x vision:** Track a graspable ball; place target / dispenser pose stays a
+  **known scenario parameter** (fixed industrial fixture).
+* **v2.x hardware:** Raspberry Pi 5 + Arduino Mega (Micro-ROS) and real cameras,
+  introduced **after** v1.5 is validated — modular milestones, not a big-bang cutover.
 
 ---
 
-## Release sequence
+## Phase map (v1.x complete → open)
 
-```
-v1.1   ✅  Dubins dual-robot race A→B through warehouse maze (Menagerie TB3)
-  │
-  ▼
-v1.2   ✅  MuJoCo physics SITL — actuators, contacts, controller tuning
-  │
-  ├─ v1.2.3  ✅  OpenMANIPULATOR-X tabletop (Menagerie OM-X)
-  │
-  └─ v1.2.4  🔲  6-DOF manipulator challenge (Menagerie OMY / equivalent)
-  │
-  ▼
-v1.3   🔲  Hardware HITL — Micro-ROS bridge (after debug)
-  │
-  ▼
-post v1.3     Vision, dynamic replanning
-```
+### Phase 0 — Specification ✅
 
-Full acceptance criteria and tasks: [releases.md](releases.md).
+- [x] C-space / SE(2) domains, interface contracts, QoS, CI
 
-Robot models come **only** from the Menagerie submodule (same pattern as TurtleBot3).
-Legacy SCARA/RRP bootstrap work is retired — validated historically, not a product target.
+### Phase 1 — Mobile race showcase ✅ *(v1.1)*
 
----
+**Robot:** TurtleBot3 Burger (Menagerie). **Role:** ARCO → MuJoCo case study.
 
-## Phase 0 — Specification ✅ *Complete*
+- [x] SE(2) planning, dual-agent race, AWS maze, path-following MPC, release MP4s
 
-- [x] C-space planning domain decided
-- [x] Interface contracts (`PlanningRequest`, `OccupancyUpdatePayload`, …)
-- [x] ROS 2 Action format (`PlanRequest.action`)
-- [x] QoS profiles and node FSMs
-- [x] CI workflows (formatting, tests, type check, integration)
+### Phase 2 — MuJoCo physics SITL ✅ *(v1.2)*
 
----
+- [x] `physics_mode`, wheel actuators, contact logging, physics-default showcase
 
-## Phase 1 — Mobile race showcase ✅ *Complete*
+### Phase 3 — OpenMANIPULATOR-X tabletop ✅ *(v1.2.3)*
 
-**Robot:** TurtleBot3 Burger × 3 (Menagerie). **Scenario:** SC-v11 warehouse race.
+- [x] SC-v13a–d: reach, pick-place FSM, desk clutter, Γ-wall maze
 
-- [x] SE(2) planning adapter (ARCO DubinsVehicle)
-- [x] Dual/triple-agent race orchestration
-- [x] AWS warehouse maze + submodule meshes
-- [x] Path-following MPC tracking + obstacle barriers (ARCO v0.3.2)
-- [x] Release workflow + showcase MP4s
-- [x] Tag `v1.1.0` … physics iterations through `v1.2.0`
+### Phase 4 — 6-DOF OpenMANIPULATOR-Y ✅ *(v1.2.4 + patches)*
 
----
+- [x] SC-v14a–c: reach, pedestal pick-place, clutter detour; showcase RRT*/SST
+- [x] Telemetry beside R2 videos *(v1.2.6)*; Dubins encode polish *(v1.2.7)*
 
-## Phase 2 — v1.2 MuJoCo physics SITL ✅ *Complete*
+Optional sim polish (non-blocking for the CV line): denser AWS desk props;
+explicit 6-D self-collision C-space checker.
 
-**Cross-cutting release.** Applies to the v1.1 Dubins showcase.
+### Phase 5 — Computer vision pipeline 🔲 *(v1.3)*
 
-- [x] `physics_mode` + wheel actuators + contact logging
-- [x] Physics integration tests
-- [x] Package version 1.2.0
+**Scope:** algorithms + unit tests + **algorithm selection** only. No MuJoCo
+camera MJCF required to *select*; fixtures may use synthetic images.
 
-Full specification: [releases.md § v1.2](releases.md#v12--mujoco-physics-sitl).
-
----
-
-## Phase 3 — v1.2.3 OpenMANIPULATOR-X tabletop ✅ *Complete*
-
-**Robot:** OpenMANIPULATOR-X (4-DOF + gripper) from
-`third_party/robotis_mujoco_menagerie/robotis_open_manipulator_x`.
-**Scenarios:** SC-v13a (empty A→B), SC-v13b (pick-and-place FSM),
-SC-v13c (desk clutter detour), SC-v13d (Γ-wall maze).
-
-- [x] Wire Menagerie OM-X MJCF into FRET cell (empty tabletop)
-- [x] Command chain: plan → track → MuJoCo actuators (A→B, no obstacles)
-- [x] Pick-and-place FSM: green → physical grasp → red → release (plain MuJoCo box)
-- [x] Desk-clutter wall: planned retract transfer (planner + controller)
-- [x] Γ-wall maze: retract → climb → place (SC-v13d)
-- [x] Showcase videos (Γ-maze overview: RRT* + SST)
-- [x] Tag `v1.2.3`
-
-Optional polish (non-blocking): AWS desk / clutter props; denser detour tuning.
-
----
-
-## Phase 4 — v1.2.4 6-DOF challenge 🔲
-
-**Robot:** Menagerie 6-DOF arm (OpenMANIPULATOR-Y preferred). **Scenario:** SC-v14.
-
-- [ ] Select Menagerie 6-DOF model (OMY)
-- [ ] Numerical IK + Jacobian controller
-- [ ] 6-D C-space checker with self-collision
-- [ ] Cluttered cell MJCF (AWS props)
-- [ ] Tag `v1.2.4`
-
----
-
-## Phase 5 — v1.3 Hardware HITL 🔲 *After debug*
-
-- [ ] Micro-ROS serial bridge (`hardware/bridge_node.py`)
-- [ ] Encoder feedback loop
-- [ ] Physical prototype integration
+- [ ] Spec `FR-VIS-*` + module package `fret.vision`
+- [ ] Evaluate candidates against [vision/algorithm-selection.md](vision/algorithm-selection.md)
+- [ ] Lock primary detector / tracker for ball centre in image + world lift
+- [ ] Unit tests on synthetic / recorded fixtures (no manipulation loop yet)
 - [ ] Tag `v1.3.0`
 
+### Phase 6 — CV ↔ manipulation integration 🔲 *(v1.4)*
+
+- [ ] MuJoCo cameras in OM-X / OMY cells (realistic mount — portal / gantry)
+- [ ] Wire `BallObservation` → pick-and-place (replace hardcoded ball / `pick_xy`)
+- [ ] Keep **place / dispenser** as known YAML parameters
+- [ ] Equivalent behaviour to today’s physics smoke without pose cheats
+- [ ] Tag `v1.4.0`
+
+### Phase 7 — Dynamic scene + industrial place 🔲 *(v1.5)*
+
+- [ ] Ball rolls on floor to a **random** rest pose; CV detects it
+- [ ] **Pickability** classifier (in workspace / graspable vs reject)
+- [ ] Asset research + improved container / dispenser geometry
+- [ ] Decide single-ball vs multi-ball delivery for the release scenario
+- [ ] Tag `v1.5.0`
+
+### Phase 8 — Hardware line 🔲 *(v2.x)*
+
+Modular integration (order fixed; each may be its own minor tag):
+
+1. Low-level target bridge (Micro-ROS / serial)
+2. Real image pipeline (same `fret.vision` contracts)
+3. Real manipulator actuation + encoder feedback
+4. Full closed-loop pick-and-place on hardware
+
+See [releases.md § v2.x](releases.md#v2x--hardware-integration-line).
+
+### Phase 9 — Definitive product ○ *(v3.0)*
+
+Mention only: a release where simulation-proven algorithms and hardware modules
+are validated together as the default product. Detailed 3.0+ planning is
+**out of scope** for this document.
+
 ---
 
-## Phase 6 — Vision 🔲 *Post v1.3*
+## Robot roles (stable)
 
-- [ ] Camera-based perception
-- [ ] Dynamic replanning from visual feedback
+| Model | Era role | Uses CV? |
+| --- | --- | --- |
+| `dubins` (TB3) | Case study: ARCO kinematics → MuJoCo physics race | **No** |
+| `open_manipulator_x` | 4-DOF tabletop manipulation + CV from v1.4 | **Yes** |
+| `omy` / `six_dof` | 6-DOF manipulation + CV from v1.4 | **Yes** |
+
+Full acceptance criteria: [releases.md](releases.md).  
+Architecture for vision: [vision/architecture.md](vision/architecture.md).

--- a/docs/robots/README.md
+++ b/docs/robots/README.md
@@ -3,13 +3,20 @@
 Each FRET release targets one robot class. Models are selectable via `model:=` at launch.
 **Product robots come from git submodules** (ROBOTIS MuJoCo Menagerie + AWS props).
 
-| Model | Release | Doc | Status |
-|---|---|---|---|
-| `dubins` (TB3 Burger) | v1.1–v1.2 | [dubins.md](dubins.md) | ✅ Shipped |
-| `open_manipulator_x` | v1.2.3 | [open_manipulator_x.md](open_manipulator_x.md) | ✅ Shipped (`v1.2.3`) |
-| `six_dof` / `omy` (OpenMANIPULATOR-Y) | v1.2.4 | [six_dof.md](six_dof.md) | 🔲 In progress |
+| Model | Release | Doc | Status | Uses CV? |
+|---|---|---|---|---|
+| `dubins` (TB3 Burger) | v1.1–v1.2 | [dubins.md](dubins.md) | ✅ Shipped | **No** — ARCO→MuJoCo case study |
+| `open_manipulator_x` | v1.2.3 (+ CV from v1.4) | [open_manipulator_x.md](open_manipulator_x.md) | ✅ Shipped | **Yes** from v1.4 |
+| `six_dof` / `omy` (OpenMANIPULATOR-Y) | v1.2.4 (+ CV from v1.4) | [six_dof.md](six_dof.md) | ✅ Shipped | **Yes** from v1.4 |
 
 All robots run on **MuJoCo** for physics, rendering, and SITL. See [mujoco.md](../mujoco.md).
+
+**Roles:**
+
+- **TB3 / Dubins** proves SE(2) planning and path-following under MuJoCo physics.
+  It does not grasp objects and does not consume the vision pipeline.
+- **OM-X / OMY** perform tabletop manipulation; from **v1.4** ball pose comes from
+  `fret.vision` ([vision/README.md](../vision/README.md)).
 
 Unit physics sandboxes (no race): `turtlebot3_unit` via
 `fret.simulation.TurtleBot3UnitRobot` (FR-SIM-11); procedural `diffdrive_unit`

--- a/docs/robots/dubins.md
+++ b/docs/robots/dubins.md
@@ -1,6 +1,7 @@
 # Dubins Mobile Robot (v1.1)
 
-> **Release:** v1.1 · **Scenario:** SC-v11 (`dubins_race`) ·
+> **Release:** v1.1–v1.2 · **Scenario:** SC-v11 (`dubins_race`) ·
+> **Role:** ARCO SE(2) → MuJoCo physics **case study** — **no computer vision** ·
 > [Release spec](../releases.md#v11--dubins-dual-robot-race)
 
 ---

--- a/docs/robots/open_manipulator_x.md
+++ b/docs/robots/open_manipulator_x.md
@@ -2,6 +2,7 @@
 
 > **Release:** v1.2.3 · **Scenarios:** SC-v13a (`omx_reach`), SC-v13b (`omx_pick_place`),
 > SC-v13c (`omx_desk_clutter`), SC-v13d (`omx_wall_maze`) ·
+> **CV integration:** from v1.4 ([vision/README.md](../vision/README.md)) ·
 > [Release spec](../releases.md#v123--openmanipulator-x-tabletop)
 
 ---

--- a/docs/robots/six_dof.md
+++ b/docs/robots/six_dof.md
@@ -1,6 +1,7 @@
 # 6-DOF Manipulator — OpenMANIPULATOR-Y (v1.2.4)
 
-> **Release:** v1.2.4 · **Scenarios:** SC-v14a–c ·
+> **Release:** v1.2.4 ✅ · **Scenarios:** SC-v14a–c ·
+> **CV integration:** from v1.4 ([vision/README.md](../vision/README.md)) ·
 > [Release spec](../releases.md#v124--6-dof-manipulator-challenge)
 
 ---

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -6,9 +6,10 @@ Scenarios are defined in `src/fret/config/scenarios/` and launched via:
 ros2 launch fret sitl.py scenario:=<name> model:=<model>
 ```
 
-**Release scenarios** (product targets): SC-v11 – SC-v14.
+**Release scenarios** (product targets): SC-v11 – SC-v14 (shipped);
+SC-v15 – SC-v17 (vision line, planned).
 
-Full release spec: [releases.md](releases.md).
+Full release spec: [releases.md](releases.md). Vision program: [vision/README.md](vision/README.md).
 
 ---
 
@@ -140,6 +141,34 @@ tip-down cone funnel at a loaded-reachable pose — 6-DOF analogue of SC-v13b.
 occupancy planner so the transfer must detour (6-DOF analogue of SC-v13c).
 
 **Pass criteria:** See [releases.md § v1.2.4](releases.md#v124--6-dof-manipulator-challenge).
+
+---
+
+## Vision line scenarios (planned)
+
+### SC-v15 — Vision pipeline fixtures (v1.3)
+
+**Purpose:** Unit / fixture gates for `fret.vision` (ball centre accuracy). Not a
+robot showcase. Algorithm selection is part of the release:
+[vision/algorithm-selection.md](vision/algorithm-selection.md).
+
+**Pass criteria:** [releases.md § v1.3](releases.md#v13--computer-vision-pipeline).
+
+### SC-v16 — CV-driven pick-and-place (v1.4)
+
+**Purpose:** OM-X / OMY pick-place (and optional clutter) with **MuJoCo cameras**
+and ball pose from vision. Place / dispenser remains a known YAML parameter.
+Camera mount: [vision/camera-layout.md](vision/camera-layout.md).
+
+**Pass criteria:** [releases.md § v1.4](releases.md#v14--cv--manipulation-integration).
+
+### SC-v17 — Dynamic ball + industrial place (v1.5)
+
+**Purpose:** Ball rolls to a random rest pose; vision detects and classifies
+pickability; pickable balls go into an improved container / dispenser.
+Provisional cadence: one ball per cycle.
+
+**Pass criteria:** [releases.md § v1.5](releases.md#v15--dynamic-ball--industrial-place).
 
 ---
 

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -2,7 +2,8 @@
 
 > **MuJoCo integration spec:** [mujoco.md](mujoco.md)  
 > **Visual tutorial:** [tutorial.md](tutorial.md)  
-> **Release focus:** v1.1 Dubins · v1.2 physics SITL. See [releases.md](releases.md).
+> **Release focus:** v1.1 Dubins · v1.2 physics SITL · v1.3–v1.5 CV in sim.
+> Hardware HITL is **v2.x**. See [releases.md](releases.md).
 
 ---
 

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -1,0 +1,76 @@
+# Computer vision program (v1.3–v1.5)
+
+> **Era:** Simulation & algorithms (v1.x only).  
+> **Release criteria:** [releases.md](../releases.md) · **Roadmap:** [roadmap.md](../roadmap.md)
+
+FRET’s computer-vision work lives entirely in **simulation** through **v1.5**.
+Hardware cameras and real images belong to **v2.x**.
+
+---
+
+## Why vision exists here
+
+Manipulators **grasp scene objects**. Today’s OM-X / OMY scenarios hardcode ball
+poses (`pick_xy`, joint grasp configs derived offline). The CV line replaces
+that cheat with a measured ball pose while keeping planning, FSM, and MPC.
+
+**TurtleBot3 / Dubins does not use CV.** It remains an ARCO → MuJoCo mobility
+case study (no graspable object interaction in the product scenarios).
+
+---
+
+## Release ladder
+
+| Tag | Deliverable | Doc |
+| --- | --- | --- |
+| **v1.3** | Pipeline + unit tests + **algorithm selection** | [algorithm-selection.md](algorithm-selection.md) |
+| **v1.4** | MuJoCo cameras + wire into pick-place (no hardcoded ball) | [camera-layout.md](camera-layout.md) · [architecture.md](architecture.md) |
+| **v1.5** | Rolling ball, pickability, industrial container | [releases.md § v1.5](../releases.md#v15--dynamic-ball--industrial-place) |
+
+---
+
+## Locked product decisions
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| Who uses CV | OM-X and OMY only | Only manipulators interact with graspable objects |
+| What CV must find | Ball centre (and pickability from v1.5) | Grasp entry needs object pose |
+| What stays parametric | Place / dispenser / container pose | Fixed industrial fixture; no need to detect every cycle |
+| Primary algo (v1.3) | HSV blob + circularity + table-plane Z | Deterministic, unit-testable, no heavy ML deps in CI |
+| Multi-camera | Interface required in v1.3; dual overhead+side optional in v1.4 | Occlusion robustness without blocking mono baseline |
+| v1.5 cadence | One ball per cycle (provisional) | Clearer FSM and metrics; multi-ball is stretch |
+
+---
+
+## Package layout (target)
+
+```
+src/fret/vision/          # pure Python — no rclpy
+  types.py                # CameraFrame, BallObservation, …
+  detect/                 # selected + candidate detectors
+  track/                  # temporal association (optional in v1.3)
+  geometry/               # pixel → world (plane / stereo)
+  pipeline.py             # BallVisionPipeline
+
+src/fret/ros/             # thin adapters only (v1.4+)
+  vision_bridge.py        # images in → BallObservation out (topic)
+
+src/fret/config/vision/   # HSV ranges, camera extrinsics, thresholds
+```
+
+Module API spec: [modules/vision.md](../modules/vision.md).
+
+---
+
+## Relationship to existing “perception”
+
+`PerceptionBridgeNode` (`fret.ros.perception_bridge`) publishes a **synthetic
+obstacle point cloud** from YAML boxes/cylinders for occupancy. It is **not**
+the ball CV pipeline. Naming:
+
+| Component | Role |
+| --- | --- |
+| `perception_bridge` | Occupancy obstacles → `/obstacle_cloud` (existing) |
+| `fret.vision` | Ball detection / tracking → `BallObservation` (new) |
+
+Do not overload `perception_bridge` with ball tracking; keep contracts separate.

--- a/docs/vision/algorithm-selection.md
+++ b/docs/vision/algorithm-selection.md
@@ -1,0 +1,97 @@
+# Algorithm selection (v1.3)
+
+> **Release:** v1.3 · Acceptance: V13-2 / V13-3 in [releases.md](../releases.md)  
+> This document **is** the selection work product. Implementation fills the
+> comparison table; the **provisional primary** below is the starting choice.
+
+---
+
+## Goal
+
+Track a **single graspable ball** in a tabletop / floor cell using **one or more
+cameras**, producing an image-space detection that can lift to a metric
+`BallObservation` when calibration and scene geometry allow.
+
+Out of scope for the v1.3 *selection*: full pick-place, learned detectors as
+**required** baseline, TB3, detecting the place dispenser.
+
+---
+
+## Evaluation criteria
+
+| ID | Criterion | Weight | Notes |
+| --- | --- | --- | --- |
+| C1 | Centre error on fixtures (px / mm) | High | Primary gate |
+| C2 | Determinism / CI friendliness | High | No GPU / large weights required |
+| C3 | Works under MuJoCo lighting | High | Controlled HDR-ish renders |
+| C4 | Multi-camera extensibility | Medium | Same interface for N≥1 |
+| C5 | Path to real cameras (v2.x) | Medium | Classical ops transfer; ML optional later |
+| C6 | Implementation size | Medium | Prefer small, testable modules |
+
+**Fixture gate (proposed for V13-3):** median ball-centre error ≤ **3 px** on
+640×480 synthetic fixtures; when plane geometry is available, world XY error
+≤ **10 mm** on the table plane.
+
+---
+
+## Candidates
+
+| ID | Method | Pros | Cons |
+| --- | --- | --- | --- |
+| **A** | **HSV colour segmentation + contour circularity** | Fast, deterministic, easy unit tests | Needs colour contrast; lighting sensitivity |
+| **B** | Hough circle on edges / gradient | Radius prior helps | Weaker under texture / partial occlusion |
+| **C** | Stereo triangulation (2 calibrated views) | True 3-D without plane assumption | Needs dual cameras + calibration; heavier MJCF |
+| **D** | Learned detector (e.g. YOLO-class) | Robust appearance | CI weight, non-determinism, overkill for v1.3 |
+
+---
+
+## Provisional primary selection
+
+**Primary (v1.3):** **Candidate A** — HSV blob + circularity score.  
+**Depth / Z lift:** intersect camera ray with the **known table / floor plane**
+(scenario parameter), using configured ball radius for contact offset.  
+**Secondary (optional in v1.3, useful in v1.4):** Candidate **C** as a refinement
+when two cameras are mounted — same `BallObservation` output type.  
+**Not required for v1.3 tag:** Candidate D.
+
+### Why A
+
+1. Tennis-like balls in FRET cells are **high-chroma** against table/floor.
+2. MuJoCo lighting is controllable → HSV thresholds live in
+   `config/vision/*.yml` (configuration-over-code).
+3. Matches FRET’s SDD/CI culture: pure NumPy/OpenCV-class ops, golden fixtures.
+4. Interface still allows swapping in B/C/D without changing FSM consumers.
+
+### What “selection complete” means
+
+v1.3 is done when:
+
+1. This table has **measured** C1 results for at least A and one runner-up.
+2. Primary remains A **or** is explicitly changed here with rationale.
+3. Unit tests encode the fixture gate for the chosen primary.
+
+Until measurements land, treat **A** as the engineering default.
+
+---
+
+## Interface expectation (independent of algo)
+
+```text
+CameraFrame[+…]  →  detect()  →  BallDetection[+…]
+                 →  lift()    →  BallObservation | None
+```
+
+Multi-camera: detections may be fused in `lift()` (stereo) or selected
+(best monocular). The pipeline must accept `Sequence[CameraFrame]`.
+
+---
+
+## Dependencies (allowed)
+
+| Allowed in v1.3 core | Avoid as hard requirement |
+| --- | --- |
+| NumPy | GPU runtimes |
+| OpenCV *or* skimage (pick one in implementation PR) | Large ONNX/Torch weights in default CI |
+
+If OpenCV is chosen, document the apt/pip pin in the vision module README /
+`pyproject` optional extra `vision`.

--- a/docs/vision/architecture.md
+++ b/docs/vision/architecture.md
@@ -1,0 +1,108 @@
+# Vision architecture (v1.3–v1.5)
+
+> Level-2 design for the computer-vision line. Contracts also appear in
+> [interfaces.md](../interfaces.md). Module API: [modules/vision.md](../modules/vision.md).
+
+---
+
+## Context
+
+Pick-and-place today:
+
+```
+scenario YAML (pick_xy / grasp joints) → PickPlaceFSM → JointSpaceMPC → MuJoCo
+```
+
+Target from **v1.4**:
+
+```
+MuJoCo cameras → CameraAdapter → BallVisionPipeline → BallObservation
+                                                      ↓
+                         PickPlaceFSM / IK entry (ball pose)
+place / dispenser ← scenario YAML (known parameter)
+```
+
+**v1.3** implements the middle box (`BallVisionPipeline`) against fixtures.
+**v1.5** adds pickability and dynamic ball delivery upstream of the same pipe.
+
+---
+
+## Layering
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Scenario / SITL (manipulators only)                        │
+│  PickPlaceFSM · planners · JointSpaceMPC · MuJoCo actuators │
+└──────────────▲──────────────────────────────────────────────┘
+               │ BallObservation (world frame)
+┌──────────────┴──────────────────────────────────────────────┐
+│  fret.ros.vision_bridge   (v1.4+; thin)                     │
+│  topics: Image(s) in → BallObservation / diagnostics out    │
+└──────────────▲──────────────────────────────────────────────┘
+               │ CameraFrame(s)
+┌──────────────┴──────────────────────────────────────────────┐
+│  fret.vision  (pure Python)                                 │
+│  detect → (optional) track → geometry lift → BallObservation│
+└──────────────▲──────────────────────────────────────────────┘
+               │ RGB (+ optional depth later)
+┌──────────────┴──────────────────────────────────────────────┐
+│  Camera sources                                             │
+│  v1.3: fixture PNG/NPY · v1.4: MuJoCo <camera> · v2.x: real │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Rules:**
+
+1. `fret.vision` must not import `rclpy` or MuJoCo.
+2. Camera drivers / MuJoCo renderers live in adapters (`fret.ros`,
+   `fret.simulation`, or scripts).
+3. Occupancy perception (`perception_bridge`) stays a separate path.
+4. TB3 / Dubins never subscribe to ball vision outputs.
+
+---
+
+## Data contracts (summary)
+
+Full dataclasses: [interfaces.md § Vision](../interfaces.md#vision--manipulation-boundary-v13).
+
+| Type | Meaning |
+| --- | --- |
+| `CameraFrame` | Image + camera_id + timestamp + intrinsics ref |
+| `BallDetection` | Image-space centre, radius_px, confidence, camera_id |
+| `BallObservation` | World-frame position (± covariance), pickable flag (v1.5), timestamp |
+| `PlaceTarget` | Known dispenser / container pose from scenario YAML — **not** from CV |
+
+---
+
+## Control integration (v1.4)
+
+1. On each vision tick (or once per pick cycle), obtain `BallObservation`.
+2. If missing / low confidence → FSM stays IDLE or FAULT policy (scenario YAML).
+3. If present → compute grasp approach from ball position + known ball radius
+   (scenario or detection) via existing IK / pad-mid helpers.
+4. `place_*` configurations continue to come from YAML (fixed fixture).
+
+Hardcoded `pick_xy` / offline grasp joints used as **ground truth for the ball**
+are forbidden on SC-v16 release paths. They may remain as **test oracles**
+(compare vision vs MuJoCo `qpos`) in CI.
+
+---
+
+## Camera mount (v1.4)
+
+Default design: **overhead portal / gantry** above the cell so the ball rests in
+a top-down view with stable lighting. Optional second **side** camera if the
+selected algorithm needs stereo or occlusion recovery.
+
+Detail and MJCF conventions: [camera-layout.md](camera-layout.md).
+
+---
+
+## Failure modes
+
+| Failure | Policy (default) |
+| --- | --- |
+| No detection | Do not grasp; log; optional replan wait |
+| Multiple blobs | Prefer highest circularity × area score; emit diagnostics |
+| Outside workspace | `pickable=False` (required behaviour by v1.5) |
+| Place fixture missing in YAML | Fail at scenario load (config policy) |

--- a/docs/vision/camera-layout.md
+++ b/docs/vision/camera-layout.md
@@ -1,0 +1,75 @@
+# Camera layout (v1.4)
+
+> **Release:** v1.4 · Related: [architecture.md](architecture.md) ·
+> [algorithm-selection.md](algorithm-selection.md)
+
+Perception cameras (ball tracking) are **not** the same as release **overview**
+encode cameras in `showcase.yml`.
+
+---
+
+## Design goals
+
+1. Ball resting on table or floor is visible with high probability.
+2. Extrinsics are **stable and documented** (YAML), matching MJCF.
+3. Mount looks **realistic** for a lab / light-industrial cell (not a free-floating eye).
+4. Layout supports the **selected** algorithm (HSV mono + optional stereo).
+
+---
+
+## Default mount: overhead portal
+
+**Choice:** a rigid **portal / gantry** frame above the manipulation cell holding
+one downward-facing camera on the centreline of the workspace.
+
+```
+        ____ portal beam ____
+       /                      \
+      Cam-A (down)             optional Cam-B (oblique)
+       |                        /
+       v                       /
+   +--------+  arm  +--------+
+   | ball?  |       | place  |
+   +--------+       +--------+
+```
+
+| Property | Guidance |
+| --- | --- |
+| Height | Above max EE / wall obstacles used in SC-v13/14 clutter |
+| FOV | Cover pick region + approach; place fixture may be partial |
+| Intrinsics | Fixed; stored in `config/vision/cameras_*.yml` |
+| Extrinsics | `T_world_cam` from MJCF body pose; unit-tested vs model |
+
+**Why portal over eye-in-hand (for v1.4):** simpler calibration, no motion blur
+during detection-before-grasp, matches “detect then pick” FSM. Wrist cameras
+may be studied later; they are not the v1.4 default.
+
+---
+
+## Optional second camera
+
+If stereo refinement (candidate C) is enabled:
+
+- Cam-B on the portal leg or a side post, ~30–45° toward the pick region.
+- Baseline and overlap documented in the camera YAML.
+- Fusion stays inside `fret.vision`; scenarios only list camera ids.
+
+---
+
+## Scenario / MJCF requirements
+
+Each SC-v16 cell must:
+
+1. Include portal geometry (simple boxes OK) + `<camera>` elements.
+2. Reference calibration YAML from the scenario file.
+3. Keep **place / dispenser** pose as ros parameters (known).
+4. Expose a MuJoCo adapter that renders RGB for listed camera names each tick
+   (or each pick cycle).
+
+---
+
+## Open points (resolve during T14-01)
+
+- Exact portal dimensions per OM-X vs OMY cell scale.
+- Whether clutter walls require Cam-B for V14 acceptance or remain optional.
+- Sync rate: 10–30 Hz vision vs 50 Hz control (vision may run slower).

--- a/src/fret/hardware/bridge_node.py
+++ b/src/fret/hardware/bridge_node.py
@@ -1,12 +1,12 @@
-"""Serial / Micro-ROS bridge to Arduino for hardware-in-the-loop.
+"""Serial / Micro-ROS bridge to Arduino for hardware-in-the-loop (v2.x).
 
-Subscribes to ``/joint_commands`` (``trajectory_msgs/JointTrajectory``),
-serialises each setpoint, and forwards it over a serial link to the
-embedded firmware running on Arduino.  Also reads encoder feedback and
-re-publishes it as ``/joint_states`` (``sensor_msgs/JointState``).
+Subscribes to ``/joint_commands``, serialises each setpoint, and forwards it
+over a serial link to embedded firmware.  Also reads encoder feedback and
+re-publishes it as ``/joint_states``.
 
-This node is only active in the ``hardware.py`` launch configuration.
-Satisfies requirements FR-HW-01 through FR-HW-03.
+This node is only active in a future ``hardware.py`` launch configuration.
+It is **not** part of the v1.3–v1.5 simulation / CV line — see
+``docs/releases.md`` § v2.x. Satisfies requirements FR-HW-01 through FR-HW-03.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The roadmap still framed **v1.3 as hardware HITL** and vision as “post-v1.3”, which conflicts with the intended product line: keep **all of v1.x in simulation**, introduce **computer vision for manipulators** before any HITL, and push hardware to a **modular v2.x** era (with **v3.0** as a north-star only).

## Fix

Reorganized release eras and documentation:

| Era | Versions | Focus |
| --- | --- | --- |
| Simulation & algorithms | **v1.x** | Planners, MuJoCo, CV in sim |
| Hardware integration | **v2.x** | Modular HITL |
| Product | **v3.0+** | Definitive system (mentioned only) |

**v1.3** — CV pipeline + unit tests + algorithm selection (ball track, N≥1 cameras).  
**v1.4** — MuJoCo cameras + wire into OM-X/OMY pick-place; **no hardcoded ball**; place/dispenser stays a known parameter.  
**v1.5** — Rolling ball, pickability, industrial container research; provisional **one ball per cycle**.

Locked choices documented: TB3 = ARCO→MuJoCo case study (**no CV**); primary algo provisional **HSV + circularity + table-plane Z**; overhead **portal** camera mount for v1.4.

New docs under `docs/vision/` (README, architecture, algorithm-selection, camera-layout) plus `docs/modules/vision.md`. Updated `releases.md`, `roadmap.md`, `requirements.md` (`FR-VIS-*`), `scenarios.md` (SC-v15–17), interfaces, robots, README, hardware module → v2.x.

## Verification

- Docs-only + one docstring retarget (`bridge_node.py`).
- Gates: `bash scripts/check/formatting.sh` → PASS; `bash scripts/check/types.sh` → PASS (mypy, 69 files).
- No runtime/CV implementation in this PR (spec-first for the new line).

## Recurrence

Supersedes older “v1.3 = HITL / vision post-v1.3” framing called out in `releases.md` Deprecated section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

