### PR TITLE
feat(vision): algorithm-agnostic ball vision scaffold

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -337,13 +337,20 @@ print('ARCO API surface OK')
 **Version pinning:** ARCO is co-developed with FRET. No version pin is enforced.
 The CI checkout step is responsible for obtaining a compatible ARCO snapshot.
 The CI job that requires ARCO must check out `../arco/` before installing it.
+The exact CI checkout configuration is tracked in `.github/workflows/tests.yml`.
 
 ---
 
 ## Vision → Manipulation Boundary (v1.3+)
 
-Typed contracts for `fret.vision`. Full architecture:
-[vision/architecture.md](vision/architecture.md).
+Typed contracts implemented in `fret.vision.types`. Full architecture:
+[vision/architecture.md](vision/architecture.md). These types are
+**algorithm-agnostic** (no colour-space, feature, or network assumptions).
+
+### `CameraIntrinsics` / `CameraExtrinsics`
+
+Pinhole `fx, fy, cx, cy, width, height` and `T_world_cam` (4×4). Distortion
+models may be added later without breaking the frame / observation I/O.
 
 ### `CameraFrame`
 
@@ -351,9 +358,9 @@ Typed contracts for `fret.vision`. Full architecture:
 @dataclass(frozen=True)
 class CameraFrame:
     camera_id: str
-    image: np.ndarray          # HxWx3 uint8 RGB (or gray HxW)
+    image: np.ndarray          # HxWx3 uint8 RGB or HxW uint8 gray
     timestamp: float           # POSIX seconds or sim time
-    intrinsics_id: str         # key into vision camera YAML
+    intrinsics_id: str         # key into VisionConfig.intrinsics
 ```
 
 ### `BallDetection`
@@ -373,11 +380,11 @@ class BallDetection:
 @dataclass(frozen=True)
 class BallObservation:
     position_world: np.ndarray  # shape (3,), metres
-    covariance: np.ndarray | None  # optional 3x3
     radius_m: float
-    pickable: bool | None       # None until v1.5 classifier exists
     timestamp: float
-    source: str                 # e.g. "hsv_plane", "stereo"
+    source: str                 # opaque producer id (not an algo recipe)
+    covariance: np.ndarray | None = None  # optional 3x3
+    pickable: bool | None = None          # None until v1.5 classifier
 ```
 
 **Invariants:**
@@ -392,10 +399,17 @@ class BallObservation:
 @dataclass(frozen=True)
 class PlaceTarget:
     position_world: np.ndarray  # shape (3,)
-    frame_id: str               # must be "world"
+    frame_id: str = "world"     # must be "world"
 ```
 
-Loaded from scenario YAML (dispenser / container). Vision shall not be required
-to detect this fixture for v1.4–v1.5 acceptance.
+### `VisionConfig`
 
-The exact CI checkout configuration is tracked in `.github/workflows/tests.yml`.
+Shared calibration only (`intrinsics`, optional `extrinsics`). Detector /
+lifter / tracker knobs live with those implementations after algorithm
+selection.
+
+### Stage protocols
+
+`BallDetector`, `BallTracker`, `PoseLifter` — see `fret.vision.protocols`.
+`BallVisionPipeline.process(frames) -> BallObservation | None` orchestrates
+them (Level-3 stub until wired).

--- a/docs/modules/vision.md
+++ b/docs/modules/vision.md
@@ -1,67 +1,76 @@
 # Vision Module
 
-**Package:** `fret.vision` *(target — scaffold in v1.3)*  
+**Package:** `fret.vision`  
 **Source:** `src/fret/vision/`  
 **Tests:** `tests/vision/`  
 **Program docs:** [vision/README.md](../vision/README.md)
 
-> **Release:** v1.3 pipeline · v1.4 MuJoCo integration · v1.5 pickability.  
-> See [releases.md](../releases.md).
+> **Release:** v1.3 pipeline scaffold · v1.4 MuJoCo integration · v1.5
+> pickability. See [releases.md](../releases.md).
 
 ---
 
 ## Responsibility
 
-Detect and track a graspable **ball** in camera images and lift detections to a
-world-frame `BallObservation` for manipulator pick-and-place. Does **not**
-detect the place dispenser (known scenario parameter). Does **not** serve TB3.
+Expose **algorithm-agnostic** contracts so manipulator pick-and-place can
+consume a world-frame ball observation. Does **not** detect the place
+dispenser (known scenario parameter). Does **not** serve TB3.
 
 This module is distinct from `PerceptionBridgeNode` (YAML obstacle clouds for
 occupancy).
 
+**No preferred detector / tracker / lifter is encoded in this package.**
+Algorithm selection is an open v1.3 work product
+([algorithm-selection.md](../vision/algorithm-selection.md)).
+
 ---
 
-## Components (Level 3 stubs — v1.3)
+## Components
 
-### `types` — contracts
+### `types` — I/O contracts
+
+`CameraFrame`, `BallDetection`, `BallObservation`, `PlaceTarget`,
+`CameraIntrinsics`, `CameraExtrinsics`, `VisionConfig`.
 
 See [interfaces.md § Vision](../interfaces.md#vision--manipulation-boundary-v13).
 
+### `protocols` — stage interfaces
+
+| Protocol | Role |
+| --- | --- |
+| `BallDetector` | `frames → list[BallDetection]` |
+| `BallTracker` | optional temporal filter on detections |
+| `PoseLifter` | `detections (+ frames) → BallObservation \| None` |
+
 ### `pipeline.BallVisionPipeline`
 
-```python
-class BallVisionPipeline:
-    def __init__(self, config: VisionConfig) -> None: ...
+Constructor accepts injected detector + lifter (+ optional tracker) and
+shared `VisionConfig` (calibration only). `process()` is a Level-3 stub
+(`NotImplementedError`) until orchestration is implemented.
 
-    def process(
-        self, frames: Sequence[CameraFrame]
-    ) -> BallObservation | None:
-        """Detect (+ optional track) and lift to world frame."""
-        ...
+```python
+pipe = BallVisionPipeline(detector, lifter, config=cfg)
+obs = pipe.process(frames)  # BallObservation | None
 ```
 
-### `detect` — algorithm plugins
+### `detect/` · `geometry/` · `track/`
 
-Common interface; **primary** implementation is HSV + circularity
-([algorithm-selection.md](../vision/algorithm-selection.md)).
-
-### `geometry` — pixel → world
-
-Table/floor plane intersection for monocular Z; optional stereo triangulation.
+Empty package markers for future implementations. No concrete algorithms yet.
 
 ---
 
 ## Configuration
 
-All thresholds and camera extrinsics live under `src/fret/config/vision/`
-(created with the v1.3 implementation). No magic numbers in Python for tunables.
+`src/fret/config/vision/` holds algorithm-agnostic camera / scenario wiring
+once scenarios need it. Method-specific tunables stay with the chosen
+implementation’s YAML after selection.
 
 ---
 
 ## ROS boundary (v1.4+)
 
-`fret.ros.vision_bridge` (name TBD) adapts sensor messages ↔ pipeline. Core
-vision code remains ROS-free.
+A thin `fret.ros` adapter may publish/subscribe images and observations.
+Core vision code remains ROS-free.
 
 ---
 
@@ -69,4 +78,6 @@ vision code remains ROS-free.
 
 | Requirement | Description |
 |---|---|
-| FR-VIS-01–… | See [requirements.md](../requirements.md#computer-vision-v13v15) |
+| FR-VIS-01 | Pure-Python package; no ROS in core |
+| FR-VIS-02 | Pipeline API accepts `N ≥ 1` frames |
+| FR-VIS-03–04 | Selection + fixture gates (later in v1.3) |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -60,7 +60,7 @@ OpenMANIPULATOR-X/Y, …). Legacy SCARA/RRP assets are retired.
 | CV consumers | Manipulators only (`open_manipulator_x`, `omy`) |
 | Ball pose | From vision (v1.4+); no hardcoded ball / `pick_xy` in release paths |
 | Place / dispenser | **Known scenario parameter** (fixed fixture) — not required from CV |
-| v1.3 primary algorithm | Colour (HSV) blob + circular contour; table-plane lift for Z; dual-cam optional — see [algorithm-selection.md](vision/algorithm-selection.md) |
+| v1.3 algorithm | **Open** — selection doc; scaffold API is algorithm-agnostic |
 | v1.5 ball cadence (provisional) | **One ball at a time** for the release scenario; multi-ball deferred |
 
 ---

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -137,7 +137,8 @@ in one or more camera frames without importing ROS.
 primary `BallObservation` per call (plus diagnostics).
 
 **FR-VIS-03:** v1.3 shall record an algorithm selection (candidates + metrics +
-chosen primary) under `docs/vision/algorithm-selection.md`.
+chosen primary) under `docs/vision/algorithm-selection.md`. The `fret.vision`
+public API shall remain usable without committing to a specific algorithm.
 
 **FR-VIS-04:** Unit tests shall gate fixture centre accuracy for the chosen
 primary algorithm (thresholds in the selection doc).

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -35,30 +35,30 @@ case study (no graspable object interaction in the product scenarios).
 | --- | --- | --- |
 | Who uses CV | OM-X and OMY only | Only manipulators interact with graspable objects |
 | What CV must find | Ball centre (and pickability from v1.5) | Grasp entry needs object pose |
-| What stays parametric | Place / dispenser / container pose | Fixed industrial fixture; no need to detect every cycle |
-| Primary algo (v1.3) | HSV blob + circularity + table-plane Z | Deterministic, unit-testable, no heavy ML deps in CI |
-| Multi-camera | Interface required in v1.3; dual overhead+side optional in v1.4 | Occlusion robustness without blocking mono baseline |
-| v1.5 cadence | One ball per cycle (provisional) | Clearer FSM and metrics; multi-ball is stretch |
+| What stays parametric | Place / dispenser / container pose | Fixed industrial fixture |
+| Algorithm | **Open** — see [algorithm-selection.md](algorithm-selection.md) | Scaffold API is algo-agnostic |
+| Multi-camera | Interface supports `N ≥ 1` frames | Fusion is an implementation detail |
+| v1.5 cadence | One ball per cycle (provisional) | Clearer FSM and metrics; multi-ball stretch |
 
 ---
 
-## Package layout (target)
+## Package layout
 
 ```
 src/fret/vision/          # pure Python — no rclpy
-  types.py                # CameraFrame, BallObservation, …
-  detect/                 # selected + candidate detectors
-  track/                  # temporal association (optional in v1.3)
-  geometry/               # pixel → world (plane / stereo)
-  pipeline.py             # BallVisionPipeline
+  types.py                # CameraFrame, BallObservation, VisionConfig, …
+  protocols.py            # BallDetector, BallTracker, PoseLifter
+  pipeline.py             # BallVisionPipeline (Level-3 stub on process)
+  detect/                 # future detector implementations
+  geometry/               # future pose-lift implementations
+  track/                  # future trackers
+
+src/fret/config/vision/   # calibration / scenario wiring (algo knobs later)
 
 src/fret/ros/             # thin adapters only (v1.4+)
-  vision_bridge.py        # images in → BallObservation out (topic)
-
-src/fret/config/vision/   # HSV ranges, camera extrinsics, thresholds
 ```
 
-Module API spec: [modules/vision.md](../modules/vision.md).
+Module API: [modules/vision.md](../modules/vision.md).
 
 ---
 

--- a/docs/vision/algorithm-selection.md
+++ b/docs/vision/algorithm-selection.md
@@ -1,8 +1,8 @@
 # Algorithm selection (v1.3)
 
 > **Release:** v1.3 · Acceptance: V13-2 / V13-3 in [releases.md](../releases.md)  
-> This document **is** the selection work product. Implementation fills the
-> comparison table; the **provisional primary** below is the starting choice.
+> This document is the **selection work product**. It must be filled during
+> v1.3; the scaffold (`fret.vision`) deliberately does **not** encode a choice.
 
 ---
 
@@ -12,8 +12,9 @@ Track a **single graspable ball** in a tabletop / floor cell using **one or more
 cameras**, producing an image-space detection that can lift to a metric
 `BallObservation` when calibration and scene geometry allow.
 
-Out of scope for the v1.3 *selection*: full pick-place, learned detectors as
-**required** baseline, TB3, detecting the place dispenser.
+Out of scope for the v1.3 *selection*: full pick-place, TB3, detecting the
+place dispenser. The stable API is independent of which algorithm wins:
+[architecture.md](architecture.md), [modules/vision.md](../modules/vision.md).
 
 ---
 
@@ -22,76 +23,66 @@ Out of scope for the v1.3 *selection*: full pick-place, learned detectors as
 | ID | Criterion | Weight | Notes |
 | --- | --- | --- | --- |
 | C1 | Centre error on fixtures (px / mm) | High | Primary gate |
-| C2 | Determinism / CI friendliness | High | No GPU / large weights required |
-| C3 | Works under MuJoCo lighting | High | Controlled HDR-ish renders |
-| C4 | Multi-camera extensibility | Medium | Same interface for N≥1 |
-| C5 | Path to real cameras (v2.x) | Medium | Classical ops transfer; ML optional later |
+| C2 | Determinism / CI friendliness | High | Prefer no GPU / large weights in default CI |
+| C3 | Works under MuJoCo lighting | High | Controlled sim renders |
+| C4 | Multi-camera extensibility | Medium | Same `BallDetector` / `PoseLifter` shapes |
+| C5 | Path to real cameras (v2.x) | Medium | Same contracts |
 | C6 | Implementation size | Medium | Prefer small, testable modules |
 
 **Fixture gate (proposed for V13-3):** median ball-centre error ≤ **3 px** on
 640×480 synthetic fixtures; when plane geometry is available, world XY error
-≤ **10 mm** on the table plane.
+≤ **10 mm** on the table plane. Thresholds may be revised when selection runs.
 
 ---
 
-## Candidates
+## Candidates (discussion list — not ranked)
 
-| ID | Method | Pros | Cons |
-| --- | --- | --- | --- |
-| **A** | **HSV colour segmentation + contour circularity** | Fast, deterministic, easy unit tests | Needs colour contrast; lighting sensitivity |
-| **B** | Hough circle on edges / gradient | Radius prior helps | Weaker under texture / partial occlusion |
-| **C** | Stereo triangulation (2 calibrated views) | True 3-D without plane assumption | Needs dual cameras + calibration; heavier MJCF |
-| **D** | Learned detector (e.g. YOLO-class) | Robust appearance | CI weight, non-determinism, overkill for v1.3 |
+Examples to evaluate; none is selected by the scaffold:
+
+| ID | Method family | Notes |
+| --- | --- | --- |
+| A | Colour segmentation + shape score | Classic blob track |
+| B | Edge / circle fitting | Radius prior in image |
+| C | Multi-view geometric lift | Needs ≥2 calibrated cameras |
+| D | Learned detector | Heavier deps; optional stretch |
+
+Add / remove rows as the discussion proceeds. Record measured C1–C6 here
+before locking a primary.
 
 ---
 
-## Provisional primary selection
+## Selection status
 
-**Primary (v1.3):** **Candidate A** — HSV blob + circularity score.  
-**Depth / Z lift:** intersect camera ray with the **known table / floor plane**
-(scenario parameter), using configured ball radius for contact offset.  
-**Secondary (optional in v1.3, useful in v1.4):** Candidate **C** as a refinement
-when two cameras are mounted — same `BallObservation` output type.  
-**Not required for v1.3 tag:** Candidate D.
+**Status: open.** No primary algorithm is locked.
 
-### Why A
+When selection completes, this section must record:
 
-1. Tennis-like balls in FRET cells are **high-chroma** against table/floor.
-2. MuJoCo lighting is controllable → HSV thresholds live in
-   `config/vision/*.yml` (configuration-over-code).
-3. Matches FRET’s SDD/CI culture: pure NumPy/OpenCV-class ops, golden fixtures.
-4. Interface still allows swapping in B/C/D without changing FSM consumers.
+1. Chosen primary (and optional secondary) with rationale against C1–C6.
+2. Measured fixture metrics.
+3. Pointer to the implementing modules under `fret.vision.detect` /
+   `geometry` / `track`.
 
-### What “selection complete” means
-
-v1.3 is done when:
-
-1. This table has **measured** C1 results for at least A and one runner-up.
-2. Primary remains A **or** is explicitly changed here with rationale.
-3. Unit tests encode the fixture gate for the chosen primary.
-
-Until measurements land, treat **A** as the engineering default.
+Until then, `BallVisionPipeline` accepts any objects matching
+`BallDetector` / `PoseLifter` / `BallTracker`.
 
 ---
 
 ## Interface expectation (independent of algo)
 
 ```text
-CameraFrame[+…]  →  detect()  →  BallDetection[+…]
-                 →  lift()    →  BallObservation | None
+Sequence[CameraFrame]
+  → BallDetector.detect()   → list[BallDetection]
+  → BallTracker.update()    → list[BallDetection]   (optional)
+  → PoseLifter.lift()       → BallObservation | None
 ```
 
-Multi-camera: detections may be fused in `lift()` (stereo) or selected
-(best monocular). The pipeline must accept `Sequence[CameraFrame]`.
+Multi-camera: the detector and lifter receive the full frame sequence; fusion
+strategy is an implementation detail behind those protocols.
 
 ---
 
-## Dependencies (allowed)
+## Dependencies
 
-| Allowed in v1.3 core | Avoid as hard requirement |
-| --- | --- |
-| NumPy | GPU runtimes |
-| OpenCV *or* skimage (pick one in implementation PR) | Large ONNX/Torch weights in default CI |
-
-If OpenCV is chosen, document the apt/pip pin in the vision module README /
-`pyproject` optional extra `vision`.
+Dependency choices (OpenCV vs skimage vs other) are part of algorithm
+selection and are **not** pinned by the scaffold. Optional extras may be added
+to `pyproject.toml` when an implementation lands.

--- a/docs/vision/architecture.md
+++ b/docs/vision/architecture.md
@@ -42,7 +42,8 @@ place / dispenser ← scenario YAML (known parameter)
                │ CameraFrame(s)
 ┌──────────────┴──────────────────────────────────────────────┐
 │  fret.vision  (pure Python)                                 │
-│  detect → (optional) track → geometry lift → BallObservation│
+│  BallDetector → (BallTracker) → PoseLifter                  │
+│  via BallVisionPipeline  →  BallObservation | None          │
 └──────────────▲──────────────────────────────────────────────┘
                │ RGB (+ optional depth later)
 ┌──────────────┴──────────────────────────────────────────────┐

--- a/docs/vision/camera-layout.md
+++ b/docs/vision/camera-layout.md
@@ -13,7 +13,7 @@ encode cameras in `showcase.yml`.
 1. Ball resting on table or floor is visible with high probability.
 2. Extrinsics are **stable and documented** (YAML), matching MJCF.
 3. Mount looks **realistic** for a lab / light-industrial cell (not a free-floating eye).
-4. Layout supports the **selected** algorithm (HSV mono + optional stereo).
+4. Layout supports the **selected** algorithm once chosen (mono or multi-view).
 
 ---
 
@@ -48,11 +48,12 @@ may be studied later; they are not the v1.4 default.
 
 ## Optional second camera
 
-If stereo refinement (candidate C) is enabled:
+If multi-view lift is selected during algorithm discussion:
 
 - Cam-B on the portal leg or a side post, ~30–45° toward the pick region.
 - Baseline and overlap documented in the camera YAML.
-- Fusion stays inside `fret.vision`; scenarios only list camera ids.
+- Fusion stays inside `PoseLifter` / detector implementations; scenarios only
+  list camera ids.
 
 ---
 

--- a/src/fret/config/vision/README.md
+++ b/src/fret/config/vision/README.md
@@ -1,0 +1,8 @@
+# Vision configuration (v1.3+)
+#
+# Algorithm-agnostic camera calibration and scenario wiring will live here.
+# Detector / tracker / lifter tunables belong in per-implementation YAML once
+# an algorithm is selected — do not put method-specific knobs in a shared
+# "default" until that selection lands.
+#
+# See docs/vision/README.md and docs/modules/vision.md.

--- a/src/fret/vision/__init__.py
+++ b/src/fret/vision/__init__.py
@@ -1,0 +1,34 @@
+"""Computer-vision package for graspable-ball observation (v1.3+).
+
+Algorithm-agnostic contracts and pipeline scaffolding. Concrete detectors /
+lifters are selected and implemented separately; this package must not encode
+a preferred algorithm.
+
+Pure Python: no ``rclpy`` or MuJoCo imports.
+"""
+
+from fret.vision.pipeline import BallVisionPipeline
+from fret.vision.protocols import BallDetector, BallTracker, PoseLifter
+from fret.vision.types import (
+    BallDetection,
+    BallObservation,
+    CameraExtrinsics,
+    CameraFrame,
+    CameraIntrinsics,
+    PlaceTarget,
+    VisionConfig,
+)
+
+__all__ = [
+    "BallDetection",
+    "BallDetector",
+    "BallObservation",
+    "BallTracker",
+    "BallVisionPipeline",
+    "CameraExtrinsics",
+    "CameraFrame",
+    "CameraIntrinsics",
+    "PlaceTarget",
+    "PoseLifter",
+    "VisionConfig",
+]

--- a/src/fret/vision/detect/__init__.py
+++ b/src/fret/vision/detect/__init__.py
@@ -1,0 +1,5 @@
+"""Package markers for future detector / lifter / tracker implementations.
+
+No concrete algorithms live here yet. Selection is tracked in
+``docs/vision/algorithm-selection.md``.
+"""

--- a/src/fret/vision/geometry/__init__.py
+++ b/src/fret/vision/geometry/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for pixel → world lift implementations (future)."""

--- a/src/fret/vision/pipeline.py
+++ b/src/fret/vision/pipeline.py
@@ -1,0 +1,70 @@
+"""Ball vision pipeline: frames in → optional world observation out.
+
+Composes detector → optional tracker → pose lifter. Concrete algorithms are
+injected; this module does not select or embed one.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from fret.vision.protocols import BallDetector, BallTracker, PoseLifter
+from fret.vision.types import BallObservation, CameraFrame, VisionConfig
+
+
+class BallVisionPipeline:
+    """Orchestrates vision stages behind a stable I/O boundary.
+
+    Args:
+        detector: Image-space ball detector (required).
+        lifter: Pixel → world pose lifter (required).
+        tracker: Optional temporal filter between detect and lift.
+        config: Shared camera calibration (algorithm-agnostic).
+        source: Opaque id written onto successful :class:`BallObservation`
+            values by a future Level-4 implementation (stored for API shape).
+    """
+
+    def __init__(
+        self,
+        detector: BallDetector,
+        lifter: PoseLifter,
+        *,
+        tracker: BallTracker | None = None,
+        config: VisionConfig | None = None,
+        source: str = "ball_vision_pipeline",
+    ) -> None:
+        if not source:
+            raise ValueError("source must be non-empty")
+        self._detector = detector
+        self._lifter = lifter
+        self._tracker = tracker
+        self._config = config
+        self._source = source
+
+    @property
+    def config(self) -> VisionConfig | None:
+        """Shared vision config, if provided at construction."""
+        return self._config
+
+    @property
+    def source(self) -> str:
+        """Opaque producer id for observations emitted by this pipeline."""
+        return self._source
+
+    def process(self, frames: Sequence[CameraFrame]) -> BallObservation | None:
+        """Run detect → (track) → lift.
+
+        Returns:
+            A world-frame :class:`BallObservation`, or ``None`` when no ball
+            can be reported (never fabricates a pose).
+
+        Raises:
+            NotImplementedError: Level-3 stub — orchestration not filled yet.
+            ValueError: If ``frames`` is empty.
+        """
+        if not frames:
+            raise ValueError("frames must be non-empty")
+        raise NotImplementedError(
+            "BallVisionPipeline.process is a Level-3 stub; "
+            "wire detector/tracker/lifter in the v1.3 implementation"
+        )

--- a/src/fret/vision/protocols.py
+++ b/src/fret/vision/protocols.py
@@ -1,0 +1,46 @@
+"""Algorithm-agnostic protocols for ball vision stages.
+
+Implementations plug in after algorithm selection. The scaffold defines only
+the call shapes so inputs/outputs stay stable across candidates.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from fret.vision.types import BallDetection, BallObservation, CameraFrame
+
+
+@runtime_checkable
+class BallDetector(Protocol):
+    """Produce image-space ball hypotheses from one or more frames."""
+
+    def detect(self, frames: Sequence[CameraFrame]) -> list[BallDetection]:
+        """Return zero or more detections (may be empty)."""
+        ...
+
+
+@runtime_checkable
+class BallTracker(Protocol):
+    """Optional temporal association over detections."""
+
+    def update(
+        self,
+        detections: Sequence[BallDetection],
+        timestamp: float,
+    ) -> list[BallDetection]:
+        """Return tracked / filtered detections for this timestamp."""
+        ...
+
+
+@runtime_checkable
+class PoseLifter(Protocol):
+    """Lift image-space detections to a world-frame ball observation."""
+
+    def lift(
+        self,
+        detections: Sequence[BallDetection],
+        frames: Sequence[CameraFrame],
+    ) -> BallObservation | None:
+        """Return one observation, or ``None`` if lift is impossible."""
+        ...

--- a/src/fret/vision/track/__init__.py
+++ b/src/fret/vision/track/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for temporal tracking implementations (future)."""

--- a/src/fret/vision/types.py
+++ b/src/fret/vision/types.py
@@ -1,0 +1,214 @@
+"""Typed I/O contracts for the vision → manipulation boundary.
+
+Algorithm-agnostic: these types describe images, detections, and world-frame
+observations only. They must not encode colour spaces, feature methods, or
+network architectures. See ``docs/interfaces.md`` § Vision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Pinhole camera intrinsics for one sensor (metres / pixels).
+
+    Distortion models are intentionally omitted from the scaffold; add them
+    when a concrete calibration path requires them.
+    """
+
+    camera_id: str
+    width: int
+    height: int
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+    def __post_init__(self) -> None:
+        if not self.camera_id:
+            raise ValueError("camera_id must be non-empty")
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(
+                f"width/height must be positive, got {self.width}x{self.height}"
+            )
+        if self.fx <= 0.0 or self.fy <= 0.0:
+            raise ValueError(
+                f"fx/fy must be positive, got fx={self.fx}, fy={self.fy}"
+            )
+
+
+@dataclass(frozen=True)
+class CameraExtrinsics:
+    """Rigid transform from camera frame to ``world`` (4×4 homogeneous)."""
+
+    camera_id: str
+    t_world_cam: npt.NDArray[np.float64]
+
+    def __post_init__(self) -> None:
+        if not self.camera_id:
+            raise ValueError("camera_id must be non-empty")
+        matrix = np.asarray(self.t_world_cam, dtype=np.float64)
+        if matrix.shape != (4, 4):
+            raise ValueError(
+                f"t_world_cam must have shape (4, 4), got {matrix.shape}"
+            )
+        object.__setattr__(self, "t_world_cam", matrix)
+
+
+@dataclass(frozen=True)
+class CameraFrame:
+    """One camera image sample for the vision pipeline.
+
+    ``image`` is RGB ``(H, W, 3)`` uint8 or grayscale ``(H, W)`` uint8.
+    ``intrinsics_id`` names the calibration entry in :class:`VisionConfig`
+    (may equal ``camera_id``).
+    """
+
+    camera_id: str
+    image: npt.NDArray[np.uint8]
+    timestamp: float
+    intrinsics_id: str
+
+    def __post_init__(self) -> None:
+        if not self.camera_id:
+            raise ValueError("camera_id must be non-empty")
+        if not self.intrinsics_id:
+            raise ValueError("intrinsics_id must be non-empty")
+        image = np.asarray(self.image)
+        if image.dtype != np.uint8:
+            raise ValueError(f"image dtype must be uint8, got {image.dtype}")
+        if image.ndim == 2:
+            pass
+        elif image.ndim == 3 and image.shape[2] == 3:
+            pass
+        else:
+            raise ValueError(
+                "image must be (H, W) or (H, W, 3), "
+                f"got shape {image.shape}"
+            )
+        object.__setattr__(self, "image", image)
+
+
+@dataclass(frozen=True)
+class BallDetection:
+    """Image-space ball hypothesis from one or more views.
+
+    Geometry is expressed in pixels only. How the centre / radius were
+    estimated is left to the detector implementation.
+    """
+
+    camera_id: str
+    centre_px: tuple[float, float]
+    radius_px: float
+    confidence: float
+
+    def __post_init__(self) -> None:
+        if not self.camera_id:
+            raise ValueError("camera_id must be non-empty")
+        if self.radius_px < 0.0:
+            raise ValueError(f"radius_px must be >= 0, got {self.radius_px}")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                f"confidence must be in [0, 1], got {self.confidence}"
+            )
+        if len(self.centre_px) != 2:
+            raise ValueError(
+                f"centre_px must be length 2, got {self.centre_px!r}"
+            )
+
+
+@dataclass(frozen=True)
+class BallObservation:
+    """World-frame ball estimate for manipulation consumers.
+
+    ``pickable`` is ``None`` until a pickability classifier exists (v1.5).
+    ``source`` is an opaque producer id (pipeline / stage name), not an
+    algorithm recipe.
+    """
+
+    position_world: npt.NDArray[np.float64]
+    radius_m: float
+    timestamp: float
+    source: str
+    covariance: npt.NDArray[np.float64] | None = None
+    pickable: bool | None = None
+
+    def __post_init__(self) -> None:
+        position = np.asarray(self.position_world, dtype=np.float64)
+        if position.shape != (3,):
+            raise ValueError(
+                f"position_world must have shape (3,), got {position.shape}"
+            )
+        object.__setattr__(self, "position_world", position)
+        if self.radius_m < 0.0:
+            raise ValueError(f"radius_m must be >= 0, got {self.radius_m}")
+        if not self.source:
+            raise ValueError("source must be non-empty")
+        if self.covariance is not None:
+            cov = np.asarray(self.covariance, dtype=np.float64)
+            if cov.shape != (3, 3):
+                raise ValueError(
+                    f"covariance must have shape (3, 3), got {cov.shape}"
+                )
+            object.__setattr__(self, "covariance", cov)
+
+
+@dataclass(frozen=True)
+class PlaceTarget:
+    """Known place / dispenser pose from scenario parameters (not from CV)."""
+
+    position_world: npt.NDArray[np.float64]
+    frame_id: str = "world"
+
+    def __post_init__(self) -> None:
+        if self.frame_id != "world":
+            raise ValueError(
+                f"PlaceTarget frame_id must be 'world', got '{self.frame_id}'"
+            )
+        position = np.asarray(self.position_world, dtype=np.float64)
+        if position.shape != (3,):
+            raise ValueError(
+                f"position_world must have shape (3,), got {position.shape}"
+            )
+        object.__setattr__(self, "position_world", position)
+
+
+@dataclass(frozen=True)
+class VisionConfig:
+    """Shared, algorithm-agnostic vision configuration.
+
+    Holds camera calibration only. Detector / lifter / tracker knobs belong
+    with those implementations (and their YAML), not here.
+    """
+
+    intrinsics: tuple[CameraIntrinsics, ...]
+    extrinsics: tuple[CameraExtrinsics, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.intrinsics:
+            raise ValueError("VisionConfig.intrinsics must be non-empty")
+        ids = [item.camera_id for item in self.intrinsics]
+        if len(ids) != len(set(ids)):
+            raise ValueError(f"duplicate camera_id in intrinsics: {ids}")
+        ext_ids = [item.camera_id for item in self.extrinsics]
+        if len(ext_ids) != len(set(ext_ids)):
+            raise ValueError(f"duplicate camera_id in extrinsics: {ext_ids}")
+
+    def intrinsics_for(self, camera_id: str) -> CameraIntrinsics:
+        """Return intrinsics for ``camera_id`` or raise ``KeyError``."""
+        for item in self.intrinsics:
+            if item.camera_id == camera_id:
+                return item
+        raise KeyError(f"no intrinsics for camera_id={camera_id!r}")
+
+    def extrinsics_for(self, camera_id: str) -> CameraExtrinsics:
+        """Return extrinsics for ``camera_id`` or raise ``KeyError``."""
+        for item in self.extrinsics:
+            if item.camera_id == camera_id:
+                return item
+        raise KeyError(f"no extrinsics for camera_id={camera_id!r}")

--- a/tests/vision/__init__.py
+++ b/tests/vision/__init__.py
@@ -1,0 +1,1 @@
+"""Package init for vision tests."""

--- a/tests/vision/test_pipeline.py
+++ b/tests/vision/test_pipeline.py
@@ -1,0 +1,92 @@
+"""Unit tests for BallVisionPipeline scaffolding (Level 3)."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import pytest
+
+from fret.vision.pipeline import BallVisionPipeline
+from fret.vision.protocols import BallDetector, PoseLifter
+from fret.vision.types import (
+    BallDetection,
+    BallObservation,
+    CameraFrame,
+    CameraIntrinsics,
+    VisionConfig,
+)
+
+
+class _StubDetector:
+    def detect(self, frames: Sequence[CameraFrame]) -> list[BallDetection]:
+        del frames
+        return []
+
+
+class _StubLifter:
+    def lift(
+        self,
+        detections: Sequence[BallDetection],
+        frames: Sequence[CameraFrame],
+    ) -> BallObservation | None:
+        del detections, frames
+        return None
+
+
+def _frame() -> CameraFrame:
+    return CameraFrame(
+        camera_id="cam0",
+        image=np.zeros((8, 8, 3), dtype=np.uint8),
+        timestamp=0.0,
+        intrinsics_id="cam0",
+    )
+
+
+def _config() -> VisionConfig:
+    return VisionConfig(
+        intrinsics=(
+            CameraIntrinsics(
+                camera_id="cam0",
+                width=8,
+                height=8,
+                fx=10.0,
+                fy=10.0,
+                cx=4.0,
+                cy=4.0,
+            ),
+        )
+    )
+
+
+def test_pipeline_stores_dependencies() -> None:
+    detector: BallDetector = _StubDetector()
+    lifter: PoseLifter = _StubLifter()
+    pipe = BallVisionPipeline(
+        detector,
+        lifter,
+        config=_config(),
+        source="scaffold",
+    )
+    assert pipe.config is not None
+    assert pipe.source == "scaffold"
+    assert isinstance(detector, BallDetector)
+    assert isinstance(lifter, PoseLifter)
+
+
+def test_pipeline_rejects_empty_source() -> None:
+    with pytest.raises(ValueError, match="source"):
+        BallVisionPipeline(_StubDetector(), _StubLifter(), source="")
+
+
+@pytest.mark.xfail(strict=True, raises=NotImplementedError)
+def test_pipeline_process_not_implemented() -> None:
+    """Level-3: orchestration raises until v1.3 implementation lands."""
+    pipe = BallVisionPipeline(_StubDetector(), _StubLifter())
+    pipe.process([_frame()])
+
+
+def test_pipeline_process_rejects_empty_frames() -> None:
+    pipe = BallVisionPipeline(_StubDetector(), _StubLifter())
+    with pytest.raises(ValueError, match="non-empty"):
+        pipe.process([])

--- a/tests/vision/test_protocols.py
+++ b/tests/vision/test_protocols.py
@@ -1,0 +1,72 @@
+"""Tests that vision protocols are structural (algorithm-agnostic)."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+
+from fret.vision.protocols import BallDetector, BallTracker, PoseLifter
+from fret.vision.types import BallDetection, BallObservation, CameraFrame
+
+
+class _AnyDetector:
+    """Stand-in with no algorithm semantics — only the call shape."""
+
+    def detect(self, frames: Sequence[CameraFrame]) -> list[BallDetection]:
+        assert frames
+        return [
+            BallDetection(
+                camera_id=frames[0].camera_id,
+                centre_px=(1.0, 2.0),
+                radius_px=3.0,
+                confidence=0.9,
+            )
+        ]
+
+
+class _AnyTracker:
+    def update(
+        self,
+        detections: Sequence[BallDetection],
+        timestamp: float,
+    ) -> list[BallDetection]:
+        del timestamp
+        return list(detections)
+
+
+class _AnyLifter:
+    def lift(
+        self,
+        detections: Sequence[BallDetection],
+        frames: Sequence[CameraFrame],
+    ) -> BallObservation | None:
+        del frames
+        if not detections:
+            return None
+        return BallObservation(
+            position_world=np.zeros(3, dtype=np.float64),
+            radius_m=0.01,
+            timestamp=0.0,
+            source="protocol_test",
+        )
+
+
+def test_structural_protocol_instances() -> None:
+    assert isinstance(_AnyDetector(), BallDetector)
+    assert isinstance(_AnyTracker(), BallTracker)
+    assert isinstance(_AnyLifter(), PoseLifter)
+
+
+def test_detector_lifter_round_trip_shape() -> None:
+    frame = CameraFrame(
+        camera_id="cam0",
+        image=np.zeros((4, 4), dtype=np.uint8),
+        timestamp=0.0,
+        intrinsics_id="cam0",
+    )
+    detections = _AnyDetector().detect([frame])
+    tracked = _AnyTracker().update(detections, timestamp=0.0)
+    obs = _AnyLifter().lift(tracked, [frame])
+    assert obs is not None
+    assert obs.position_world.shape == (3,)

--- a/tests/vision/test_types.py
+++ b/tests/vision/test_types.py
@@ -1,0 +1,126 @@
+"""Unit tests for fret.vision typed contracts (algorithm-agnostic)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fret.vision.types import (
+    BallDetection,
+    BallObservation,
+    CameraExtrinsics,
+    CameraFrame,
+    CameraIntrinsics,
+    PlaceTarget,
+    VisionConfig,
+)
+
+
+def _rgb(h: int = 4, w: int = 6) -> np.ndarray:
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+def test_camera_intrinsics_rejects_non_positive_focal() -> None:
+    with pytest.raises(ValueError, match="fx/fy"):
+        CameraIntrinsics(
+            camera_id="cam0",
+            width=640,
+            height=480,
+            fx=0.0,
+            fy=500.0,
+            cx=320.0,
+            cy=240.0,
+        )
+
+
+def test_camera_frame_accepts_rgb_and_gray() -> None:
+    rgb = CameraFrame(
+        camera_id="cam0",
+        image=_rgb(),
+        timestamp=1.0,
+        intrinsics_id="cam0",
+    )
+    assert rgb.image.shape == (4, 6, 3)
+    gray = CameraFrame(
+        camera_id="cam0",
+        image=np.zeros((4, 6), dtype=np.uint8),
+        timestamp=1.0,
+        intrinsics_id="cam0",
+    )
+    assert gray.image.ndim == 2
+
+
+def test_camera_frame_rejects_float_image() -> None:
+    with pytest.raises(ValueError, match="uint8"):
+        CameraFrame(
+            camera_id="cam0",
+            image=np.zeros((4, 6, 3), dtype=np.float32),
+            timestamp=0.0,
+            intrinsics_id="cam0",
+        )
+
+
+def test_ball_detection_confidence_bounds() -> None:
+    with pytest.raises(ValueError, match="confidence"):
+        BallDetection(
+            camera_id="cam0",
+            centre_px=(10.0, 20.0),
+            radius_px=5.0,
+            confidence=1.5,
+        )
+
+
+def test_ball_observation_world_position_shape() -> None:
+    obs = BallObservation(
+        position_world=np.array([0.1, 0.2, 0.03], dtype=np.float64),
+        radius_m=0.025,
+        timestamp=2.0,
+        source="unit_test",
+    )
+    assert obs.position_world.shape == (3,)
+    assert obs.pickable is None
+    with pytest.raises(ValueError, match="shape \\(3,\\)"):
+        BallObservation(
+            position_world=np.array([0.1, 0.2], dtype=np.float64),
+            radius_m=0.025,
+            timestamp=2.0,
+            source="unit_test",
+        )
+
+
+def test_place_target_requires_world_frame() -> None:
+    target = PlaceTarget(
+        position_world=np.array([0.3, 0.0, 0.05], dtype=np.float64)
+    )
+    assert target.frame_id == "world"
+    with pytest.raises(ValueError, match="world"):
+        PlaceTarget(
+            position_world=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            frame_id="base_link",
+        )
+
+
+def test_vision_config_lookup() -> None:
+    intr = CameraIntrinsics(
+        camera_id="cam0",
+        width=640,
+        height=480,
+        fx=500.0,
+        fy=500.0,
+        cx=320.0,
+        cy=240.0,
+    )
+    ext = CameraExtrinsics(
+        camera_id="cam0",
+        t_world_cam=np.eye(4, dtype=np.float64),
+    )
+    cfg = VisionConfig(intrinsics=(intr,), extrinsics=(ext,))
+    assert cfg.intrinsics_for("cam0") is intr
+    assert cfg.extrinsics_for("cam0") is ext
+    with pytest.raises(KeyError):
+        cfg.intrinsics_for("missing")
+
+
+def test_vision_config_rejects_empty_intrinsics() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        VisionConfig(intrinsics=())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

v1.3 needs a `fret.vision` package, but algorithm selection is still open. The API must not bake in HSV, stereo, learned detectors, or other method-specific knobs.

## Fix

Scaffold an **algorithm-agnostic** vision boundary:

- `types`: `CameraFrame`, `BallDetection`, `BallObservation`, `PlaceTarget`, `CameraIntrinsics` / `Extrinsics`, `VisionConfig` (calibration only)
- `protocols`: `BallDetector`, `BallTracker`, `PoseLifter`
- `BallVisionPipeline`: DI constructor; `process()` Level-3 stub (`NotImplementedError`)
- Empty `detect/` / `geometry/` / `track/` markers; `config/vision/` README (no algo YAML)
- Docs: selection status set to **open**; removed provisional HSV lock from roadmap-facing docs

## Verification

```bash
python3 -m pytest tests/vision/ -p no:launch_testing -p no:launch_ros -q
# 13 passed, 1 xfailed (process stub)
bash scripts/check/formatting.sh   # PASS
bash scripts/check/types.sh        # PASS (mypy, 76 files)
```

## Recurrence

Follows the merged CV roadmap; deliberately does **not** close V13-2/V13-3 (selection + fixture gates remain future work).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

