### PR TITLE
docs(release): mark v1.3.0 tag shipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ connects the [ARCO](https://github.com/alexandrelheinen/arco) motion-planning st
 MuJoCo simulation. Algorithm code lives in pure Python; a thin ROS 2 layer handles
 topics, actions, and simulator I/O.
 
-**Current release: v1.2.7** — dual-agent Dubins race (TB3 case study),
-**MuJoCo physics SITL**, OM-X / OMY tabletop showcases, PlotJuggler telemetry
-beside release videos on R2. Mobile showcase renders use `--physics-mode`.
+**Current release: v1.3.0** — `fret.vision` ball pipeline (OpenCV HSV blob +
+table-plane lift), unit tests, algorithm selection; plus v1.2.x MuJoCo physics
+SITL showcases (TB3 Dubins, OM-X / OMY) with PlotJuggler telemetry on R2.
 
 <br clear="left">
 
@@ -25,9 +25,8 @@ beside release videos on R2. Mobile showcase renders use `--physics-mode`.
 | Computer vision | **Not used** | Pipeline in v1.3; integrated v1.4–v1.5 |
 | Sim | MuJoCo physics SITL | MuJoCo physics + (v1.4) cameras |
 
-**Current release line:** v1.2.7 shipped showcases; **v1.3 CV pipeline** is
-implemented on `main` once PR #126 merges (tag `v1.3.0` next). Package on
-`main` is **1.3.0**. Next: **v1.4** CV↔manipulation. See
+**Current release line:** **v1.3.0** ships the CV algorithm layer. Next:
+**v1.4** CV↔manipulation (MuJoCo cameras, no hardcoded ball). See
 [docs/roadmap.md](docs/roadmap.md) and [docs/releases.md](docs/releases.md).
 
 ---
@@ -41,7 +40,7 @@ src/fret/
 ├── scenario/          # Pure-Python E2E orchestrators (Dubins race)
 ├── telemetry/         # Opt-in PlotJuggler CSV logger + layouts (FR-SIM-12)
 ├── scene/             # Scene acquisition → occupancy adapter
-├── vision/            # Ball CV pipeline (scaffold from v1.3)
+├── vision/            # Ball CV pipeline (v1.3: HSV + table-plane)
 ├── ros/               # MuJoCo bridge, perception bridge, race node
 ├── validation/        # Metrics and quality gates
 ├── hardware/          # HITL bridge stub (v2.x)

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -510,8 +510,8 @@ this repository documentation** — see [roadmap.md](roadmap.md).
 | `v2.0.0+` | Hardware line (modular) | T2x-* |
 | `v3.0.0` | Definitive product (north-star) | — |
 
-Python package on `main` is **1.3.0** for the open CV development line
-(`pyproject.toml`). Product tags remain `v1.3.0`, `v1.4.0`, `v1.5.0`, then
+Python package on `main` is **1.3.0** (`pyproject.toml`). Product tag
+`v1.3.0` ships the CV pipeline; next product tags are `v1.4.0`, `v1.5.0`, then
 `v2.x` / `v3.0.0`.
 
 ### v1.1.x → v1.2.0 retrospective

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -504,7 +504,7 @@ this repository documentation** — see [roadmap.md](roadmap.md).
 | `v1.2.5` | Patch: OMY clutter showcase detour | — ✅ |
 | `v1.2.6` | Patch: telemetry on R2 (FR-SIM-12) | — ✅ |
 | `v1.2.7` | Patch: Dubins showcase encode / clip length | — ✅ |
-| `v1.3.0` | **CV pipeline + algorithm selection** | T13-* |
+| `v1.3.0` | **CV pipeline + algorithm selection** | T13-* ✅ |
 | `v1.4.0` | CV ↔ manipulation + MuJoCo cameras | T14-* |
 | `v1.5.0` | Dynamic ball + industrial place | T15-* |
 | `v2.0.0+` | Hardware line (modular) | T2x-* |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,7 +104,7 @@ camera MJCF required to *select*; fixtures may use synthetic images.
   (HSV blob + table-plane lift; OpenCV)
 - [x] Unit tests on synthetic fixtures (`tests/vision/`; CI control shard)
 - [x] Web gallery script for qualitative photos (`scripts/vision_web_ball_gallery.py`)
-- [ ] Tag `v1.3.0` *(after this PR merges)*
+- [x] Tag `v1.3.0`
 
 ### Phase 6 — CV ↔ manipulation integration 🔲 *(v1.4)*
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

v1.3 CV pipeline is merged (#124–#126) and tagged `v1.3.0`, but README / roadmap still described the tag as pending.

## Fix

- README: current release → **v1.3.0**
- Roadmap Phase 5: check off `Tag v1.3.0`
- `docs/releases.md`: T13-* prerequisite ✅; clarify package vs product tag

## Verification

| Check | Result |
| --- | --- |
| Tag `v1.3.0` | annotated @ `be43f03` |
| GitHub Release | https://github.com/alexandrelheinen/fret/releases/tag/v1.3.0 |
| `release.yml` | **success** — all showcase renders + R2 publish ([run 30092831980](https://github.com/alexandrelheinen/fret/actions/runs/30092831980)) |
| Local gates | `formatting.sh` / `types.sh` PASS |

Docs PR is post-tag (same pattern as v1.1.0 checklist PR #80).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

