### PR TITLE
chore(release): T14-04 SC-v16 + bump package to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ connects the [ARCO](https://github.com/alexandrelheinen/arco) motion-planning st
 MuJoCo simulation. Algorithm code lives in pure Python; a thin ROS 2 layer handles
 topics, actions, and simulator I/O.
 
-**Current release: v1.3.0** — `fret.vision` ball pipeline (OpenCV HSV blob +
-table-plane lift), unit tests, algorithm selection; plus v1.2.x MuJoCo physics
-SITL showcases (TB3 Dubins, OM-X / OMY) with PlotJuggler telemetry on R2.
+**Package on `main`: 1.4.0** — CV↔manipulation ready (MuJoCo gate cameras →
+`BallObservation` → OM-X/OMY pick-place). Product tag **`v1.4.0`** is next
+after this line merges. Prior tag: **v1.3.0** (CV pipeline).
 
 <br clear="left">
 
@@ -25,9 +25,9 @@ SITL showcases (TB3 Dubins, OM-X / OMY) with PlotJuggler telemetry on R2.
 | Computer vision | **Not used** | Pipeline in v1.3; integrated v1.4–v1.5 |
 | Sim | MuJoCo physics SITL | MuJoCo physics + (v1.4) cameras |
 
-**Current release line:** **v1.3.0** ships the CV algorithm layer. Next:
-**v1.4** CV↔manipulation (MuJoCo cameras, no hardcoded ball). See
-[docs/roadmap.md](docs/roadmap.md) and [docs/releases.md](docs/releases.md).
+**Release line:** package **1.4.0** completes T14-* (SC-v16 CV pick-place).
+Tag **`v1.4.0`** next. See [docs/roadmap.md](docs/roadmap.md) and
+[docs/releases.md](docs/releases.md).
 
 ---
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -419,5 +419,5 @@ them.
 `fret.simulation.MujocoCameraAdapter` renders a named MJCF camera
 (default `overhead`) at **1280×720**, converts MuJoCo `cam_xmat` to the
 OpenCV optical frame, and returns `CameraFrame` plus live
-intrinsics/extrinsics. It does **not** publish to ROS or drive the FSM; that
-wiring is T14-03.
+intrinsics/extrinsics. It does **not** publish to ROS. FSM feed lives in
+`fret.control.pick_place_vision` (T14-03, done in v1.4).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -357,7 +357,7 @@ Selection ADR: [vision/algorithm-selection.md](vision/algorithm-selection.md).
 
 ---
 
-## v1.4 — CV ↔ manipulation integration
+## v1.4 — CV ↔ manipulation integration ✅
 
 ### Goal
 
@@ -371,28 +371,41 @@ positions**. Simulate cameras in MuJoCo with a **realistic mount**. The
 | Item | Detail |
 |---|---|
 | Robots | `open_manipulator_x`, `omy` |
-| Cameras | MJCF `<camera>` on a portal / gantry (or better mount from selection needs) |
-| Ball pose | From `BallObservation` → FSM / IK / planner entry |
+| Cameras | MJCF `<camera>` on rear structural gate (dual corner cams) |
+| Ball pose | From `BallObservation` → pad-mid IK → FSM |
 | Place pose | YAML known parameter (fixed industrial fixture) |
 | Equivalence | Same DONE / cone-place success as pre-CV scenarios on seeded runs |
 
 ### Scenario IDs
 
-| ID | File (planned) | Description |
+| ID | File | Description |
 |---|---|---|
-| SC-v16a | `omx_pick_place_cv.yml` (name TBD) | OM-X pick-place driven by CV ball pose |
-| SC-v16b | `omy_pick_place_cv.yml` (name TBD) | OMY analogue |
-| SC-v16c | clutter variants | Optional: clutter + CV ball (place still known) |
+| SC-v16a | `omx_pick_place_cv.yml` | OM-X CV pick-place (`scenario_id: omx_pick_place`) |
+| SC-v16b | `omy_pick_place_cv.yml` | OMY analogue (`scenario_id: omy_pick_place`) |
+| SC-v16c | clutter variants | Optional / deferred: clutter + CV ball |
+
+Base cells `omx_pick_place.yml` / `omy_pick_place.yml` already default
+`use_vision=True` in runners; SC-v16 YAML locks the CV contract explicitly.
 
 ### Acceptance criteria
 
-| # | Criterion |
+| # | Criterion | Status |
+|---|---|---|
+| V14-1 | Scenario MJCF includes calibrated sim cameras with documented extrinsics | ✅ |
+| V14-2 | Release pick-place paths do not read hardcoded ball / `pick_xy` as ground truth | ✅ |
+| V14-3 | Place / dispenser pose comes only from scenario parameters | ✅ |
+| V14-4 | Physics smoke: FSM reaches DONE and ball enters place volume (seeded) | ✅ |
+| V14-5 | Behaviour parity checklist vs SC-v13b / SC-v14b on shared seeds | ✅ see below |
+
+### V14-5 — parity checklist (SC-v13b / SC-v14b ↔ SC-v16)
+
+| Check | How verified |
 |---|---|
-| V14-1 | Scenario MJCF includes calibrated sim cameras with documented extrinsics |
-| V14-2 | Release pick-place paths do not read hardcoded ball / `pick_xy` as ground truth |
-| V14-3 | Place / dispenser pose comes only from scenario parameters |
-| V14-4 | Physics smoke: FSM reaches DONE and ball enters place volume (seeded) |
-| V14-5 | Behaviour parity checklist vs SC-v13b / SC-v14b on shared seeds |
+| Same MJCF cell + place cone | CV YAML keeps `scenario_id` / `mjcf` of base pick-place |
+| Place from YAML only | `place_xy` + place joint configs unchanged by vision path |
+| Pick not from `pick_xy` | `tests/control/test_pick_place_vision.py` + runners |
+| DONE + ball in place volume | `test_*_pick_place_cv_physics_done` / base physics smokes |
+| Vision XY ≪ gripper opening | Portal lift error ≪ open gap (OM-X ~60 mm / OMY ~115 mm) |
 
 ### Implementation tasks
 
@@ -401,7 +414,7 @@ positions**. Simulate cameras in MuJoCo with a **realistic mount**. The
 | T14-01 | Camera mount MJCF + calibration YAML for OM-X / OMY cells | ✅ rear gate + `*_portal_overhead.yml` |
 | T14-02 | MuJoCo image adapter → `fret.vision` | ✅ `MujocoCameraAdapter` + CI benchmarks |
 | T14-03 | Replace hardcoded ball pose in runners with vision output | ✅ `pick_place_vision` + OM-X/OMY runners |
-| T14-04 | SC-v16 scenarios + tests; update showcase matrix when clips are ready | 🔲 |
+| T14-04 | SC-v16 scenarios + tests; showcase matrix note (vision-on) | ✅ `*_pick_place_cv.yml` + tests |
 
 ---
 
@@ -505,14 +518,13 @@ this repository documentation** — see [roadmap.md](roadmap.md).
 | `v1.2.6` | Patch: telemetry on R2 (FR-SIM-12) | — ✅ |
 | `v1.2.7` | Patch: Dubins showcase encode / clip length | — ✅ |
 | `v1.3.0` | **CV pipeline + algorithm selection** | T13-* ✅ |
-| `v1.4.0` | CV ↔ manipulation + MuJoCo cameras | T14-* |
+| `v1.4.0` | CV ↔ manipulation + MuJoCo cameras | T14-* ✅ *(tag next)* |
 | `v1.5.0` | Dynamic ball + industrial place | T15-* |
 | `v2.0.0+` | Hardware line (modular) | T2x-* |
 | `v3.0.0` | Definitive product (north-star) | — |
 
-Python package on `main` is **1.3.0** (`pyproject.toml`). Product tag
-`v1.3.0` ships the CV pipeline; next product tags are `v1.4.0`, `v1.5.0`, then
-`v2.x` / `v3.0.0`.
+Python package on `main` is **1.4.0** (`pyproject.toml`). Product tag
+`v1.4.0` is next (T14-* complete); then `v1.5.0`, `v2.x` / `v3.0.0`.
 
 ### v1.1.x → v1.2.0 retrospective
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@ v1.1–v1.2.x   ✅  Mobile + arm MuJoCo showcases (TB3, OM-X, OMY)
 v1.3   ✅  Computer-vision pipeline (algorithms, unit tests, selection)
      │
      ▼
-v1.4   🔲  CV ↔ manipulation integration (MuJoCo cameras, no hardcoded ball)
+v1.4   ✅  CV ↔ manipulation integration (MuJoCo cameras, no hardcoded ball)
      │
      ▼
 v1.5   🔲  Dynamic ball delivery + industrial place geometry + pickability
@@ -106,15 +106,16 @@ camera MJCF required to *select*; fixtures may use synthetic images.
 - [x] Web gallery script for qualitative photos (`scripts/vision_web_ball_gallery.py`)
 - [x] Tag `v1.3.0`
 
-### Phase 6 — CV ↔ manipulation integration 🔲 *(v1.4)*
+### Phase 6 — CV ↔ manipulation integration ✅ *(v1.4)*
 
 - [x] MuJoCo cameras in OM-X / OMY cells (rear structural gate, dual corner cams)
-- [x] MuJoCo image adapter → `fret.vision` + dual-view detect/lift benchmarks (no FSM feed)
+- [x] MuJoCo image adapter → `fret.vision` + dual-view detect/lift benchmarks
 - [x] Place cone moved in front of arm; pick on the side (±90° yaw margin)
 - [x] Wire `BallObservation` → pick-and-place (replace hardcoded ball / `pick_xy` as grasp GT)
 - [x] Keep **place / dispenser** as known YAML parameters
 - [x] Equivalent behaviour to today’s physics smoke without pose cheats
-- [ ] Tag `v1.4.0`
+- [x] SC-v16a/b scenario YAML + tests (`*_pick_place_cv.yml`)
+- [ ] Tag `v1.4.0` *(after this prep PR merges)*
 
 ### Phase 7 — Dynamic scene + industrial place 🔲 *(v1.5)*
 

--- a/docs/robots/six_dof.md
+++ b/docs/robots/six_dof.md
@@ -16,7 +16,7 @@ without intermediate maze steps:
 | Scenario | File | Purpose |
 |---|---|---|
 | SC-v14a | `omy_reach.yml` | Empty tabletop joint-space reach |
-| SC-v14b | `omy_pick_place.yml` | Pedestal ball → cone pick-and-place |
+| SC-v14b | `omy_pick_place.yml` | Floor ball → cone pick-and-place (+ CV in v1.4) |
 | SC-v14c | `omy_clutter.yml` | Cluttered pedestal pick-and-place with detour |
 
 Model key: `omy` (aliases: `six_dof`, `open_manipulator_y`).

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -154,13 +154,24 @@ robot showcase. Algorithm selection is part of the release:
 
 **Pass criteria:** [releases.md § v1.3](releases.md#v13--computer-vision-pipeline).
 
-### SC-v16 — CV-driven pick-and-place (v1.4)
+### SC-v16a — OpenMANIPULATOR-X CV pick-and-place (v1.4)
 
-**Purpose:** OM-X / OMY pick-place (and optional clutter) with **MuJoCo cameras**
-and ball pose from vision. Place / dispenser remains a known YAML parameter.
-Camera mount: [vision/camera-layout.md](vision/camera-layout.md).
+**File:** `config/scenarios/omx_pick_place_cv.yml`  
+**Model:** `open_manipulator_x` · **MJCF:** same as SC-v13b (`omx_pick_place`)
+
+**Purpose:** Floor ball pick-place with **gate-camera** `BallObservation` driving
+pick IK. Place / dispenser stays YAML. `pick_xy` is a test oracle only.
+
+### SC-v16b — OpenMANIPULATOR-Y CV pick-and-place (v1.4)
+
+**File:** `config/scenarios/omy_pick_place_cv.yml`  
+**Model:** `omy` · **MJCF:** same as SC-v14b (`omy_pick_place`)
+
+**Purpose:** OMY analogue of SC-v16a. Showcase matrix keeps id `omy_pick_place`
+(vision-on by default); this YAML is the explicit SC-v16 contract for tests.
 
 **Pass criteria:** [releases.md § v1.4](releases.md#v14--cv--manipulation-integration).
+Camera mount: [vision/camera-layout.md](vision/camera-layout.md).
 
 ### SC-v17 — Dynamic ball + industrial place (v1.5)
 

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -10,9 +10,9 @@ Hardware cameras and real images belong to **v2.x**.
 
 ## Why vision exists here
 
-Manipulators **grasp scene objects**. Today’s OM-X / OMY scenarios hardcode ball
-poses (`pick_xy`, joint grasp configs derived offline). The CV line replaces
-that cheat with a measured ball pose while keeping planning, FSM, and MPC.
+Manipulators **grasp scene objects**. From **v1.4**, OM-X / OMY pick-place
+takes the ball pose from gate-camera `BallObservation` (SC-v16). YAML
+`pick_xy` remains a **test oracle** only; place / dispenser stays parametric.
 
 **TurtleBot3 / Dubins does not use CV.** It remains an ARCO → MuJoCo mobility
 case study (no graspable object interaction in the product scenarios).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fret"
-version = "1.3.0"
+version = "1.4.0"
 description = "Full-stack Robotic Effector Trajectories Framework"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/fret/__init__.py
+++ b/src/fret/__init__.py
@@ -1,3 +1,3 @@
 """FRET: Full-stack Robotic Effector Trajectories Framework."""
 
-__version__ = "1.2.3"
+__version__ = "1.4.0"

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -16,7 +16,11 @@
 #
 # Static release focus:
 #   * OM-X SC-v13d Γ-wall maze — RRT* vs SST (v1.2.3)
-#   * OMY SC-v14b pick-place + SC-v14c clutter RRT* vs SST (v1.2.4)
+#   * OMY pick-place (SC-v14b / SC-v16b CV path) + SC-v14c clutter RRT* vs SST
+#
+# v1.4: OMY pick-place runners default use_vision=True (gate cams → pick IK).
+# Showcase id stays omy_pick_place so R2 clip names remain stable; SC-v16b
+# alias is config/scenarios/omy_pick_place_cv.yml for tests / explicit CV runs.
 #
 # Regenerate clips via scripts/release/render_showcase.py or release.yml.
 

--- a/src/fret/config/scenarios/omx_pick_place_cv.yml
+++ b/src/fret/config/scenarios/omx_pick_place_cv.yml
@@ -1,14 +1,15 @@
-# SC-v13b — OpenMANIPULATOR-X pick-and-place (FSM + physical transfer).
+# SC-v16a — OpenMANIPULATOR-X CV-driven floor pick-and-place (v1.4).
 #
-# Pick: ball (Ø 25 mm, tennis grip) on the floor / table plane.
-# Place: drop into tip-down cone under a transparent plate.
-# No obstacles (see SC-v13c). Runners default use_vision=True (v1.4);
-# explicit CV contract: omx_pick_place_cv.yml (SC-v16a).
+# Same geometry / FSM / pad-mid waypoints as SC-v13b (`omx_pick_place.yml`).
+# Pick pose comes from gate-camera BallObservation; place stays YAML.
+# Internal scenario_id stays omx_pick_place so MJCF resolve stays stable.
+# pick_xy is a test oracle only — not grasp ground truth.
 
 /**:
   ros__parameters:
     model: open_manipulator_x
     scenario_id: omx_pick_place
+    showcase_id: omx_pick_place_cv
     simulation_dt: 0.02
     duration: 25.0
     planning_timeout: 60.0
@@ -19,6 +20,8 @@
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
+    use_vision: true
+    vision_config: src/fret/config/vision/omx_portal_overhead.yml
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     # Pad-mid IK for floor ball (centre z = ball_radius); grasp pads clear plane.
     pick_hover_configuration: [-0.7987, 0.4197, 0.0612, -0.1683]

--- a/src/fret/config/scenarios/omy_pick_place_cv.yml
+++ b/src/fret/config/scenarios/omy_pick_place_cv.yml
@@ -1,14 +1,15 @@
-# SC-v14b — OpenMANIPULATOR-Y floor pick-and-place.
+# SC-v16b — OpenMANIPULATOR-Y CV-driven floor pick-and-place (v1.4).
 #
-# Pick: Ø 86 mm sphere on the floor; pad pinch + mass-scaled adhesion
-# (OMX tennis-grip pattern). Place: tip-down cone at the loaded reachable pose.
-# Idle is a distinct fold; retreat returns to idle. Runners default
-# use_vision=True (v1.4); explicit CV contract: omy_pick_place_cv.yml (SC-v16b).
+# Same geometry / FSM / pad-mid waypoints as SC-v14b (`omy_pick_place.yml`).
+# Pick pose comes from gate-camera BallObservation; place stays YAML.
+# Internal scenario_id stays omy_pick_place so MJCF resolve stays stable.
+# pick_xy is a test oracle only — not grasp ground truth.
 
 /**:
   ros__parameters:
     model: omy
     scenario_id: omy_pick_place
+    showcase_id: omy_pick_place_cv
     simulation_dt: 0.02
     duration: 45.0
     planning_timeout: 60.0
@@ -19,6 +20,8 @@
     place_cone_height_m: 0.280
     place_cone_radius_m: 0.140
     grasp_mode: mujoco_adhesion
+    use_vision: true
+    vision_config: src/fret/config/vision/omy_portal_overhead.yml
     # Floor ball centre ~0.043 m; adhered lift settles near ~0.12 m pad mid.
     lift_height_m: 0.10
     phase_timeout_s: 45.0

--- a/src/fret/control/omy_pick_place_sim.py
+++ b/src/fret/control/omy_pick_place_sim.py
@@ -124,6 +124,10 @@ def simulate_omy_pick_place(
 
     scenario = Path(scenario_path or _SCENARIO)
     params = load_scenario_parameters(scenario)
+    if "use_vision" in params:
+        use_vision = bool(params["use_vision"])
+    if vision_config is None and params.get("vision_config"):
+        vision_config = str(params["vision_config"])
     scenario_id = str(params.get("scenario_id", "omy_pick_place"))
     wp = waypoints_from_scenario(scenario)
     xml = mjcf_path(_MODEL, scenario_id)

--- a/src/fret/control/pick_place_sim.py
+++ b/src/fret/control/pick_place_sim.py
@@ -97,10 +97,11 @@ def simulate_pick_place(
     telemetry_enabled: bool | None = None,
     telemetry_output_dir: Path | None = None,
     telemetry_csv_basename: str | None = None,
+    scenario_path: str | Path | None = None,
     use_vision: bool = True,
     vision_config: str | Path | None = None,
 ) -> tuple[PickPlaceState, list[PickPlaceSample]]:
-    """Run one SC-v13b cycle and optionally record trajectory samples.
+    """Run one SC-v13b / SC-v16a cycle and optionally record trajectory samples.
 
     When ``use_vision`` is True (default), pick-side joints come from gate-camera
     ``BallObservation`` + IK. Place / dispenser joints stay on scenario YAML.
@@ -113,16 +114,25 @@ def simulate_pick_place(
 
     from fret.control.pick_place_vision import apply_vision_pick_goals
 
-    wp = waypoints_from_scenario()
-    xml = mjcf_path("open_manipulator_x", "omx_pick_place")
+    scenario = Path(
+        scenario_path or "src/fret/config/scenarios/omx_pick_place.yml"
+    )
+    params = load_scenario_parameters(scenario)
+    if "use_vision" in params:
+        use_vision = bool(params["use_vision"])
+    if vision_config is None and params.get("vision_config"):
+        vision_config = str(params["vision_config"])
+    scenario_id = str(params.get("scenario_id", "omx_pick_place"))
+    wp = waypoints_from_scenario(scenario)
+    xml = mjcf_path("open_manipulator_x", scenario_id)
     model = mj.MjModel.from_xml_path(str(xml))
     data = mj.MjData(model)
     joint_names = ("Joint1", "Joint2", "Joint3", "Joint4")
     tele = open_scenario_telemetry(
-        "omx_pick_place",
+        scenario_id,
         enabled=telemetry_enabled,
         output_dir=telemetry_output_dir,
-        csv_basename=telemetry_csv_basename or "omx_pick_place_overview",
+        csv_basename=telemetry_csv_basename or f"{scenario_id}_overview",
         dt_nominal_s=float(model.opt.timestep),
     )
     joint_components: list[str] = []
@@ -296,13 +306,15 @@ def run_pick_place(
     *,
     duration_s: float = 25.0,
     joint_tol_rad: float = 0.12,
+    scenario_path: str | Path | None = None,
     use_vision: bool = True,
 ) -> tuple[PickPlaceState, npt.NDArray[np.float64]]:
-    """Execute one SC-v13b cycle; return final FSM state and box position."""
+    """Execute one SC-v13b / SC-v16a cycle; return final FSM state and box."""
     state, samples = simulate_pick_place(
         duration_s=duration_s,
         joint_tol_rad=joint_tol_rad,
         record_every_steps=1,
+        scenario_path=scenario_path,
         use_vision=use_vision,
     )
     if not samples:

--- a/src/fret/package.xml
+++ b/src/fret/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fret</name>
-  <version>1.2.3</version>
+  <version>1.4.0</version>
   <description>
     Full-stack Robotic Effector Trajectories (FRET) — ROS 2 framework for
     C-space manipulation and mobile-agent planning with MuJoCo showcase scenes.

--- a/src/fret/simulation/mujoco_camera.py
+++ b/src/fret/simulation/mujoco_camera.py
@@ -3,7 +3,7 @@
 Converts MuJoCo camera poses to OpenCV optical frames, derives pinhole
 intrinsics from ``fovy``, and renders RGB into :class:`CameraFrame`.
 
-Does **not** feed detections into the pick-and-place FSM — that is T14-03.
+Frame capture only — FSM feed is ``fret.control.pick_place_vision`` (T14-03).
 """
 
 from __future__ import annotations

--- a/tests/control/test_pick_place_cv_scenarios.py
+++ b/tests/control/test_pick_place_cv_scenarios.py
@@ -1,0 +1,95 @@
+"""SC-v16a/b — CV pick-place scenario registration + physics smoke (T14-04)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from fret.sitl_config import load_scenario_parameters, mjcf_path
+
+mujoco = pytest.importorskip("mujoco")
+
+_OMX_CV = Path("src/fret/config/scenarios/omx_pick_place_cv.yml")
+_OMY_CV = Path("src/fret/config/scenarios/omy_pick_place_cv.yml")
+
+
+@pytest.mark.parametrize(
+    ("path", "model", "scenario_id", "showcase_id", "vision_cfg"),
+    [
+        (
+            _OMX_CV,
+            "open_manipulator_x",
+            "omx_pick_place",
+            "omx_pick_place_cv",
+            "src/fret/config/vision/omx_portal_overhead.yml",
+        ),
+        (
+            _OMY_CV,
+            "omy",
+            "omy_pick_place",
+            "omy_pick_place_cv",
+            "src/fret/config/vision/omy_portal_overhead.yml",
+        ),
+    ],
+)
+def test_sc_v16_cv_scenario_registration(
+    path: Path,
+    model: str,
+    scenario_id: str,
+    showcase_id: str,
+    vision_cfg: str,
+) -> None:
+    params = load_scenario_parameters(path)
+    assert params["model"] == model
+    assert params["scenario_id"] == scenario_id
+    assert params["showcase_id"] == showcase_id
+    assert params.get("use_vision") is True
+    assert params["vision_config"] == vision_cfg
+    assert "place_xy" in params
+    assert "pick_xy" in params  # oracle only
+    xml = mjcf_path(model, scenario_id)
+    assert xml.is_file()
+    assert "pick_place" in xml.name
+
+
+def test_omx_pick_place_cv_physics_done() -> None:
+    from fret.control.pick_place_fsm import PickPlaceState
+    from fret.control.pick_place_sim import run_pick_place
+
+    params = load_scenario_parameters(_OMX_CV)
+    place_xy = np.asarray(params["place_xy"], dtype=np.float64)
+    pick_xy = np.asarray(params["pick_xy"], dtype=np.float64)
+    state, ball = run_pick_place(
+        duration_s=25.0,
+        scenario_path=_OMX_CV,
+        use_vision=True,
+    )
+    assert state != PickPlaceState.FAULT
+    assert state == PickPlaceState.DONE, f"ended in {state.name}"
+    assert float(np.linalg.norm(ball[:2] - place_xy)) < 0.08
+    assert float(np.linalg.norm(ball[:2] - pick_xy)) > 0.15
+    assert float(ball[2]) < 0.08
+
+
+@pytest.mark.slow
+def test_omy_pick_place_cv_physics_done() -> None:
+    from fret.control.omy_pick_place_sim import run_omy_pick_place
+    from fret.control.pick_place_fsm import PickPlaceState
+
+    params = load_scenario_parameters(_OMY_CV)
+    place_xy = np.asarray(params["place_xy"], dtype=np.float64)
+    pick_xy = np.asarray(params["pick_xy"], dtype=np.float64)
+    cone_r = float(params.get("place_cone_radius_m", 0.14))
+    state, ball = run_omy_pick_place(
+        duration_s=45.0,
+        joint_tol_rad=0.16,
+        scenario_path=_OMY_CV,
+        use_vision=True,
+    )
+    assert state != PickPlaceState.FAULT
+    assert state == PickPlaceState.DONE, f"ended in {state.name}"
+    assert float(np.linalg.norm(ball[:2] - place_xy)) < cone_r
+    assert float(np.linalg.norm(ball[:2] - pick_xy)) > 0.15
+    assert float(ball[2]) < float(params.get("place_cone_height_m", 0.28))

--- a/tests/simulation/test_mujoco_portal_vision.py
+++ b/tests/simulation/test_mujoco_portal_vision.py
@@ -1,6 +1,6 @@
 """MuJoCo rear-gate dual-camera + HSV fusion validation (v1.4).
 
-Stops before wiring ``BallObservation`` into the pick-and-place FSM (T14-03).
+Adapter / detect / lift gates only. FSM wiring: ``test_pick_place_vision``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

T14-01–03 are on `main`. Before cutting product tag **`v1.4.0`**, T14-04 still needed locked SC-v16 scenario files/tests, V14-5 parity documentation, package bump to **1.4.0**, and doc sync — without creating the git tag yet.

## Fix

### T14-04 — SC-v16
- `omx_pick_place_cv.yml` / `omy_pick_place_cv.yml` (same MJCF as SC-v13b/14b; `scenario_id` unchanged for `mjcf_path`)
- Explicit `use_vision` + `vision_config`; `pick_xy` oracle-only
- OMX runner accepts `scenario_path`; both runners honor YAML vision knobs
- Tests: `tests/control/test_pick_place_cv_scenarios.py` (registration + physics → DONE)
- Showcase matrix: keep `omy_pick_place` id (stable R2 names); header notes vision-on
- V14-5 parity checklist in `docs/releases.md`

### Package / docs (pre-tag)
- `pyproject.toml` / `__init__.py` / `package.xml` → **1.4.0**
- Roadmap Phase 6 ✅; **Tag `v1.4.0` left unchecked** until annotated tag
- README / scenarios / vision docs synced; stale “stops before FSM” comments cleared

## Verification

| Check | Result |
| --- | --- |
| `pytest tests/control/test_pick_place_cv_scenarios.py` | PASS (4) |
| `pytest tests/release/test_showcase_manifest.py` | PASS |
| `formatting.sh` / `types.sh` | PASS |
| `fret.__version__` | `1.4.0` |

## After merge (maintainer)

1. Tag annotated **`v1.4.0`** on `main` → `release.yml` / R2
2. Small post-tag docs PR (mirror #127): check Tag checkbox, “Current release: v1.4.0”

## Out of scope

- Creating the git tag / GitHub Release
- Regenerating showcase MP4s
- SC-v16c clutter+CV

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

