### PR TITLE
feat(showcase): floor balls all cells, CV ghost, gate-cam overlay clips

### DIFF
--- a/docs/robots/open_manipulator_x.md
+++ b/docs/robots/open_manipulator_x.md
@@ -18,8 +18,8 @@ v1.2.3 showcase:
 
 1. **SC-v13a** — empty tabletop, end-effector pose A → B (validate command chain)
 2. **SC-v13b** — pick-and-place FSM: green → grasp plain box → red (no obstacles)
-3. **SC-v13c** — mid-cell wall forces a joint-space retract detour
-4. **SC-v13d** — Γ (inverted-L) wall maze: retract → climb → place
+3. **SC-v13c** — mid-chord wall + front place cone forces a retract detour
+4. **SC-v13d** — dual Γ wall maze (front place): retract → climb → place
 
 **Pick object:** tennis-like MuJoCo ball (Ø 25 mm, grippy friction, density 400).
 Pick rests on the floor / table plane; place is a transparent non-colliding
@@ -61,11 +61,11 @@ Implementation substates:
 
 `IDLE → APPROACH_PICK → DESCEND_PICK → GRASP → LIFT → MOVE_PLACE → DESCEND_PLACE → RELEASE → RETREAT → DONE`
 
-**SC-v13c:** same grasp cell plus a mid-cell wall. ``MOVE_PLACE`` is planned
+**SC-v13c:** floor pick + front place cone plus a mid-chord wall. ``MOVE_PLACE`` is planned
 around the wall (not a straight joint-space line). Grasp / lift / release
 SC-v13b phase targets use the same joint-space MPC.
 
-**SC-v13d:** Γ maze (vertical stem + horizontal roof overhang toward the
+**SC-v13d:** dual Γ maze (stems flank the front place corridor; caps overhang ±Y toward the
 pick ball) — forces back-out from under the roof, climb, then place.
 
 ---

--- a/docs/robots/six_dof.md
+++ b/docs/robots/six_dof.md
@@ -17,7 +17,7 @@ without intermediate maze steps:
 |---|---|---|
 | SC-v14a | `omy_reach.yml` | Empty tabletop joint-space reach |
 | SC-v14b | `omy_pick_place.yml` | Floor ball → cone pick-and-place (+ CV in v1.4) |
-| SC-v14c | `omy_clutter.yml` | Cluttered pedestal pick-and-place with detour |
+| SC-v14c | `omy_clutter.yml` | Cluttered floor pick-and-place with detour |
 
 Model key: `omy` (aliases: `six_dof`, `open_manipulator_y`).
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -94,23 +94,24 @@ warehouse meshes stay for denser clutter later — too large for the OM-X jaw.
 
 **Pass criteria:** See [releases.md § v1.2.3](releases.md#v123--openmanipulator-x-tabletop).
 
-### SC-v13c — OpenMANIPULATOR-X desk clutter (v1.2.3)
+### SC-v13c — OpenMANIPULATOR-X desk clutter (v1.2.3 / v1.4)
 
 **File:** `config/scenarios/omx_desk_clutter.yml`  
 **Model:** `open_manipulator_x`
 
-**Purpose:** Mid-cell wall blocks the straight green→red transfer; planner +
-controller must retract around it under full MuJoCo physics (AWS meshes later).
+**Purpose:** Floor pick on −Y and **front** place cone on +X; a mid-chord wall
+blocks the straight transfer so the planner + controller must retract around
+it under full MuJoCo physics (AWS meshes later).
 
-### SC-v13d — OpenMANIPULATOR-X Γ-wall maze (v1.2.3)
+### SC-v13d — OpenMANIPULATOR-X dual Γ-wall maze (v1.2.3 / v1.4)
 
 **File:** `config/scenarios/omx_wall_maze.yml`  
 **Model:** `open_manipulator_x`
 
-**Purpose:** Inverted-L (letter Γ) obstacle — vertical stem plus a horizontal
-roof overhang toward the pick ball — forces grasp → back out from under the
-roof → climb → place (not a simple lift-and-fly over the stem). Arm↔wall
-collision bitmasks stay active (`contype`/`conaffinity` = 1).
+**Purpose:** Front place cone on +X with a **dual Γ** obstacle — stems flank
+the place corridor and caps overhang ±Y — so the arm cannot swing either side
+and must back out → climb → place. Arm↔wall collision bitmasks stay active
+(`contype`/`conaffinity` = 1).
 
 ---
 
@@ -136,9 +137,9 @@ tip-down cone funnel at a loaded-reachable pose — 6-DOF analogue of SC-v13b.
 **File:** `config/scenarios/omy_clutter.yml`  
 **Model:** `omy`
 
-**Purpose:** Same floor ball + cone as SC-v14b, plus a mid-cell wall
-(perpendicular to the pick→place line of sight, centred between them) and
-occupancy planner so the transfer must detour (6-DOF analogue of SC-v13c).
+**Purpose:** Same floor ball + **front** place cone as SC-v14b, plus a
+mid-chord wall between pick (−Y) and place (+X) so the transfer must detour
+(6-DOF analogue of SC-v13c).
 
 **Pass criteria:** See [releases.md § v1.2.4](releases.md#v124--6-dof-manipulator-challenge).
 

--- a/docs/scenarios.md
+++ b/docs/scenarios.md
@@ -131,12 +131,12 @@ SITL wiring for the 6-DOF arm (same role as SC-v13a for OM-X).
 reach (same OMX SC-v13b pattern: pads pinch the equator) and place it in a
 tip-down cone funnel at a loaded-reachable pose — 6-DOF analogue of SC-v13b.
 
-### SC-v14c — OpenMANIPULATOR-Y cluttered pedestal pick-and-place (v1.2.4)
+### SC-v14c — OpenMANIPULATOR-Y cluttered floor pick-and-place (v1.2.4 / v1.4)
 
 **File:** `config/scenarios/omy_clutter.yml`  
 **Model:** `omy`
 
-**Purpose:** Same scaled pedestal ball + cone as SC-v14b, plus a mid-cell wall
+**Purpose:** Same floor ball + cone as SC-v14b, plus a mid-cell wall
 (perpendicular to the pick→place line of sight, centred between them) and
 occupancy planner so the transfer must detour (6-DOF analogue of SC-v13c).
 

--- a/docs/vision/camera-layout.md
+++ b/docs/vision/camera-layout.md
@@ -48,7 +48,7 @@ tube posts, top/bottom beams, and an **X-brace**, holding two cameras at the
 | Cameras | `gate_cam_left`, `gate_cam_right` | same names |
 | `fovy` | 42° | 45° |
 | Look-at (shared) | ~(0.22, −0.08, 0.08) | ~(0.38, −0.10, 0.10) |
-| Pick (side) | `(0.22, −0.20)` | `(0.35, −0.30)` |
+| Pick (side) | `(0.22, −0.20)` open; clutter/maze `(0.18, −0.26)` | `(0.35, −0.30)` |
 | Place (front) | `(0.26, 0.0)` | `(0.48, 0.0)` |
 
 Gate geoms are visual-only (`contype=0`). The gate may clip a little rear

--- a/scripts/regenerate_omy_pick_place_xml.py
+++ b/scripts/regenerate_omy_pick_place_xml.py
@@ -2,11 +2,15 @@
 """Regenerate OMY pick-place / clutter MJCF templates at Menagerie scale.
 
 Sizing rules (SC-v14b/c, matching docs/scenarios.md):
-  - Pick object: Ø 86 mm sphere on a short pedestal (OMX SC-v13b analogue)
+  - Pick object: Ø 86 mm sphere on the **floor** (no pedestal)
   - Cone diameter ≈ place funnel; cone height = diameter
   - Pick / place radial reach ~0.49 m (forward stretch, not full extension)
-  - Pedestal raises the ball so pads pinch at the equator (no floor spears)
   - Clutter wall perpendicular to pick→place LOS at the midpoint
+
+Note: committed templates also carry the v1.4 vision_gate + ``cv_ball_ghost``
+bodies (see ``regen_cell_layout_v14.py``). Re-running this script alone will
+not recreate those — prefer editing the committed XML when changing vision
+geometry.
 """
 
 from __future__ import annotations
@@ -17,20 +21,20 @@ from pathlib import Path
 _REPO = Path(__file__).resolve().parents[1]
 _MJCF = _REPO / "src/fret/mjcf"
 
-# SC-v14b: Ø 86 mm ball on a short pick pedestal (same pattern as OMX).
+# SC-v14b/c: Ø 86 mm ball resting on the floor / table plane.
 _BALL_RADIUS_M = 0.043
-_PEDESTAL_HALF_H_M = 0.045
-_PEDESTAL_RADIUS_M = 0.035
-_PEDESTAL_Z_M = _PEDESTAL_HALF_H_M
-_BALL_Z_M = 2.0 * _PEDESTAL_HALF_H_M + _BALL_RADIUS_M
+_BALL_Z_M = _BALL_RADIUS_M
 # Funnel wider than 1.5× ball diameter — physics place has centimetre slip.
 _CONE_RADIUS_M = 0.14
 _CONE_HEIGHT_M = 2.0 * _CONE_RADIUS_M
 _BALL_DENSITY = 150.0
 
-_PICK_XY = (0.40, -0.28)
+# Open pick-place cell (SC-v14b) pick XY; clutter overrides in footer.
+_PICK_XY = (0.350, -0.300)
 # Place sits where the loaded 6-DOF arm can deliver past the mid-cell wall.
-_PLACE_XY = (0.50, 0.20)
+_PLACE_XY = (0.480, 0.000)
+_CLUTTER_PICK_XY = (0.40, -0.28)
+_CLUTTER_PLACE_XY = (0.50, 0.20)
 
 # OMX reference cone (assets/cone.obj native size).
 _OMX_CONE_R = 0.05
@@ -97,7 +101,7 @@ def _scene_header(model_name: str, comment: str) -> str:
   <!--
     {comment}
 
-    Pick: Ø {ball_d_mm:.0f} mm sphere on a short pedestal.
+    Pick: Ø {ball_d_mm:.0f} mm sphere resting on the floor / table plane.
     Place: tip-down cone funnel — Ø {cone_d_mm:.0f} mm, height {cone_d_mm:.0f} mm.
     Cone mesh: assets/cone.obj (scaled in geom).
 
@@ -136,18 +140,33 @@ def _scene_header(model_name: str, comment: str) -> str:
   <worldbody>
     <light name="key" pos="0.95 0.0 1.6" dir="0 0 -1" directional="true"
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
-    <!-- Contact bits: arm=1, pedestal/cone=2, pads=4, floor=1|8.
-         Ball=2|4|8 hits floor/pads/pedestal/cone but not arm links. -->
+    <!-- Contact bits: arm=1, cone=2, pads=4, floor=1|8.
+         Ball=2|4|8 hits floor/pads/cone but not arm links. -->
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 """
 
 
-def _scene_footer(*, clutter: bool) -> str:
+def _scene_footer(
+    *,
+    clutter: bool,
+    pick_xy: tuple[float, float],
+    place_xy: tuple[float, float],
+) -> str:
     zone_r = _CONE_RADIUS_M + 0.01
     plate_z = _CONE_HEIGHT_M
     goal_z = plate_z + 0.001
-    start_z = 2.0 * _PEDESTAL_HALF_H_M + 0.001
+    start_z = 0.001
+    # Funnel geoms are authored relative to the open pick-place place XY;
+    # for clutter, shift them from the open-cell place to the clutter place.
+    funnel_src = (_MJCF / "omx_pick_place.xml").read_text(encoding="utf-8")
+    global _PLACE_XY  # noqa: PLW0603 — temporary override for funnel map
+    saved_place = _PLACE_XY
+    _PLACE_XY = place_xy
+    try:
+        funnel_lines = _funnel_geoms_from_omx(funnel_src)
+    finally:
+        _PLACE_XY = saved_place
     wall_block = ""
     if clutter:
         # Mid-cell slab: blocks the straight lift→place chord but leaves a
@@ -163,37 +182,31 @@ def _scene_footer(*, clutter: bool) -> str:
           friction="1.0 0.1 0.01" contype="1" conaffinity="1"/>
 """
     return f"""
-    <geom name="pedestal_pick" type="cylinder"
-          pos="{_fmt_pos(_PICK_XY[0], _PICK_XY[1], _PEDESTAL_Z_M)}"
-          size="{_PEDESTAL_RADIUS_M:.5f} {_PEDESTAL_HALF_H_M:.5f}"
-          material="start_zone" friction="1.2 0.1 0.01"
-          contype="2" conaffinity="2"/>
-
     <!-- Visual mesh only; funnel_w* / funnel_tip carry rigid collision. -->
     <geom name="place_cone" type="mesh" mesh="place_cone"
-          pos="{_fmt_pos(_PLACE_XY[0], _PLACE_XY[1], 0.0)}"
+          pos="{_fmt_pos(place_xy[0], place_xy[1], 0.0)}"
           material="place_cone" contype="0" conaffinity="0"/>
-{chr(10).join(_funnel_geoms_from_omx((_MJCF / "omx_pick_place.xml").read_text()))}
+{chr(10).join(funnel_lines)}
 
     <geom name="place_plate" type="cylinder"
-          pos="{_fmt_pos(_PLACE_XY[0], _PLACE_XY[1], plate_z)}"
+          pos="{_fmt_pos(place_xy[0], place_xy[1], plate_z)}"
           size="{_CONE_RADIUS_M:.5f} 0.001"
           material="place_plate" contype="0" conaffinity="0"/>
     <geom name="place_cone_rim" type="cylinder"
-          pos="{_fmt_pos(_PLACE_XY[0], _PLACE_XY[1], plate_z)}"
+          pos="{_fmt_pos(place_xy[0], place_xy[1], plate_z)}"
           size="{_CONE_RADIUS_M:.5f} 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
     <geom name="start_zone" type="cylinder"
-          pos="{_fmt_pos(_PICK_XY[0], _PICK_XY[1], start_z)}"
+          pos="{_fmt_pos(pick_xy[0], pick_xy[1], start_z)}"
           size="{zone_r:.5f} 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
     <geom name="goal_zone" type="cylinder"
-          pos="{_fmt_pos(_PLACE_XY[0], _PLACE_XY[1], goal_z)}"
+          pos="{_fmt_pos(place_xy[0], place_xy[1], goal_z)}"
           size="{zone_r:.5f} 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
 
-    <body name="pick_box" pos="{_fmt_pos(_PICK_XY[0], _PICK_XY[1], _BALL_Z_M)}">
+    <body name="pick_box" pos="{_fmt_pos(pick_xy[0], pick_xy[1], _BALL_Z_M)}">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere"
             size="{_BALL_RADIUS_M:.5f}"
@@ -202,25 +215,9 @@ def _scene_footer(*, clutter: bool) -> str:
             condim="6" contype="14" conaffinity="14" priority="1"/>
     </body>
 {wall_block}
-    <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->
-    <body name="vision_portal" pos="0.40 0 0">
-      <geom name="portal_post_n" type="box" size="0.025 0.025 0.65"
-            pos="0 -0.48 0.65" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
-      <geom name="portal_post_p" type="box" size="0.025 0.025 0.65"
-            pos="0 0.48 0.65" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
-      <geom name="portal_beam" type="box" size="0.030 0.50 0.025"
-            pos="0 0 1.32" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
-      <geom name="portal_cam_plate" type="box" size="0.045 0.035 0.015"
-            pos="0 0 1.285" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
-      <camera name="overhead" pos="0 0 1.30"
-              xyaxes="0 1 0 -1 0 0" fovy="50"/>
-    </body>
-    <camera name="overview" pos="0.95 -0.95 1.05"
-            xyaxes="0.82 0.57 0 -0.32 0.46 0.83" fovy="40"/>
+    <!-- Vision gate / CV ghost are maintained on committed XML (v1.4). -->
+    <camera name="overview" pos="1.05 -0.70 1.00"
+            xyaxes="0.55 0.84 0 -0.40 0.26 0.88" fovy="40"/>
     <camera name="follow" pos="0.70 0.15 0.55"
             xyaxes="-0.7 0.7 0 -0.3 -0.3 0.9" fovy="50"/>
   </worldbody>
@@ -235,27 +232,32 @@ def _write_clutter_template() -> str:
     )
     header = _scene_header(
         "omy_clutter",
-        "OpenMANIPULATOR-Y cluttered pedestal pick-and-place (SC-v14c).",
+        "OpenMANIPULATOR-Y cluttered floor pick-and-place (SC-v14c).",
     )
     header = header.replace(
         '    <material name="pick_ball"',
         extra_asset + '    <material name="pick_ball"',
     )
-    return header + _scene_footer(clutter=True)
+    return header + _scene_footer(
+        clutter=True,
+        pick_xy=_CLUTTER_PICK_XY,
+        place_xy=_CLUTTER_PLACE_XY,
+    )
 
 
 def main() -> None:
     pick = _scene_header(
         "omy_pick_place",
-        "OpenMANIPULATOR-Y pedestal pick-and-place (SC-v14b).",
-    ) + _scene_footer(clutter=False)
+        "OpenMANIPULATOR-Y floor pick-and-place (SC-v14b).",
+    ) + _scene_footer(
+        clutter=False, pick_xy=_PICK_XY, place_xy=_PLACE_XY
+    )
     clutter = _write_clutter_template()
     (_MJCF / "omy_pick_place.xml").write_text(pick, encoding="utf-8")
     (_MJCF / "omy_clutter.xml").write_text(clutter, encoding="utf-8")
     print(
         f"wrote pick_place ball_r={_BALL_RADIUS_M:.4f} "
-        f"cone_r={_CONE_RADIUS_M:.4f} ball_z={_BALL_Z_M:.4f} "
-        f"pedestal_h={2.0 * _PEDESTAL_HALF_H_M:.4f}"
+        f"cone_r={_CONE_RADIUS_M:.4f} ball_z={_BALL_Z_M:.4f} (floor)"
     )
     print(f"pick={_PICK_XY} place={_PLACE_XY}")
 

--- a/scripts/render_mujoco.py
+++ b/scripts/render_mujoco.py
@@ -995,6 +995,68 @@ def _assert_camera_exists(mujoco: object, model: object, camera: str) -> None:
         raise ValueError(f"Camera not found in MJCF: {camera}")
 
 
+def _place_cv_ghost_from_vision(
+    mujoco: object,
+    model: object,
+    data: object,
+    *,
+    robot: str,
+    sample: object,
+    apply_sample: object,
+) -> npt.NDArray[np.float64] | None:
+    """Sense once at the first replay sample and show the CV ghost sphere."""
+    _ensure_fret_importable()
+    from fret.control.pick_place_vision import (
+        observe_ball_mujoco,
+        set_cv_ball_ghost,
+    )
+
+    apply_sample(sample)  # type: ignore[operator]
+    observation = observe_ball_mujoco(model, data, robot=robot)  # type: ignore[arg-type]
+    if observation is None:
+        return None
+    pose = np.asarray(observation.position_world, dtype=np.float64)
+    set_cv_ball_ghost(model, data, pose)
+    return pose
+
+
+def _append_gate_cam_overlays(
+    *,
+    mujoco: object,
+    model: object,
+    data: object,
+    samples: list[object],
+    apply_sample: object,
+    box_qadr: int,
+    output_dir: Path,
+    scenario: str,
+    main_fps: int,
+    timing: ShowcaseTiming,
+    cv_pose: npt.NDArray[np.float64] | None = None,
+) -> list[RenderResult]:
+    """Write low-FPS annotated gate-cam side clips next to the overview."""
+    _ensure_fret_importable()
+    from fret.simulation.gate_overlay import write_gate_cam_overlay_videos
+
+    return write_gate_cam_overlay_videos(
+        mujoco=mujoco,
+        model=model,
+        data=data,
+        samples=samples,
+        apply_sample=apply_sample,  # type: ignore[arg-type]
+        box_qadr=box_qadr,
+        output_dir=output_dir,
+        scenario=scenario,
+        main_fps=main_fps,
+        cv_pose=cv_pose,
+        open_writer=_open_video_writer,
+        frame_mean=_frame_mean,
+        output_name=showcase_output_name,
+        result_cls=RenderResult,
+        timing=timing,
+    )
+
+
 def _load_omx_reach_configurations(
     scenario: str,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
@@ -1293,6 +1355,18 @@ def render_omx_desk_clutter_showcase_videos(
     if box_jid < 0:
         raise ValueError("pick_box_joint missing from OM-X desk-clutter MJCF")
     box_qadr = int(model.jnt_qposadr[box_jid])
+
+    def _apply(sample: object) -> None:
+        _apply_omx_pick_place_sample(
+            mujoco,
+            model,
+            data,
+            q_arm=sample.q_arm,  # type: ignore[attr-defined]
+            gripper=sample.gripper,  # type: ignore[attr-defined]
+            box_qpos=sample.box_qpos,  # type: ignore[attr-defined]
+            box_qadr=box_qadr,
+        )
+
     renderer = mujoco.Renderer(model, height=height, width=width)
     for camera in camera_names:
         _assert_camera_exists(mujoco, model, camera)
@@ -1311,15 +1385,7 @@ def render_omx_desk_clutter_showcase_videos(
 
     try:
         for sample in samples:
-            _apply_omx_pick_place_sample(
-                mujoco,
-                model,
-                data,
-                q_arm=sample.q_arm,
-                gripper=sample.gripper,
-                box_qpos=sample.box_qpos,
-                box_qadr=box_qadr,
-            )
+            _apply(sample)
             for camera in camera_names:
                 renderer.update_scene(data, camera=camera)
                 frame = renderer.render()
@@ -1347,10 +1413,23 @@ def render_omx_desk_clutter_showcase_videos(
                 timing=timing,
             )
         )
-    return postprocess_showcase_results(
+    overview = postprocess_showcase_results(
         results,
         enabled=realtime_postprocess,
     )
+    overlays = _append_gate_cam_overlays(
+        mujoco=mujoco,
+        model=model,
+        data=data,
+        samples=list(samples),
+        apply_sample=_apply,
+        box_qadr=box_qadr,
+        output_dir=output_dir,
+        scenario=scenario,
+        main_fps=fps,
+        timing=timing,
+    )
+    return overview + overlays
 
 
 def render_omx_pick_place_showcase_videos(
@@ -1423,6 +1502,26 @@ def render_omx_pick_place_showcase_videos(
     if box_jid < 0:
         raise ValueError("pick_box_joint missing from OM-X pick-place MJCF")
     box_qadr = int(model.jnt_qposadr[box_jid])
+
+    def _apply(sample: object) -> None:
+        _apply_omx_pick_place_sample(
+            mujoco,
+            model,
+            data,
+            q_arm=sample.q_arm,  # type: ignore[attr-defined]
+            gripper=sample.gripper,  # type: ignore[attr-defined]
+            box_qpos=sample.box_qpos,  # type: ignore[attr-defined]
+            box_qadr=box_qadr,
+        )
+
+    cv_pose = _place_cv_ghost_from_vision(
+        mujoco,
+        model,
+        data,
+        robot="omx",
+        sample=samples[0],
+        apply_sample=_apply,
+    )
     renderer = mujoco.Renderer(model, height=height, width=width)
     for camera in camera_names:
         _assert_camera_exists(mujoco, model, camera)
@@ -1441,15 +1540,7 @@ def render_omx_pick_place_showcase_videos(
 
     try:
         for sample in samples:
-            _apply_omx_pick_place_sample(
-                mujoco,
-                model,
-                data,
-                q_arm=sample.q_arm,
-                gripper=sample.gripper,
-                box_qpos=sample.box_qpos,
-                box_qadr=box_qadr,
-            )
+            _apply(sample)
             for camera in camera_names:
                 renderer.update_scene(data, camera=camera)
                 frame = renderer.render()
@@ -1477,10 +1568,24 @@ def render_omx_pick_place_showcase_videos(
                 timing=timing,
             )
         )
-    return postprocess_showcase_results(
+    overview = postprocess_showcase_results(
         results,
         enabled=realtime_postprocess,
     )
+    overlays = _append_gate_cam_overlays(
+        mujoco=mujoco,
+        model=model,
+        data=data,
+        samples=list(samples),
+        apply_sample=_apply,
+        box_qadr=box_qadr,
+        output_dir=output_dir,
+        scenario=scenario,
+        main_fps=fps,
+        timing=timing,
+        cv_pose=cv_pose,
+    )
+    return overview + overlays
 
 
 def _apply_omy_pick_place_sample(
@@ -1591,6 +1696,26 @@ def render_omy_pick_place_showcase_videos(
     if box_jid < 0:
         raise ValueError("pick_box_joint missing from OMY pick-place MJCF")
     box_qadr = int(model.jnt_qposadr[box_jid])
+
+    def _apply(sample: object) -> None:
+        _apply_omy_pick_place_sample(
+            mujoco,
+            model,
+            data,
+            q_arm=sample.q_arm,  # type: ignore[attr-defined]
+            gripper=sample.gripper,  # type: ignore[attr-defined]
+            box_qpos=sample.box_qpos,  # type: ignore[attr-defined]
+            box_qadr=box_qadr,
+        )
+
+    cv_pose = _place_cv_ghost_from_vision(
+        mujoco,
+        model,
+        data,
+        robot="omy",
+        sample=samples[0],
+        apply_sample=_apply,
+    )
     renderer = mujoco.Renderer(model, height=height, width=width)
     for camera in camera_names:
         _assert_camera_exists(mujoco, model, camera)
@@ -1609,15 +1734,7 @@ def render_omy_pick_place_showcase_videos(
 
     try:
         for sample in samples:
-            _apply_omy_pick_place_sample(
-                mujoco,
-                model,
-                data,
-                q_arm=sample.q_arm,
-                gripper=sample.gripper,
-                box_qpos=sample.box_qpos,
-                box_qadr=box_qadr,
-            )
+            _apply(sample)
             for camera in camera_names:
                 renderer.update_scene(data, camera=camera)
                 frame = renderer.render()
@@ -1645,10 +1762,24 @@ def render_omy_pick_place_showcase_videos(
                 timing=timing,
             )
         )
-    return postprocess_showcase_results(
+    overview = postprocess_showcase_results(
         results,
         enabled=realtime_postprocess,
     )
+    overlays = _append_gate_cam_overlays(
+        mujoco=mujoco,
+        model=model,
+        data=data,
+        samples=list(samples),
+        apply_sample=_apply,
+        box_qadr=box_qadr,
+        output_dir=output_dir,
+        scenario=scenario,
+        main_fps=fps,
+        timing=timing,
+        cv_pose=cv_pose,
+    )
+    return overview + overlays
 
 
 def render_omy_clutter_showcase_videos(
@@ -1723,6 +1854,18 @@ def render_omy_clutter_showcase_videos(
     if box_jid < 0:
         raise ValueError("pick_box_joint missing from OMY clutter MJCF")
     box_qadr = int(model.jnt_qposadr[box_jid])
+
+    def _apply(sample: object) -> None:
+        _apply_omy_pick_place_sample(
+            mujoco,
+            model,
+            data,
+            q_arm=sample.q_arm,  # type: ignore[attr-defined]
+            gripper=sample.gripper,  # type: ignore[attr-defined]
+            box_qpos=sample.box_qpos,  # type: ignore[attr-defined]
+            box_qadr=box_qadr,
+        )
+
     renderer = mujoco.Renderer(model, height=height, width=width)
     for camera in camera_names:
         _assert_camera_exists(mujoco, model, camera)
@@ -1741,15 +1884,7 @@ def render_omy_clutter_showcase_videos(
 
     try:
         for sample in samples:
-            _apply_omy_pick_place_sample(
-                mujoco,
-                model,
-                data,
-                q_arm=sample.q_arm,
-                gripper=sample.gripper,
-                box_qpos=sample.box_qpos,
-                box_qadr=box_qadr,
-            )
+            _apply(sample)
             for camera in camera_names:
                 renderer.update_scene(data, camera=camera)
                 frame = renderer.render()
@@ -1777,10 +1912,23 @@ def render_omy_clutter_showcase_videos(
                 timing=timing,
             )
         )
-    return postprocess_showcase_results(
+    overview = postprocess_showcase_results(
         results,
         enabled=realtime_postprocess,
     )
+    overlays = _append_gate_cam_overlays(
+        mujoco=mujoco,
+        model=model,
+        data=data,
+        samples=list(samples),
+        apply_sample=_apply,
+        box_qadr=box_qadr,
+        output_dir=output_dir,
+        scenario=scenario,
+        main_fps=fps,
+        timing=timing,
+    )
+    return overview + overlays
 
 
 def render_video(

--- a/src/fret/config/release/showcase.yml
+++ b/src/fret/config/release/showcase.yml
@@ -22,6 +22,13 @@
 # Showcase id stays omy_pick_place so R2 clip names remain stable; SC-v16b
 # alias is config/scenarios/omy_pick_place_cv.yml for tests / explicit CV runs.
 #
+# Post-v1.4.0 showcase refresh:
+#   * All arm cells use floor balls (no pick pedestals).
+#   * Overview may show a red transparent CV ghost at the vision pose.
+#   * Side clips ``*_gate_cam_{left,right}.mp4`` (low-FPS, circle+pose text)
+#     are written next to overview and uploaded to the same R2 folder.
+#     Not composited into overview (no subwindows).
+#
 # Regenerate clips via scripts/release/render_showcase.py or release.yml.
 
 fps: 30

--- a/src/fret/config/scenarios/omx_desk_clutter.yml
+++ b/src/fret/config/scenarios/omx_desk_clutter.yml
@@ -1,6 +1,6 @@
 # SC-v13c — OpenMANIPULATOR-X desk clutter (planned transfer around a wall).
 #
-# Same floor ball / place cone as SC-v13b, plus a mid-cell wall.
+# Same floor ball / front place cone as SC-v13b, plus a mid-chord wall.
 # MOVE_PLACE uses PlannerNode (RRT*) + ControllerNode joint-space tracking.
 
 /**:
@@ -9,7 +9,7 @@
     scenario_id: omx_desk_clutter
     simulation_dt: 0.02
     duration: 45.0
-    planning_timeout: 25.0
+    planning_timeout: 30.0
     goal_tolerance: 0.05
     mjcf: mjcf/omx_desk_clutter.xml
     pick_object: ball
@@ -19,21 +19,99 @@
     grasp_mode: mujoco_adhesion
     planner_algorithm: rrt_star
     planner_rng_seed: 7
-    wall_x_min: 0.24
-    wall_x_max: 0.34
-    wall_y_half: 0.008
-    wall_z_max: 0.22
-    wall_inflate_m: 0.04
+    walls:
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: -0.11
+        y_max: -0.09
+        z_min: 0.0
+        z_max: 0.22
+    wall_inflate_m: 0.03
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     occupancy_density: 1000.0
-    max_transfer_radius_m: 0.12
+    max_transfer_radius_m: 0.14
     min_transfer_ee_z_m: 0.10
     lift_height_m: 0.06
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     # Pad-mid IK for floor ball at pick_xy (centre z = ball_radius).
-    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
-    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
-    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
-    place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
-    place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
-    pick_xy: [0.273, -0.160]
-    place_xy: [0.273, 0.160]
+    pick_hover_configuration: [-1.0074, 0.7092, -0.4510, 0.6500]
+    pick_grasp_configuration: [-1.0099, 0.8605, -0.3398, 0.5000]
+    lift_hover_configuration: [-1.0099, 0.6518, -0.5637, 0.7000]
+    place_hover_configuration: [0.0000, 0.2129, -0.2377, 0.7000]
+    place_grasp_configuration: [0.0000, 0.2381, -0.0763, 0.5000]
+    pick_xy: [0.180, -0.260]
+    place_xy: [0.260, 0.000]

--- a/src/fret/config/scenarios/omx_desk_clutter.yml
+++ b/src/fret/config/scenarios/omx_desk_clutter.yml
@@ -1,6 +1,6 @@
 # SC-v13c — OpenMANIPULATOR-X desk clutter (planned transfer around a wall).
 #
-# Same ball / pick pedestal / place cone as SC-v13b, plus a mid-cell wall.
+# Same floor ball / place cone as SC-v13b, plus a mid-cell wall.
 # MOVE_PLACE uses PlannerNode (RRT*) + ControllerNode joint-space tracking.
 
 /**:
@@ -14,8 +14,6 @@
     mjcf: mjcf/omx_desk_clutter.xml
     pick_object: ball
     ball_radius_m: 0.0125
-    pedestal_top_m: 0.098
-    pedestal_radius_m: 0.018
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
@@ -28,10 +26,13 @@
     wall_inflate_m: 0.04
     occupancy_density: 1000.0
     max_transfer_radius_m: 0.12
-    min_transfer_ee_z_m: 0.145
+    min_transfer_ee_z_m: 0.10
+    lift_height_m: 0.06
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]
-    pick_grasp_configuration: [-0.55, 0.60, -0.65, 0.65]
+    # Pad-mid IK for floor ball at pick_xy (centre z = ball_radius).
+    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
+    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
+    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
     place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
     place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
     pick_xy: [0.273, -0.160]

--- a/src/fret/config/scenarios/omx_wall_maze.yml
+++ b/src/fret/config/scenarios/omx_wall_maze.yml
@@ -1,9 +1,9 @@
 # SC-v13d — OpenMANIPULATOR-X Γ-wall maze (back out → climb → place).
 #
-# Same ball / pick pedestal / place cone as SC-v13b/c, plus an inverted-L
-# (letter Γ) obstacle: vertical stem + horizontal roof overhang toward the
-# pick ball (negative Y / "telhadinho"), so lift-and-fly over the stem is
-# blocked and the arm must back out first.
+# Same floor ball / place cone as SC-v13b/c, plus an inverted-L (letter Γ)
+# obstacle: vertical stem + horizontal roof overhang toward the pick ball
+# (negative Y / "telhadinho"), so lift-and-fly over the stem is blocked and
+# the arm must back out first.
 #
 # Release showcases use planner variants:
 #   omx_wall_maze_rrt.yml  (ARCO RRT*)
@@ -21,8 +21,6 @@
     mjcf: mjcf/omx_wall_maze.xml
     pick_object: ball
     ball_radius_m: 0.0125
-    pedestal_top_m: 0.098
-    pedestal_radius_m: 0.018
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
@@ -46,16 +44,18 @@
     occupancy_density: 1200.0
     # Back-out under the pick-side roof (not a short hover chord).
     max_transfer_radius_m: 0.16
-    min_transfer_ee_z_m: 0.145
+    min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.14
+    lift_height_m: 0.10
     phase_timeout_s: 60.0
     # Start folded at center (approach under the roof); retreat on place side
     # so Joint1 need not drive back through the stem after place.
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]
-    pick_grasp_configuration: [-0.55, 0.60, -0.65, 0.65]
+    # Pad-mid IK for floor ball at pick_xy (centre z = ball_radius).
+    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
+    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
+    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
     place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
     place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
     pick_xy: [0.273, -0.160]

--- a/src/fret/config/scenarios/omx_wall_maze.yml
+++ b/src/fret/config/scenarios/omx_wall_maze.yml
@@ -1,9 +1,8 @@
 # SC-v13d — OpenMANIPULATOR-X Γ-wall maze (back out → climb → place).
 #
-# Same floor ball / place cone as SC-v13b/c, plus an inverted-L (letter Γ)
-# obstacle: vertical stem + horizontal roof overhang toward the pick ball
-# (negative Y / "telhadinho"), so lift-and-fly over the stem is blocked and
-# the arm must back out first.
+# Same floor ball / front place cone as SC-v13b, plus a dual Γ maze
+# obstacle: stems flank the +X place corridor and caps overhang ±Y so the
+# arm cannot swing either side — it must back out, then climb to place.
 #
 # Release showcases use planner variants:
 #   omx_wall_maze_rrt.yml  (ARCO RRT*)
@@ -27,36 +26,92 @@
     planner_algorithm: rrt_star
     # Pinned under deterministic_planner_rng (mesh-clear retract+climb).
     planner_rng_seed: 204
-    # Stem (mid-cell) + roof overhang toward pick (asymmetric y).
     walls:
-      - x_min: 0.25
-        x_max: 0.34
-        y_half: 0.010
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: -0.11
+        y_max: -0.09
         z_min: 0.0
         z_max: 0.22
-      - x_min: 0.26
-        x_max: 0.34
-        y_min: -0.15
-        y_max: 0.01
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: -0.24
+        y_max: -0.09
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.025
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.11
+        z_min: 0.0
+        z_max: 0.22
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.24
+        z_min: 0.225
+        z_max: 0.265
+    wall_inflate_m: 0.03
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     occupancy_density: 1200.0
     # Back-out under the pick-side roof (not a short hover chord).
     max_transfer_radius_m: 0.16
     min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.10
+    lift_height_m: 0.055
     phase_timeout_s: 60.0
     # Start folded at center (approach under the roof); retreat on place side
     # so Joint1 need not drive back through the stem after place.
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
     # Pad-mid IK for floor ball at pick_xy (centre z = ball_radius).
-    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
-    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
-    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
-    place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
-    place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
-    pick_xy: [0.273, -0.160]
-    place_xy: [0.273, 0.160]
+    pick_hover_configuration: [-1.0074, 0.7092, -0.4510, 0.6500]
+    pick_grasp_configuration: [-1.0099, 0.8605, -0.3398, 0.5000]
+    lift_hover_configuration: [-1.0099, 0.6518, -0.5637, 0.7000]
+    place_hover_configuration: [0.0000, 0.2129, -0.2377, 0.7000]
+    place_grasp_configuration: [0.0000, 0.2381, -0.0763, 0.5000]
+    pick_xy: [0.180, -0.260]
+    place_xy: [0.260, 0.000]

--- a/src/fret/config/scenarios/omx_wall_maze_rrt.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_rrt.yml
@@ -16,8 +16,6 @@
     mjcf: mjcf/omx_wall_maze.xml
     pick_object: ball
     ball_radius_m: 0.0125
-    pedestal_top_m: 0.098
-    pedestal_radius_m: 0.018
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
@@ -39,14 +37,15 @@
     wall_inflate_m: 0.025
     occupancy_density: 1200.0
     max_transfer_radius_m: 0.16
-    min_transfer_ee_z_m: 0.145
+    min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.14
+    lift_height_m: 0.10
     phase_timeout_s: 60.0
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]
-    pick_grasp_configuration: [-0.55, 0.60, -0.65, 0.65]
+    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
+    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
+    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
     place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
     place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
     pick_xy: [0.273, -0.160]

--- a/src/fret/config/scenarios/omx_wall_maze_rrt.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_rrt.yml
@@ -23,30 +23,48 @@
     # Pinned under deterministic_planner_rng for mesh-clear retract+climb.
     planner_rng_seed: 204
     walls:
-      - x_min: 0.25
-        x_max: 0.34
-        y_half: 0.010
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: -0.11
+        y_max: -0.09
         z_min: 0.0
         z_max: 0.22
-      - x_min: 0.26
-        x_max: 0.34
-        y_min: -0.15
-        y_max: 0.01
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: -0.24
+        y_max: -0.09
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.025
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.11
+        z_min: 0.0
+        z_max: 0.22
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.24
+        z_min: 0.225
+        z_max: 0.265
+    wall_inflate_m: 0.03
+
     occupancy_density: 1200.0
     max_transfer_radius_m: 0.16
     min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.10
+    lift_height_m: 0.055
     phase_timeout_s: 60.0
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
-    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
-    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
-    place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
-    place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
-    pick_xy: [0.273, -0.160]
-    place_xy: [0.273, 0.160]
+    pick_hover_configuration: [-1.0074, 0.7092, -0.4510, 0.6500]
+    pick_grasp_configuration: [-1.0099, 0.8605, -0.3398, 0.5000]
+    lift_hover_configuration: [-1.0099, 0.6518, -0.5637, 0.7000]
+    place_hover_configuration: [0.0000, 0.2129, -0.2377, 0.7000]
+    place_grasp_configuration: [0.0000, 0.2381, -0.0763, 0.5000]
+    pick_xy: [0.180, -0.260]
+    place_xy: [0.260, 0.000]

--- a/src/fret/config/scenarios/omx_wall_maze_sst.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_sst.yml
@@ -16,8 +16,6 @@
     mjcf: mjcf/omx_wall_maze.xml
     pick_object: ball
     ball_radius_m: 0.0125
-    pedestal_top_m: 0.098
-    pedestal_radius_m: 0.018
     place_cone_height_m: 0.098
     place_cone_radius_m: 0.050
     grasp_mode: mujoco_adhesion
@@ -39,14 +37,15 @@
     wall_inflate_m: 0.025
     occupancy_density: 1200.0
     max_transfer_radius_m: 0.16
-    min_transfer_ee_z_m: 0.145
+    min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.14
+    lift_height_m: 0.10
     phase_timeout_s: 60.0
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.55, 0.416, -0.55, 0.20]
-    pick_grasp_configuration: [-0.55, 0.60, -0.65, 0.65]
+    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
+    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
+    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
     place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
     place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
     pick_xy: [0.273, -0.160]

--- a/src/fret/config/scenarios/omx_wall_maze_sst.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_sst.yml
@@ -23,30 +23,48 @@
     # Pinned under deterministic_planner_rng for mesh-clear retract+climb.
     planner_rng_seed: 7
     walls:
-      - x_min: 0.25
-        x_max: 0.34
-        y_half: 0.010
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: -0.11
+        y_max: -0.09
         z_min: 0.0
         z_max: 0.22
-      - x_min: 0.26
-        x_max: 0.34
-        y_min: -0.15
-        y_max: 0.01
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: -0.24
+        y_max: -0.09
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.025
+      -
+        x_min: 0.23
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.11
+        z_min: 0.0
+        z_max: 0.22
+      -
+        x_min: 0.24
+        x_max: 0.31
+        y_min: 0.09
+        y_max: 0.24
+        z_min: 0.225
+        z_max: 0.265
+    wall_inflate_m: 0.03
+
     occupancy_density: 1200.0
     max_transfer_radius_m: 0.16
     min_transfer_ee_z_m: 0.10
     min_transfer_peak_ee_z_m: 0.21
-    lift_height_m: 0.10
+    lift_height_m: 0.055
     phase_timeout_s: 60.0
     idle_configuration: [0.0, -1.05, 0.7, 0.7]
     retreat_configuration: [0.25, -1.05, 0.7, 0.7]
-    pick_hover_configuration: [-0.5810, 0.5663, -0.3587, 0.3026]
-    pick_grasp_configuration: [-0.5336, 0.8586, -0.5485, 0.5024]
-    lift_hover_configuration: [-0.5336, 0.5278, -0.5953, 0.5497]
-    place_hover_configuration: [0.55, 0.416, -0.55, 0.20]
-    place_grasp_configuration: [0.55, 0.60, -0.65, 0.65]
-    pick_xy: [0.273, -0.160]
-    place_xy: [0.273, 0.160]
+    pick_hover_configuration: [-1.0074, 0.7092, -0.4510, 0.6500]
+    pick_grasp_configuration: [-1.0099, 0.8605, -0.3398, 0.5000]
+    lift_hover_configuration: [-1.0099, 0.6518, -0.5637, 0.7000]
+    place_hover_configuration: [0.0000, 0.2129, -0.2377, 0.7000]
+    place_grasp_configuration: [0.0000, 0.2381, -0.0763, 0.5000]
+    pick_xy: [0.180, -0.260]
+    place_xy: [0.260, 0.000]

--- a/src/fret/config/scenarios/omy_clutter.yml
+++ b/src/fret/config/scenarios/omy_clutter.yml
@@ -1,4 +1,4 @@
-# SC-v14c — OpenMANIPULATOR-Y cluttered pedestal pick-and-place.
+# SC-v14c — OpenMANIPULATOR-Y cluttered floor pick-and-place.
 #
 # Mid-cell wall blocks the straight transfer; ARCO RRT* plans the detour.
 # Release planner variants (same geometry, RRT* vs SST transfer plan):
@@ -27,12 +27,13 @@
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
     min_transfer_ee_z_m: -0.15
-    lift_height_m: 0.19
+    # Floor ball centre ~0.043 m; adhered lift settles near ~0.12 m pad mid.
+    lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.1096, 0.5268, 1.9468, -0.203, -0.7949, -0.0003]
-    pick_grasp_configuration: [-0.1001, 0.683, 2.0814, -0.1359, -0.7662, 0.0036]
-    lift_hover_configuration: [-0.1111, 0.4469, 2.0318, -0.2439, -0.7968, -0.0141]
+    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
+    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
+    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
     place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
     place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]

--- a/src/fret/config/scenarios/omy_clutter.yml
+++ b/src/fret/config/scenarios/omy_clutter.yml
@@ -1,4 +1,4 @@
-# SC-v14c — OpenMANIPULATOR-Y cluttered floor pick-and-place.
+# SC-v14c — OpenMANIPULATOR-Y cluttered floor pick-and-place (front cone).
 #
 # Mid-cell wall blocks the straight transfer; ARCO RRT* plans the detour.
 # Release planner variants (same geometry, RRT* vs SST transfer plan):
@@ -22,7 +22,13 @@
     grasp_mode: mujoco_adhesion
     planner_algorithm: rrt_star
     planner_rng_seed: 3
-    prefer_transfer_detour: false
+    prefer_transfer_detour: true
+    walls:
+      - x_min: 0.355
+        x_max: 0.475
+        y_min: -0.155
+        y_max: -0.085
+        z_max: 0.30
     wall_inflate_m: 0.01
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
@@ -31,18 +37,12 @@
     lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
-    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
-    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
-    place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
-    place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
+    pick_hover_configuration: [-0.2011, 0.6388, 2.1264, -0.2088, -0.8766, -0.0005]
+    pick_grasp_configuration: [-0.1518, 0.8030, 2.1535, -0.0835, -0.7328, 0.0094]
+    lift_hover_configuration: [-0.1588, 0.4894, 2.2404, -0.2132, -0.7513, -0.0234]
+    place_hover_configuration: [0.4304, 0.3638, 1.4970, -0.1607, -0.9983, 0.0291]
+    place_grasp_configuration: [0.4238, 0.3699, 1.8269, -0.2693, -1.0145, -0.0051]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    transfer_detour_configuration: [0.1844, 0.8985, 2.1993, -0.4577, -0.5335, -0.1493]
-    pick_xy: [0.40, -0.28]
-    place_xy: [0.50, 0.20]
-    walls:
-      - x_min: 0.38
-        x_max: 0.52
-        y_min: -0.04
-        y_max: 0.04
-        z_max: 0.30
+    transfer_detour_configuration: [0.1568, 0.2551, 2.2177, -0.3336, -0.9252, -0.0427]
+    pick_xy: [0.350, -0.300]
+    place_xy: [0.480, 0.000]

--- a/src/fret/config/scenarios/omy_clutter_rrt.yml
+++ b/src/fret/config/scenarios/omy_clutter_rrt.yml
@@ -21,7 +21,13 @@
     grasp_mode: mujoco_adhesion
     planner_algorithm: rrt_star
     planner_rng_seed: 3
-    prefer_transfer_detour: false
+    prefer_transfer_detour: true
+    walls:
+      - x_min: 0.355
+        x_max: 0.475
+        y_min: -0.155
+        y_max: -0.085
+        z_max: 0.30
     wall_inflate_m: 0.01
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
@@ -29,18 +35,12 @@
     lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
-    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
-    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
-    place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
-    place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
+    pick_hover_configuration: [-0.2011, 0.6388, 2.1264, -0.2088, -0.8766, -0.0005]
+    pick_grasp_configuration: [-0.1518, 0.8030, 2.1535, -0.0835, -0.7328, 0.0094]
+    lift_hover_configuration: [-0.1588, 0.4894, 2.2404, -0.2132, -0.7513, -0.0234]
+    place_hover_configuration: [0.4304, 0.3638, 1.4970, -0.1607, -0.9983, 0.0291]
+    place_grasp_configuration: [0.4238, 0.3699, 1.8269, -0.2693, -1.0145, -0.0051]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    transfer_detour_configuration: [0.1844, 0.8985, 2.1993, -0.4577, -0.5335, -0.1493]
-    pick_xy: [0.40, -0.28]
-    place_xy: [0.50, 0.20]
-    walls:
-      - x_min: 0.38
-        x_max: 0.52
-        y_min: -0.04
-        y_max: 0.04
-        z_max: 0.30
+    transfer_detour_configuration: [0.1568, 0.2551, 2.2177, -0.3336, -0.9252, -0.0427]
+    pick_xy: [0.350, -0.300]
+    place_xy: [0.480, 0.000]

--- a/src/fret/config/scenarios/omy_clutter_rrt.yml
+++ b/src/fret/config/scenarios/omy_clutter_rrt.yml
@@ -26,12 +26,12 @@
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
     min_transfer_ee_z_m: -0.15
-    lift_height_m: 0.19
+    lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.1096, 0.5268, 1.9468, -0.203, -0.7949, -0.0003]
-    pick_grasp_configuration: [-0.1001, 0.683, 2.0814, -0.1359, -0.7662, 0.0036]
-    lift_hover_configuration: [-0.1111, 0.4469, 2.0318, -0.2439, -0.7968, -0.0141]
+    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
+    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
+    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
     place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
     place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]

--- a/src/fret/config/scenarios/omy_clutter_sst.yml
+++ b/src/fret/config/scenarios/omy_clutter_sst.yml
@@ -21,7 +21,13 @@
     grasp_mode: mujoco_adhesion
     planner_algorithm: sst
     planner_rng_seed: 7
-    prefer_transfer_detour: false
+    prefer_transfer_detour: true
+    walls:
+      - x_min: 0.355
+        x_max: 0.475
+        y_min: -0.155
+        y_max: -0.085
+        z_max: 0.30
     wall_inflate_m: 0.01
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
@@ -29,18 +35,12 @@
     lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
-    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
-    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
-    place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
-    place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
+    pick_hover_configuration: [-0.2011, 0.6388, 2.1264, -0.2088, -0.8766, -0.0005]
+    pick_grasp_configuration: [-0.1518, 0.8030, 2.1535, -0.0835, -0.7328, 0.0094]
+    lift_hover_configuration: [-0.1588, 0.4894, 2.2404, -0.2132, -0.7513, -0.0234]
+    place_hover_configuration: [0.4304, 0.3638, 1.4970, -0.1607, -0.9983, 0.0291]
+    place_grasp_configuration: [0.4238, 0.3699, 1.8269, -0.2693, -1.0145, -0.0051]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    transfer_detour_configuration: [0.1844, 0.8985, 2.1993, -0.4577, -0.5335, -0.1493]
-    pick_xy: [0.40, -0.28]
-    place_xy: [0.50, 0.20]
-    walls:
-      - x_min: 0.38
-        x_max: 0.52
-        y_min: -0.04
-        y_max: 0.04
-        z_max: 0.30
+    transfer_detour_configuration: [0.1568, 0.2551, 2.2177, -0.3336, -0.9252, -0.0427]
+    pick_xy: [0.350, -0.300]
+    place_xy: [0.480, 0.000]

--- a/src/fret/config/scenarios/omy_clutter_sst.yml
+++ b/src/fret/config/scenarios/omy_clutter_sst.yml
@@ -26,12 +26,12 @@
     occupancy_density: 800.0
     max_transfer_radius_m: 0.65
     min_transfer_ee_z_m: -0.15
-    lift_height_m: 0.19
+    lift_height_m: 0.10
     phase_timeout_s: 45.0
     idle_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]
-    pick_hover_configuration: [-0.1096, 0.5268, 1.9468, -0.203, -0.7949, -0.0003]
-    pick_grasp_configuration: [-0.1001, 0.683, 2.0814, -0.1359, -0.7662, 0.0036]
-    lift_hover_configuration: [-0.1111, 0.4469, 2.0318, -0.2439, -0.7968, -0.0141]
+    pick_hover_configuration: [-0.0915, 0.7380, 1.9571, -0.2570, -0.7303, -0.0000]
+    pick_grasp_configuration: [-0.0812, 0.9197, 2.0082, -0.1781, -0.7123, 0.0176]
+    lift_hover_configuration: [-0.1036, 0.5815, 2.0908, -0.1801, -0.7759, -0.0058]
     place_hover_configuration: [0.7531, 0.5627, 1.1481, 0.0721, -1.0225, 0.0859]
     place_grasp_configuration: [0.7544, 0.5336, 1.5044, -0.0415, -1.0184, 0.0374]
     retreat_configuration: [0.7506, -0.8762, 1.7473, 0.3442, 1.4352, 0.0001]

--- a/src/fret/control/pick_place_vision.py
+++ b/src/fret/control/pick_place_vision.py
@@ -7,6 +7,7 @@ joints stay on the scenario YAML (known fixture).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -215,6 +216,32 @@ def refresh_pick_waypoints_omy(
     )
 
 
+def set_cv_ball_ghost(
+    model: Any,
+    data: Any,
+    position_world: npt.NDArray[np.float64] | Sequence[float],
+    *,
+    rgba: tuple[float, float, float, float] = (0.90, 0.10, 0.10, 0.35),
+) -> bool:
+    """Move the non-colliding red CV ghost sphere to ``position_world``.
+
+    The geom is visual-only (``contype=0``). Missing body/geom is a no-op so
+    older MJCF templates without the ghost still load.
+    """
+    import mujoco as mj
+
+    body_id = int(mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "cv_ball_ghost"))
+    if body_id < 0:
+        return False
+    pos = np.asarray(position_world, dtype=np.float64).reshape(3)
+    model.body_pos[body_id] = pos
+    geom_id = int(mj.mj_name2id(model, mj.mjtObj.mjOBJ_GEOM, "cv_ball_ghost"))
+    if geom_id >= 0:
+        model.geom_rgba[geom_id] = np.asarray(rgba, dtype=np.float64)
+    mj.mj_forward(model, data)
+    return True
+
+
 def apply_vision_pick_goals(
     base: PickPlaceWaypoints,
     *,
@@ -224,6 +251,9 @@ def apply_vision_pick_goals(
     vision_config: str | Path | None = None,
 ) -> tuple[PickPlaceWaypoints, BallObservation]:
     """Observe the ball and return updated waypoints + the observation.
+
+    Also places the transparent red ``cv_ball_ghost`` at the CV estimate for
+    overview proof renders.
 
     Raises:
         RuntimeError: if the vision pipeline returns no ball.
@@ -236,6 +266,7 @@ def apply_vision_pick_goals(
             f"{robot} vision pipeline returned no BallObservation"
         )
     ball = np.asarray(observation.position_world, dtype=np.float64)
+    set_cv_ball_ghost(model, data, ball)
     if robot == "omx":
         refreshed = refresh_pick_waypoints_omx(base, ball, model, data)
     else:

--- a/src/fret/mjcf/omx.py
+++ b/src/fret/mjcf/omx.py
@@ -125,12 +125,16 @@ def _inject_physical_gripper(robot_xml: str) -> str:
     return robot_xml
 
 
-def _enable_floor_pick_contacts(robot_xml: str) -> str:
-    """Remap palm collision bits for floor-ball grasp (SC-v13b / v1.4).
+_FLOOR_PICK_SCENES: frozenset[str] = frozenset(
+    {"omx_pick_place", "omx_desk_clutter", "omx_wall_maze"}
+)
 
-    Pedestal scenes (desk clutter / wall maze) keep stock Menagerie palm
-    contype=1. Floor pick-place only: palms match pad bit 4 so the STL does
-    not fight the plane while closing on a table-resting ball.
+
+def _enable_floor_pick_contacts(robot_xml: str) -> str:
+    """Remap palm collision bits for floor-ball grasp (all OM-X pick cells).
+
+    Palms match pad bit 4 so the STL does not fight the plane while closing
+    on a table-resting ball (pick-place, desk clutter, Γ maze).
     """
     robot_xml = robot_xml.replace(
         '<geom mesh="gripper_left_palm" class="collision"/>',
@@ -179,7 +183,7 @@ def ensure_omx_mjcf(scene: str = "omx_tabletop") -> Path:
     )
     if scene in _PHYSICAL_GRIPPER_SCENES:
         robot = _inject_physical_gripper(robot)
-    if scene == "omx_pick_place":
+    if scene in _FLOOR_PICK_SCENES:
         robot = _enable_floor_pick_contacts(robot)
     if not robot.rstrip().endswith("</mujoco>"):
         raise ValueError(f"Unexpected Menagerie MJCF footer: {robot_path}")

--- a/src/fret/mjcf/omx_desk_clutter.xml
+++ b/src/fret/mjcf/omx_desk_clutter.xml
@@ -2,9 +2,9 @@
   <!--
     OpenMANIPULATOR-X desk-clutter cell (SC-v13c / T13-05).
 
-    Same floor ball + place cone dispenser as SC-v13b, plus a
-    mid-cell wall that blocks the straight Joint1 slew. Planner retracts
-    around the wall. Cone: assets/cone.obj (visual) + funnel_w* collision.
+    Same floor ball + front place cone as SC-v13b, plus an outer
+    mid-chord wall that blocks pick (−Y) → front place. Planner
+    retracts around the wall. Cone: assets/cone.obj + funnel_w*.
   -->
   <include file="open_manipulator_x.xml"/>
 
@@ -45,55 +45,56 @@
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 
     <!-- Visual funnel (mesh is convex-hulled by MuJoCo; collision uses funnel_w*). -->
-    <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.27300 0.16000 0.00000"
+    <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.26000 0.00000 0.00000"
           material="place_cone" contype="0" conaffinity="0"/>
-    <geom name="funnel_w0" type="box" size="0.0025 0.00757 0.05501" pos="0.30100 0.16000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w1" type="box" size="0.0025 0.00757 0.05501" pos="0.30030 0.16623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w2" type="box" size="0.0025 0.00757 0.05501" pos="0.29823 0.17215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w3" type="box" size="0.0025 0.00757 0.05501" pos="0.29489 0.17746 0.04900" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w4" type="box" size="0.0025 0.00757 0.05501" pos="0.29046 0.18189 0.04900" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w5" type="box" size="0.0025 0.00757 0.05501" pos="0.28515 0.18523 0.04900" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w6" type="box" size="0.0025 0.00757 0.05501" pos="0.27923 0.18730 0.04900" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w7" type="box" size="0.0025 0.00757 0.05501" pos="0.27300 0.18800 0.04900" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w8" type="box" size="0.0025 0.00757 0.05501" pos="0.26677 0.18730 0.04900" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w9" type="box" size="0.0025 0.00757 0.05501" pos="0.26085 0.18523 0.04900" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w10" type="box" size="0.0025 0.00757 0.05501" pos="0.25554 0.18189 0.04900" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w11" type="box" size="0.0025 0.00757 0.05501" pos="0.25111 0.17746 0.04900" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w12" type="box" size="0.0025 0.00757 0.05501" pos="0.24777 0.17215 0.04900" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w13" type="box" size="0.0025 0.00757 0.05501" pos="0.24570 0.16623 0.04900" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w14" type="box" size="0.0025 0.00757 0.05501" pos="0.24500 0.16000 0.04900" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w15" type="box" size="0.0025 0.00757 0.05501" pos="0.24570 0.15377 0.04900" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w16" type="box" size="0.0025 0.00757 0.05501" pos="0.24777 0.14785 0.04900" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w17" type="box" size="0.0025 0.00757 0.05501" pos="0.25111 0.14254 0.04900" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w18" type="box" size="0.0025 0.00757 0.05501" pos="0.25554 0.13811 0.04900" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w19" type="box" size="0.0025 0.00757 0.05501" pos="0.26085 0.13477 0.04900" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w20" type="box" size="0.0025 0.00757 0.05501" pos="0.26677 0.13270 0.04900" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w21" type="box" size="0.0025 0.00757 0.05501" pos="0.27300 0.13200 0.04900" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w22" type="box" size="0.0025 0.00757 0.05501" pos="0.27923 0.13270 0.04900" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w23" type="box" size="0.0025 0.00757 0.05501" pos="0.28515 0.13477 0.04900" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w24" type="box" size="0.0025 0.00757 0.05501" pos="0.29046 0.13811 0.04900" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w25" type="box" size="0.0025 0.00757 0.05501" pos="0.29489 0.14254 0.04900" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w26" type="box" size="0.0025 0.00757 0.05501" pos="0.29823 0.14785 0.04900" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w27" type="box" size="0.0025 0.00757 0.05501" pos="0.30030 0.15377 0.04900" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_tip" type="sphere" size="0.004" pos="0.27300 0.16000 0.00400" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w0" type="box" size="0.0025 0.00757 0.05501" pos="0.28800 0.00000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w1" type="box" size="0.0025 0.00757 0.05501" pos="0.28730 0.00623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w2" type="box" size="0.0025 0.00757 0.05501" pos="0.28523 0.01215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w3" type="box" size="0.0025 0.00757 0.05501" pos="0.28189 0.01746 0.04900" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w4" type="box" size="0.0025 0.00757 0.05501" pos="0.27746 0.02189 0.04900" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w5" type="box" size="0.0025 0.00757 0.05501" pos="0.27215 0.02523 0.04900" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w6" type="box" size="0.0025 0.00757 0.05501" pos="0.26623 0.02730 0.04900" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w7" type="box" size="0.0025 0.00757 0.05501" pos="0.26000 0.02800 0.04900" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w8" type="box" size="0.0025 0.00757 0.05501" pos="0.25377 0.02730 0.04900" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w9" type="box" size="0.0025 0.00757 0.05501" pos="0.24785 0.02523 0.04900" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w10" type="box" size="0.0025 0.00757 0.05501" pos="0.24254 0.02189 0.04900" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w11" type="box" size="0.0025 0.00757 0.05501" pos="0.23811 0.01746 0.04900" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w12" type="box" size="0.0025 0.00757 0.05501" pos="0.23477 0.01215 0.04900" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w13" type="box" size="0.0025 0.00757 0.05501" pos="0.23270 0.00623 0.04900" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w14" type="box" size="0.0025 0.00757 0.05501" pos="0.23200 0.00000 0.04900" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w15" type="box" size="0.0025 0.00757 0.05501" pos="0.23270 -0.00623 0.04900" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w16" type="box" size="0.0025 0.00757 0.05501" pos="0.23477 -0.01215 0.04900" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w17" type="box" size="0.0025 0.00757 0.05501" pos="0.23811 -0.01746 0.04900" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w18" type="box" size="0.0025 0.00757 0.05501" pos="0.24254 -0.02189 0.04900" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w19" type="box" size="0.0025 0.00757 0.05501" pos="0.24785 -0.02523 0.04900" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w20" type="box" size="0.0025 0.00757 0.05501" pos="0.25377 -0.02730 0.04900" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w21" type="box" size="0.0025 0.00757 0.05501" pos="0.26000 -0.02800 0.04900" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w22" type="box" size="0.0025 0.00757 0.05501" pos="0.26623 -0.02730 0.04900" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w23" type="box" size="0.0025 0.00757 0.05501" pos="0.27215 -0.02523 0.04900" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w24" type="box" size="0.0025 0.00757 0.05501" pos="0.27746 -0.02189 0.04900" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w25" type="box" size="0.0025 0.00757 0.05501" pos="0.28189 -0.01746 0.04900" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w26" type="box" size="0.0025 0.00757 0.05501" pos="0.28523 -0.01215 0.04900" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w27" type="box" size="0.0025 0.00757 0.05501" pos="0.28730 -0.00623 0.04900" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_tip" type="sphere" size="0.004" pos="0.26000 0.00000 0.00400" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
 
-    <geom name="place_plate" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.001"
+    <geom name="place_plate" type="cylinder" pos="0.26000 0.00000 0.09800" size="0.050 0.001"
           material="place_plate" contype="0" conaffinity="0"/>
     <!-- Opaque lip: same radius as red goal disk so the cone reads as its basis. -->
-    <geom name="place_cone_rim" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.0015"
+    <geom name="place_cone_rim" type="cylinder" pos="0.26000 0.00000 0.09800" size="0.050 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
-    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.00100" size="0.05 0.001"
+    <geom name="start_zone" type="cylinder" pos="0.18000 -0.26000 0.00100" size="0.05 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
-    <geom name="goal_zone" type="cylinder" pos="0.27300 0.16000 0.09900" size="0.05 0.001"
+    <geom name="goal_zone" type="cylinder" pos="0.26000 0.00000 0.09900" size="0.05 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
 
-    <geom name="transfer_wall" type="box" pos="0.29 0 0.11" size="0.05 0.008 0.11"
+    <!-- Mid-chord wall in EE workspace (blocks pick −Y → front place). -->
+    <geom name="transfer_wall" type="box" pos="0.270 -0.100 0.11" size="0.040 0.010 0.11"
           material="transfer_wall" friction="1.0 0.1 0.01"
           contype="1" conaffinity="1"/>
 
     <!-- Ø 25 mm tennis-like ball on the floor (grippy felt). -->
-    <body name="pick_box" pos="0.27300 -0.16000 0.01250">
+    <body name="pick_box" pos="0.18000 -0.26000 0.01250">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere" size="0.0125"
             density="400" material="pick_ball"

--- a/src/fret/mjcf/omx_desk_clutter.xml
+++ b/src/fret/mjcf/omx_desk_clutter.xml
@@ -2,7 +2,7 @@
   <!--
     OpenMANIPULATOR-X desk-clutter cell (SC-v13c / T13-05).
 
-    Same pick pedestal + ball and place cone dispenser as SC-v13b, plus a
+    Same floor ball + place cone dispenser as SC-v13b, plus a
     mid-cell wall that blocks the straight Joint1 slew. Planner retracts
     around the wall. Cone: assets/cone.obj (visual) + funnel_w* collision.
   -->
@@ -28,7 +28,6 @@
              markrgb="0.55 0.56 0.58" width="300" height="300"/>
     <material name="groundplane" texture="groundplane" texuniform="true"
               texrepeat="4 4" reflectance="0.05"/>
-    <material name="pedestal" rgba="0.45 0.46 0.48 1"/>
     <material name="place_cone" rgba="0.55 0.42 0.35 1"/>
     <material name="place_plate" rgba="0.85 0.35 0.28 0.45"/>
     <material name="start_zone" rgba="0.20 0.75 0.35 0.35"/>
@@ -44,9 +43,6 @@
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
-
-    <geom name="pedestal_pick" type="cylinder" pos="0.27300 -0.16000 0.04900" size="0.018 0.049"
-          material="pedestal" friction="1.2 0.1 0.01" contype="2" conaffinity="2"/>
 
     <!-- Visual funnel (mesh is convex-hulled by MuJoCo; collision uses funnel_w*). -->
     <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.27300 0.16000 0.00000"
@@ -87,7 +83,7 @@
     <geom name="place_cone_rim" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
-    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.09900" size="0.05 0.001"
+    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.00100" size="0.05 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
     <geom name="goal_zone" type="cylinder" pos="0.27300 0.16000 0.09900" size="0.05 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
@@ -96,13 +92,21 @@
           material="transfer_wall" friction="1.0 0.1 0.01"
           contype="1" conaffinity="1"/>
 
-    <!-- Ø 25 mm tennis-like ball on the pick pedestal (grippy felt). -->
-    <body name="pick_box" pos="0.27300 -0.16000 0.11050">
+    <!-- Ø 25 mm tennis-like ball on the floor (grippy felt). -->
+    <body name="pick_box" pos="0.27300 -0.16000 0.01250">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere" size="0.0125"
             density="400" material="pick_ball"
             friction="2.8 1.2 0.15" solref="0.015 1" solimp="0.9 0.95 0.001"
             condim="6" contype="14" conaffinity="14" priority="1"/>
+    </body>
+
+
+    <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
+    <body name="cv_ball_ghost" pos="0 0 -1">
+      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+            contype="0" conaffinity="0" group="1"
+            rgba="0.90 0.10 0.10 0.0"/>
     </body>
 
     <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->

--- a/src/fret/mjcf/omx_desk_clutter.xml
+++ b/src/fret/mjcf/omx_desk_clutter.xml
@@ -104,7 +104,7 @@
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
     <body name="cv_ball_ghost" pos="0 0 -1">
-      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+      <geom name="cv_ball_ghost" type="sphere" size="0.0180"
             contype="0" conaffinity="0" group="1"
             rgba="0.90 0.10 0.10 0.0"/>
     </body>

--- a/src/fret/mjcf/omx_pick_place.xml
+++ b/src/fret/mjcf/omx_pick_place.xml
@@ -103,7 +103,7 @@
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
     <body name="cv_ball_ghost" pos="0 0 -1">
-      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+      <geom name="cv_ball_ghost" type="sphere" size="0.0180"
             contype="0" conaffinity="0" group="1"
             rgba="0.90 0.10 0.10 0.0"/>
     </body>

--- a/src/fret/mjcf/omx_pick_place.xml
+++ b/src/fret/mjcf/omx_pick_place.xml
@@ -100,6 +100,14 @@
             condim="6" contype="14" conaffinity="14" priority="1"/>
     </body>
 
+
+    <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
+    <body name="cv_ball_ghost" pos="0 0 -1">
+      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+            contype="0" conaffinity="0" group="1"
+            rgba="0.90 0.10 0.10 0.0"/>
+    </body>
+
     <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->
     <!-- Structural rear vision gate + dual corner Cam-A/B (v1.4). -->
     <body name="vision_gate" pos="-0.16000 0 0">

--- a/src/fret/mjcf/omx_wall_maze.xml
+++ b/src/fret/mjcf/omx_wall_maze.xml
@@ -2,7 +2,7 @@
   <!--
     OpenMANIPULATOR-X Γ-wall maze cell (SC-v13d).
 
-    Same pick pedestal + ball and place cone as SC-v13b/c, plus an inverted-L
+    Same floor ball + place cone as SC-v13b/c, plus an inverted-L
     (letter Γ) obstacle: a vertical stem blocks the green→red slew and a
     horizontal "roof" overhang toward the pick ball (negative Y) so the arm
     cannot simply lift-and-fly over — it must back out, then climb to place.
@@ -30,7 +30,6 @@
              markrgb="0.55 0.56 0.58" width="300" height="300"/>
     <material name="groundplane" texture="groundplane" texuniform="true"
               texrepeat="4 4" reflectance="0.05"/>
-    <material name="pedestal" rgba="0.45 0.46 0.48 1"/>
     <material name="place_cone" rgba="0.55 0.42 0.35 1"/>
     <material name="place_plate" rgba="0.85 0.35 0.28 0.45"/>
     <material name="start_zone" rgba="0.20 0.75 0.35 0.35"/>
@@ -46,9 +45,6 @@
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
-
-    <geom name="pedestal_pick" type="cylinder" pos="0.27300 -0.16000 0.04900" size="0.018 0.049"
-          material="pedestal" friction="1.2 0.1 0.01" contype="2" conaffinity="2"/>
 
     <!-- Visual funnel (mesh is convex-hulled by MuJoCo; collision uses funnel_w*). -->
     <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.27300 0.16000 0.00000"
@@ -89,7 +85,7 @@
     <geom name="place_cone_rim" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
-    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.09900" size="0.05 0.001"
+    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.00100" size="0.05 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
     <geom name="goal_zone" type="cylinder" pos="0.27300 0.16000 0.09900" size="0.05 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
@@ -102,13 +98,21 @@
           material="transfer_wall" friction="1.0 0.1 0.01"
           contype="1" conaffinity="1"/>
 
-    <!-- Ø 25 mm tennis-like ball on the pick pedestal (grippy felt). -->
-    <body name="pick_box" pos="0.27300 -0.16000 0.11050">
+    <!-- Ø 25 mm tennis-like ball on the floor (grippy felt). -->
+    <body name="pick_box" pos="0.27300 -0.16000 0.01250">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere" size="0.0125"
             density="400" material="pick_ball"
             friction="2.8 1.2 0.15" solref="0.015 1" solimp="0.9 0.95 0.001"
             condim="6" contype="14" conaffinity="14" priority="1"/>
+    </body>
+
+
+    <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
+    <body name="cv_ball_ghost" pos="0 0 -1">
+      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+            contype="0" conaffinity="0" group="1"
+            rgba="0.90 0.10 0.10 0.0"/>
     </body>
 
     <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->

--- a/src/fret/mjcf/omx_wall_maze.xml
+++ b/src/fret/mjcf/omx_wall_maze.xml
@@ -2,10 +2,9 @@
   <!--
     OpenMANIPULATOR-X Γ-wall maze cell (SC-v13d).
 
-    Same floor ball + place cone as SC-v13b/c, plus an inverted-L
-    (letter Γ) obstacle: a vertical stem blocks the green→red slew and a
-    horizontal "roof" overhang toward the pick ball (negative Y) so the arm
-    cannot simply lift-and-fly over — it must back out, then climb to place.
+    Same floor ball + front place cone as SC-v13b, plus a dual Γ maze:
+    stems flank the +X place corridor and caps overhang ±Y so the arm
+    cannot swing either side — it must back out, then climb to place.
     Cone: assets/cone.obj (visual) + funnel_w* collision.
   -->
   <include file="open_manipulator_x.xml"/>
@@ -47,59 +46,65 @@
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 
     <!-- Visual funnel (mesh is convex-hulled by MuJoCo; collision uses funnel_w*). -->
-    <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.27300 0.16000 0.00000"
+    <geom name="place_cone" type="mesh" mesh="place_cone" pos="0.26000 0.00000 0.00000"
           material="place_cone" contype="0" conaffinity="0"/>
-    <geom name="funnel_w0" type="box" size="0.0025 0.00757 0.05501" pos="0.30100 0.16000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w1" type="box" size="0.0025 0.00757 0.05501" pos="0.30030 0.16623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w2" type="box" size="0.0025 0.00757 0.05501" pos="0.29823 0.17215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w3" type="box" size="0.0025 0.00757 0.05501" pos="0.29489 0.17746 0.04900" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w4" type="box" size="0.0025 0.00757 0.05501" pos="0.29046 0.18189 0.04900" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w5" type="box" size="0.0025 0.00757 0.05501" pos="0.28515 0.18523 0.04900" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w6" type="box" size="0.0025 0.00757 0.05501" pos="0.27923 0.18730 0.04900" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w7" type="box" size="0.0025 0.00757 0.05501" pos="0.27300 0.18800 0.04900" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w8" type="box" size="0.0025 0.00757 0.05501" pos="0.26677 0.18730 0.04900" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w9" type="box" size="0.0025 0.00757 0.05501" pos="0.26085 0.18523 0.04900" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w10" type="box" size="0.0025 0.00757 0.05501" pos="0.25554 0.18189 0.04900" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w11" type="box" size="0.0025 0.00757 0.05501" pos="0.25111 0.17746 0.04900" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w12" type="box" size="0.0025 0.00757 0.05501" pos="0.24777 0.17215 0.04900" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w13" type="box" size="0.0025 0.00757 0.05501" pos="0.24570 0.16623 0.04900" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w14" type="box" size="0.0025 0.00757 0.05501" pos="0.24500 0.16000 0.04900" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w15" type="box" size="0.0025 0.00757 0.05501" pos="0.24570 0.15377 0.04900" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w16" type="box" size="0.0025 0.00757 0.05501" pos="0.24777 0.14785 0.04900" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w17" type="box" size="0.0025 0.00757 0.05501" pos="0.25111 0.14254 0.04900" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w18" type="box" size="0.0025 0.00757 0.05501" pos="0.25554 0.13811 0.04900" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w19" type="box" size="0.0025 0.00757 0.05501" pos="0.26085 0.13477 0.04900" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w20" type="box" size="0.0025 0.00757 0.05501" pos="0.26677 0.13270 0.04900" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w21" type="box" size="0.0025 0.00757 0.05501" pos="0.27300 0.13200 0.04900" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w22" type="box" size="0.0025 0.00757 0.05501" pos="0.27923 0.13270 0.04900" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w23" type="box" size="0.0025 0.00757 0.05501" pos="0.28515 0.13477 0.04900" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w24" type="box" size="0.0025 0.00757 0.05501" pos="0.29046 0.13811 0.04900" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w25" type="box" size="0.0025 0.00757 0.05501" pos="0.29489 0.14254 0.04900" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w26" type="box" size="0.0025 0.00757 0.05501" pos="0.29823 0.14785 0.04900" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w27" type="box" size="0.0025 0.00757 0.05501" pos="0.30030 0.15377 0.04900" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_tip" type="sphere" size="0.004" pos="0.27300 0.16000 0.00400" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w0" type="box" size="0.0025 0.00757 0.05501" pos="0.28800 0.00000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w1" type="box" size="0.0025 0.00757 0.05501" pos="0.28730 0.00623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w2" type="box" size="0.0025 0.00757 0.05501" pos="0.28523 0.01215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w3" type="box" size="0.0025 0.00757 0.05501" pos="0.28189 0.01746 0.04900" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w4" type="box" size="0.0025 0.00757 0.05501" pos="0.27746 0.02189 0.04900" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w5" type="box" size="0.0025 0.00757 0.05501" pos="0.27215 0.02523 0.04900" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w6" type="box" size="0.0025 0.00757 0.05501" pos="0.26623 0.02730 0.04900" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w7" type="box" size="0.0025 0.00757 0.05501" pos="0.26000 0.02800 0.04900" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w8" type="box" size="0.0025 0.00757 0.05501" pos="0.25377 0.02730 0.04900" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w9" type="box" size="0.0025 0.00757 0.05501" pos="0.24785 0.02523 0.04900" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w10" type="box" size="0.0025 0.00757 0.05501" pos="0.24254 0.02189 0.04900" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w11" type="box" size="0.0025 0.00757 0.05501" pos="0.23811 0.01746 0.04900" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w12" type="box" size="0.0025 0.00757 0.05501" pos="0.23477 0.01215 0.04900" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w13" type="box" size="0.0025 0.00757 0.05501" pos="0.23270 0.00623 0.04900" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w14" type="box" size="0.0025 0.00757 0.05501" pos="0.23200 0.00000 0.04900" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w15" type="box" size="0.0025 0.00757 0.05501" pos="0.23270 -0.00623 0.04900" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w16" type="box" size="0.0025 0.00757 0.05501" pos="0.23477 -0.01215 0.04900" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w17" type="box" size="0.0025 0.00757 0.05501" pos="0.23811 -0.01746 0.04900" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w18" type="box" size="0.0025 0.00757 0.05501" pos="0.24254 -0.02189 0.04900" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w19" type="box" size="0.0025 0.00757 0.05501" pos="0.24785 -0.02523 0.04900" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w20" type="box" size="0.0025 0.00757 0.05501" pos="0.25377 -0.02730 0.04900" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w21" type="box" size="0.0025 0.00757 0.05501" pos="0.26000 -0.02800 0.04900" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w22" type="box" size="0.0025 0.00757 0.05501" pos="0.26623 -0.02730 0.04900" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w23" type="box" size="0.0025 0.00757 0.05501" pos="0.27215 -0.02523 0.04900" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w24" type="box" size="0.0025 0.00757 0.05501" pos="0.27746 -0.02189 0.04900" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w25" type="box" size="0.0025 0.00757 0.05501" pos="0.28189 -0.01746 0.04900" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w26" type="box" size="0.0025 0.00757 0.05501" pos="0.28523 -0.01215 0.04900" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w27" type="box" size="0.0025 0.00757 0.05501" pos="0.28730 -0.00623 0.04900" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_tip" type="sphere" size="0.004" pos="0.26000 0.00000 0.00400" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
 
-    <geom name="place_plate" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.001"
+    <geom name="place_plate" type="cylinder" pos="0.26000 0.00000 0.09800" size="0.050 0.001"
           material="place_plate" contype="0" conaffinity="0"/>
     <!-- Opaque lip: same radius as red goal disk so the cone reads as its basis. -->
-    <geom name="place_cone_rim" type="cylinder" pos="0.27300 0.16000 0.09800" size="0.050 0.0015"
+    <geom name="place_cone_rim" type="cylinder" pos="0.26000 0.00000 0.09800" size="0.050 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
-    <geom name="start_zone" type="cylinder" pos="0.27300 -0.16000 0.00100" size="0.05 0.001"
+    <geom name="start_zone" type="cylinder" pos="0.18000 -0.26000 0.00100" size="0.05 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
-    <geom name="goal_zone" type="cylinder" pos="0.27300 0.16000 0.09900" size="0.05 0.001"
+    <geom name="goal_zone" type="cylinder" pos="0.26000 0.00000 0.09900" size="0.05 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
 
-    <!-- Γ maze: stem (vertical) + roof overhang toward the pick ball (-Y). -->
-    <geom name="transfer_wall_stem" type="box" pos="0.295 0 0.11" size="0.045 0.010 0.11"
+    <!-- Dual Γ flanking front place; outer stems + ±Y roofs. -->
+    <geom name="transfer_wall_stem" type="box" pos="0.270 -0.100 0.11" size="0.040 0.010 0.11"
           material="transfer_wall" friction="1.0 0.1 0.01"
           contype="1" conaffinity="1"/>
-    <geom name="transfer_wall_cap" type="box" pos="0.30 -0.07 0.245" size="0.04 0.08 0.02"
+    <geom name="transfer_wall_cap" type="box" pos="0.275 -0.165 0.245" size="0.035 0.075 0.02"
+          material="transfer_wall" friction="1.0 0.1 0.01"
+          contype="1" conaffinity="1"/>
+    <geom name="transfer_wall_stem_p" type="box" pos="0.270 0.100 0.11" size="0.040 0.010 0.11"
+          material="transfer_wall" friction="1.0 0.1 0.01"
+          contype="1" conaffinity="1"/>
+    <geom name="transfer_wall_cap_p" type="box" pos="0.275 0.165 0.245" size="0.035 0.075 0.02"
           material="transfer_wall" friction="1.0 0.1 0.01"
           contype="1" conaffinity="1"/>
 
     <!-- Ø 25 mm tennis-like ball on the floor (grippy felt). -->
-    <body name="pick_box" pos="0.27300 -0.16000 0.01250">
+    <body name="pick_box" pos="0.18000 -0.26000 0.01250">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere" size="0.0125"
             density="400" material="pick_ball"

--- a/src/fret/mjcf/omx_wall_maze.xml
+++ b/src/fret/mjcf/omx_wall_maze.xml
@@ -110,7 +110,7 @@
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
     <body name="cv_ball_ghost" pos="0 0 -1">
-      <geom name="cv_ball_ghost" type="sphere" size="0.0125"
+      <geom name="cv_ball_ghost" type="sphere" size="0.0180"
             contype="0" conaffinity="0" group="1"
             rgba="0.90 0.10 0.10 0.0"/>
     </body>

--- a/src/fret/mjcf/omy.py
+++ b/src/fret/mjcf/omy.py
@@ -145,8 +145,13 @@ def _inject_physical_gripper(robot_xml: str) -> str:
     return robot_xml
 
 
+_FLOOR_PICK_SCENES: frozenset[str] = frozenset(
+    {"omy_pick_place", "omy_clutter"}
+)
+
+
 def _enable_floor_pick_contacts(robot_xml: str) -> str:
-    """Remap distal collision bits for floor-ball grasp (SC-v14b).
+    """Remap distal collision bits for floor-ball grasp (SC-v14b/c).
 
     Menagerie wrist/finger STLs penetrate the plane at a true floor pinch.
     Distal meshes use pad bit 4 (ball only): no floor fight on pinch, and no
@@ -201,7 +206,7 @@ def ensure_omy_mjcf(scene: str = "omy_tabletop") -> Path:
     )
     if scene in _PHYSICAL_GRIPPER_SCENES:
         robot = _inject_physical_gripper(robot)
-    if scene == "omy_pick_place":
+    if scene in _FLOOR_PICK_SCENES:
         robot = _enable_floor_pick_contacts(robot)
     if not robot.rstrip().endswith("</mujoco>"):
         raise ValueError(f"Unexpected Menagerie MJCF footer: {robot_path}")

--- a/src/fret/mjcf/omy_clutter.xml
+++ b/src/fret/mjcf/omy_clutter.xml
@@ -1,8 +1,8 @@
 <mujoco model="omy_clutter">
   <!--
-    OpenMANIPULATOR-Y cluttered pedestal pick-and-place (SC-v14c).
+    OpenMANIPULATOR-Y cluttered floor pick-and-place (SC-v14c).
 
-    Pick: Ø 86 mm sphere on a short pedestal.
+    Pick: Ø 86 mm sphere resting on the floor / table plane.
     Place: tip-down cone funnel — Ø 280 mm, height 280 mm.
     Cone mesh: assets/cone.obj (scaled in geom).
 
@@ -42,16 +42,10 @@
   <worldbody>
     <light name="key" pos="0.95 0.0 1.6" dir="0 0 -1" directional="true"
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
-    <!-- Contact bits: arm=1, pedestal/cone=2, pads=4, floor=1|8.
-         Ball=2|4|8 hits floor/pads/pedestal/cone but not arm links. -->
+    <!-- Contact bits: arm=1, cone=2, pads=4, floor=1|8.
+         Ball=2|4|8 hits floor/pads/cone but not arm links. -->
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
-
-    <geom name="pedestal_pick" type="cylinder"
-          pos="0.40000 -0.28000 0.04500"
-          size="0.03500 0.04500"
-          material="start_zone" friction="1.2 0.1 0.01"
-          contype="2" conaffinity="2"/>
 
     <!-- Visual mesh only; funnel_w* / funnel_tip carry rigid collision. -->
     <geom name="place_cone" type="mesh" mesh="place_cone"
@@ -97,7 +91,7 @@
           material="place_cone" contype="0" conaffinity="0"/>
 
     <geom name="start_zone" type="cylinder"
-          pos="0.40000 -0.28000 0.09100"
+          pos="0.40000 -0.28000 0.00100"
           size="0.15000 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
     <geom name="goal_zone" type="cylinder"
@@ -105,7 +99,7 @@
           size="0.15000 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
 
-    <body name="pick_box" pos="0.40000 -0.28000 0.13300">
+    <body name="pick_box" pos="0.40000 -0.28000 0.04300">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere"
             size="0.04300"
@@ -119,6 +113,14 @@
           size="0.07000 0.04000 0.15000"
           material="transfer_wall"
           friction="1.0 0.1 0.01" contype="1" conaffinity="1"/>
+
+
+    <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
+    <body name="cv_ball_ghost" pos="0 0 -1">
+      <geom name="cv_ball_ghost" type="sphere" size="0.04300"
+            contype="0" conaffinity="0" group="1"
+            rgba="0.90 0.10 0.10 0.0"/>
+    </body>
 
     <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->
     <!-- Structural rear vision gate + dual corner Cam-A/B (v1.4). -->

--- a/src/fret/mjcf/omy_clutter.xml
+++ b/src/fret/mjcf/omy_clutter.xml
@@ -117,7 +117,7 @@
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
     <body name="cv_ball_ghost" pos="0 0 -1">
-      <geom name="cv_ball_ghost" type="sphere" size="0.04300"
+      <geom name="cv_ball_ghost" type="sphere" size="0.06500"
             contype="0" conaffinity="0" group="1"
             rgba="0.90 0.10 0.10 0.0"/>
     </body>

--- a/src/fret/mjcf/omy_clutter.xml
+++ b/src/fret/mjcf/omy_clutter.xml
@@ -2,6 +2,8 @@
   <!--
     OpenMANIPULATOR-Y cluttered floor pick-and-place (SC-v14c).
 
+    Front place cone (+X); mid-chord wall blocks pick (−Y) → place.
+
     Pick: Ø 86 mm sphere resting on the floor / table plane.
     Place: tip-down cone funnel — Ø 280 mm, height 280 mm.
     Cone mesh: assets/cone.obj (scaled in geom).
@@ -49,57 +51,57 @@
 
     <!-- Visual mesh only; funnel_w* / funnel_tip carry rigid collision. -->
     <geom name="place_cone" type="mesh" mesh="place_cone"
-          pos="0.50000 0.20000 0.00000"
+          pos="0.48000 0.00000 0.00000"
           material="place_cone" contype="0" conaffinity="0"/>
-    <geom name="funnel_w0" type="box" size="0.00700 0.02120 0.15717" pos="0.57840 0.20000 0.14000" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w1" type="box" size="0.00700 0.02120 0.15717" pos="0.57644 0.21744 0.14000" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w2" type="box" size="0.00700 0.02120 0.15717" pos="0.57064 0.23402 0.14000" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w3" type="box" size="0.00700 0.02120 0.15717" pos="0.56129 0.24889 0.14000" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w4" type="box" size="0.00700 0.02120 0.15717" pos="0.54889 0.26129 0.14000" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w5" type="box" size="0.00700 0.02120 0.15717" pos="0.53402 0.27064 0.14000" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w6" type="box" size="0.00700 0.02120 0.15717" pos="0.51744 0.27644 0.14000" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w7" type="box" size="0.00700 0.02120 0.15717" pos="0.50000 0.27840 0.14000" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w8" type="box" size="0.00700 0.02120 0.15717" pos="0.48256 0.27644 0.14000" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w9" type="box" size="0.00700 0.02120 0.15717" pos="0.46598 0.27064 0.14000" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w10" type="box" size="0.00700 0.02120 0.15717" pos="0.45111 0.26129 0.14000" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w11" type="box" size="0.00700 0.02120 0.15717" pos="0.43871 0.24889 0.14000" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w12" type="box" size="0.00700 0.02120 0.15717" pos="0.42936 0.23402 0.14000" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w13" type="box" size="0.00700 0.02120 0.15717" pos="0.42356 0.21744 0.14000" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w14" type="box" size="0.00700 0.02120 0.15717" pos="0.42160 0.20000 0.14000" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w15" type="box" size="0.00700 0.02120 0.15717" pos="0.42356 0.18256 0.14000" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w16" type="box" size="0.00700 0.02120 0.15717" pos="0.42936 0.16598 0.14000" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w17" type="box" size="0.00700 0.02120 0.15717" pos="0.43871 0.15111 0.14000" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w18" type="box" size="0.00700 0.02120 0.15717" pos="0.45111 0.13871 0.14000" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w19" type="box" size="0.00700 0.02120 0.15717" pos="0.46598 0.12936 0.14000" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w20" type="box" size="0.00700 0.02120 0.15717" pos="0.48256 0.12356 0.14000" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w21" type="box" size="0.00700 0.02120 0.15717" pos="0.50000 0.12160 0.14000" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w22" type="box" size="0.00700 0.02120 0.15717" pos="0.51744 0.12356 0.14000" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w23" type="box" size="0.00700 0.02120 0.15717" pos="0.53402 0.12936 0.14000" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w24" type="box" size="0.00700 0.02120 0.15717" pos="0.54889 0.13871 0.14000" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w25" type="box" size="0.00700 0.02120 0.15717" pos="0.56129 0.15111 0.14000" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w26" type="box" size="0.00700 0.02120 0.15717" pos="0.57064 0.16598 0.14000" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_w27" type="box" size="0.00700 0.02120 0.15717" pos="0.57644 0.18256 0.14000" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
-    <geom name="funnel_tip" type="sphere" size="0.01120 0.01120 0.01143" pos="0.50000 0.20000 0.01143" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w0" type="box" size="0.00700 0.02120 0.15717" pos="0.55840 0.00000 0.14000" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w1" type="box" size="0.00700 0.02120 0.15717" pos="0.55644 0.01744 0.14000" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w2" type="box" size="0.00700 0.02120 0.15717" pos="0.55064 0.03402 0.14000" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w3" type="box" size="0.00700 0.02120 0.15717" pos="0.54129 0.04889 0.14000" quat="0.917744 -0.077189 0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w4" type="box" size="0.00700 0.02120 0.15717" pos="0.52889 0.06129 0.14000" quat="0.876018 -0.101402 0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w5" type="box" size="0.00700 0.02120 0.15717" pos="0.51402 0.07064 0.14000" quat="0.823276 -0.124340 0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w6" type="box" size="0.00700 0.02120 0.15717" pos="0.49744 0.07644 0.14000" quat="0.760180 -0.145714 0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w7" type="box" size="0.00700 0.02120 0.15717" pos="0.48000 0.07840 0.14000" quat="0.687525 -0.165256 0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w8" type="box" size="0.00700 0.02120 0.15717" pos="0.46256 0.07644 0.14000" quat="0.606224 -0.182720 0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w9" type="box" size="0.00700 0.02120 0.15717" pos="0.44598 0.07064 0.14000" quat="0.517299 -0.197886 0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w10" type="box" size="0.00700 0.02120 0.15717" pos="0.43111 0.06129 0.14000" quat="0.421868 -0.210563 0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w11" type="box" size="0.00700 0.02120 0.15717" pos="0.41871 0.04889 0.14000" quat="0.321133 -0.220592 0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w12" type="box" size="0.00700 0.02120 0.15717" pos="0.40936 0.03402 0.14000" quat="0.216359 -0.227848 0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w13" type="box" size="0.00700 0.02120 0.15717" pos="0.40356 0.01744 0.14000" quat="0.108864 -0.232238 0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w14" type="box" size="0.00700 0.02120 0.15717" pos="0.40160 0.00000 0.14000" quat="0.000000 -0.233707 0.000000 0.972307" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w15" type="box" size="0.00700 0.02120 0.15717" pos="0.40356 -0.01744 0.14000" quat="-0.108864 -0.232238 -0.026167 0.966193" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w16" type="box" size="0.00700 0.02120 0.15717" pos="0.40936 -0.03402 0.14000" quat="-0.216359 -0.227848 -0.052005 0.947929" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w17" type="box" size="0.00700 0.02120 0.15717" pos="0.41871 -0.04889 0.14000" quat="-0.321133 -0.220592 -0.077189 0.917744" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w18" type="box" size="0.00700 0.02120 0.15717" pos="0.43111 -0.06129 0.14000" quat="-0.421868 -0.210563 -0.101402 0.876018" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w19" type="box" size="0.00700 0.02120 0.15717" pos="0.44598 -0.07064 0.14000" quat="-0.517299 -0.197886 -0.124340 0.823276" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w20" type="box" size="0.00700 0.02120 0.15717" pos="0.46256 -0.07644 0.14000" quat="-0.606224 -0.182720 -0.145714 0.760180" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w21" type="box" size="0.00700 0.02120 0.15717" pos="0.48000 -0.07840 0.14000" quat="-0.687525 -0.165256 -0.165256 0.687525" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w22" type="box" size="0.00700 0.02120 0.15717" pos="0.49744 -0.07644 0.14000" quat="-0.760180 -0.145714 -0.182720 0.606224" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w23" type="box" size="0.00700 0.02120 0.15717" pos="0.51402 -0.07064 0.14000" quat="-0.823276 -0.124340 -0.197886 0.517299" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w24" type="box" size="0.00700 0.02120 0.15717" pos="0.52889 -0.06129 0.14000" quat="-0.876018 -0.101402 -0.210563 0.421868" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w25" type="box" size="0.00700 0.02120 0.15717" pos="0.54129 -0.04889 0.14000" quat="-0.917744 -0.077189 -0.220592 0.321133" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w26" type="box" size="0.00700 0.02120 0.15717" pos="0.55064 -0.03402 0.14000" quat="-0.947929 -0.052005 -0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_w27" type="box" size="0.00700 0.02120 0.15717" pos="0.55644 -0.01744 0.14000" quat="-0.966193 -0.026167 -0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
+    <geom name="funnel_tip" type="sphere" size="0.01120 0.01120 0.01143" pos="0.48000 0.00000 0.01143" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
 
     <geom name="place_plate" type="cylinder"
-          pos="0.50000 0.20000 0.28000"
+          pos="0.48000 0.00000 0.28000"
           size="0.14000 0.001"
           material="place_plate" contype="0" conaffinity="0"/>
     <geom name="place_cone_rim" type="cylinder"
-          pos="0.50000 0.20000 0.28000"
+          pos="0.48000 0.00000 0.28000"
           size="0.14000 0.0015"
           material="place_cone" contype="0" conaffinity="0"/>
 
     <geom name="start_zone" type="cylinder"
-          pos="0.40000 -0.28000 0.00100"
+          pos="0.35000 -0.30000 0.00100"
           size="0.15000 0.001"
           material="start_zone" contype="0" conaffinity="0"/>
     <geom name="goal_zone" type="cylinder"
-          pos="0.50000 0.20000 0.28100"
+          pos="0.48000 0.00000 0.28100"
           size="0.15000 0.001"
           material="goal_zone" contype="0" conaffinity="0"/>
 
-    <body name="pick_box" pos="0.40000 -0.28000 0.04300">
+    <body name="pick_box" pos="0.35000 -0.30000 0.04300">
       <freejoint name="pick_box_joint"/>
       <geom name="pick_box_geom" type="sphere"
             size="0.04300"
@@ -109,8 +111,8 @@
     </body>
 
     <geom name="transfer_wall_a" type="box"
-          pos="0.45000 0.00000 0.15000"
-          size="0.07000 0.04000 0.15000"
+          pos="0.41500 -0.12000 0.15000"
+          size="0.06000 0.03500 0.15000"
           material="transfer_wall"
           friction="1.0 0.1 0.01" contype="1" conaffinity="1"/>
 

--- a/src/fret/mjcf/omy_pick_place.xml
+++ b/src/fret/mjcf/omy_pick_place.xml
@@ -107,6 +107,14 @@
             condim="6" contype="14" conaffinity="14" priority="1"/>
     </body>
 
+
+    <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
+    <body name="cv_ball_ghost" pos="0 0 -1">
+      <geom name="cv_ball_ghost" type="sphere" size="0.04300"
+            contype="0" conaffinity="0" group="1"
+            rgba="0.90 0.10 0.10 0.0"/>
+    </body>
+
     <!-- Perception portal / gantry (v1.4): rigid posts + beam holding Cam-A. -->
     <!-- Structural rear vision gate + dual corner Cam-A/B (v1.4). -->
     <body name="vision_gate" pos="-0.22000 0 0">

--- a/src/fret/mjcf/omy_pick_place.xml
+++ b/src/fret/mjcf/omy_pick_place.xml
@@ -110,7 +110,7 @@
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
     <body name="cv_ball_ghost" pos="0 0 -1">
-      <geom name="cv_ball_ghost" type="sphere" size="0.04300"
+      <geom name="cv_ball_ghost" type="sphere" size="0.06500"
             contype="0" conaffinity="0" group="1"
             rgba="0.90 0.10 0.10 0.0"/>
     </body>

--- a/src/fret/simulation/gate_overlay.py
+++ b/src/fret/simulation/gate_overlay.py
@@ -1,0 +1,167 @@
+"""Low-FPS gate-camera overlay clips for release showcase (v1.4+).
+
+Side MP4s (``*_gate_cam_left.mp4`` / ``*_gate_cam_right.mp4``) sit next to the
+overview encode in the same R2 folder. They are deliberately separate from the
+overview compositor (no subwindows).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+
+GATE_CAMERAS: tuple[str, ...] = ("gate_cam_left", "gate_cam_right")
+DEFAULT_OVERLAY_FPS = 5
+# Match portal HSV tennis-yellow band (omx/omy_portal_overhead.yml).
+_HSV_LOWER = (20, 40, 40)
+_HSV_UPPER = (50, 255, 255)
+
+
+def annotate_gate_frame(
+    rgb: npt.NDArray[np.uint8],
+    pose_xyz: Sequence[float] | None,
+    *,
+    label: str = "pose",
+) -> npt.NDArray[np.uint8]:
+    """Draw HSV blob circle + world-pose text on a MuJoCo RGB frame."""
+    import cv2
+
+    out = np.ascontiguousarray(rgb.copy())
+    bgr = cv2.cvtColor(out, cv2.COLOR_RGB2BGR)
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    mask = cv2.inRange(
+        hsv,
+        np.array(_HSV_LOWER, dtype=np.uint8),
+        np.array(_HSV_UPPER, dtype=np.uint8),
+    )
+    contours, _ = cv2.findContours(
+        mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
+    if contours:
+        largest = max(contours, key=cv2.contourArea)
+        if cv2.contourArea(largest) >= 40.0:
+            (cx, cy), radius = cv2.minEnclosingCircle(largest)
+            center = (int(round(cx)), int(round(cy)))
+            cv2.circle(bgr, center, int(round(radius)), (0, 255, 255), 2)
+            cv2.circle(bgr, center, 3, (0, 0, 255), -1)
+    if pose_xyz is not None:
+        x, y, z = (float(v) for v in pose_xyz[:3])
+        lines = [
+            f"{label}: x={x:+.3f} y={y:+.3f} z={z:+.3f}",
+        ]
+        y0 = 28
+        for i, line in enumerate(lines):
+            cv2.putText(
+                bgr,
+                line,
+                (12, y0 + 28 * i),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.70,
+                (20, 20, 20),
+                3,
+                cv2.LINE_AA,
+            )
+            cv2.putText(
+                bgr,
+                line,
+                (12, y0 + 28 * i),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.70,
+                (240, 240, 240),
+                1,
+                cv2.LINE_AA,
+            )
+    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+
+def present_gate_cameras(mujoco: Any, model: Any) -> list[str]:
+    """Return gate camera names that exist on ``model``."""
+    found: list[str] = []
+    for name in GATE_CAMERAS:
+        if mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_CAMERA, name) >= 0:
+            found.append(name)
+    return found
+
+
+def write_gate_cam_overlay_videos(
+    *,
+    mujoco: Any,
+    model: Any,
+    data: Any,
+    samples: Sequence[Any],
+    apply_sample: Callable[[Any], None],
+    box_qadr: int,
+    output_dir: Path,
+    scenario: str,
+    main_fps: int,
+    overlay_fps: int = DEFAULT_OVERLAY_FPS,
+    width: int = 640,
+    height: int = 360,
+    pose_label: str = "ball",
+    cv_pose: npt.NDArray[np.float64] | None = None,
+    open_writer: Callable[[Path, int], Any],
+    frame_mean: Callable[[npt.NDArray[np.uint8]], float],
+    output_name: Callable[[str, str], str],
+    result_cls: type,
+    timing: Any,
+) -> list[Any]:
+    """Encode low-FPS annotated gate-cam side clips; skip if cams missing."""
+    cameras = present_gate_cameras(mujoco, model)
+    if not cameras or not samples:
+        return []
+
+    stride = max(1, int(round(float(main_fps) / float(overlay_fps))))
+    renderer = mujoco.Renderer(model, height=height, width=width)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    paths = {
+        cam: output_dir / output_name(scenario, cam) for cam in cameras
+    }
+    writers = {cam: open_writer(paths[cam], overlay_fps) for cam in cameras}
+    first_frames: dict[str, npt.NDArray[np.uint8]] = {}
+    try:
+        for i, sample in enumerate(samples):
+            if i % stride != 0 and i != len(samples) - 1:
+                continue
+            apply_sample(sample)
+            ball = np.asarray(
+                data.qpos[box_qadr : box_qadr + 3], dtype=np.float64
+            )
+            pose = (
+                np.asarray(cv_pose, dtype=np.float64).reshape(3)
+                if cv_pose is not None
+                else ball
+            )
+            label = "CV" if cv_pose is not None else pose_label
+            for cam in cameras:
+                renderer.update_scene(data, camera=cam)
+                frame = annotate_gate_frame(
+                    renderer.render(), pose, label=label
+                )
+                writers[cam].append_data(frame)
+                if cam not in first_frames:
+                    first_frames[cam] = frame.copy()
+    finally:
+        for writer in writers.values():
+            writer.close()
+        renderer.close()
+
+    results: list[Any] = []
+    for cam in cameras:
+        mean = frame_mean(first_frames[cam])
+        if mean <= 1.0:
+            raise RuntimeError(
+                f"Camera {cam!r} overlay looks blank (frame mean={mean:.2f})"
+            )
+        results.append(
+            result_cls(
+                camera=cam,
+                path=paths[cam],
+                frame_mean=mean,
+                timing=timing,
+            )
+        )
+    return results

--- a/src/fret/simulation/gate_overlay.py
+++ b/src/fret/simulation/gate_overlay.py
@@ -23,7 +23,7 @@ _HSV_UPPER = (50, 255, 255)
 
 def annotate_gate_frame(
     rgb: npt.NDArray[np.uint8],
-    pose_xyz: Sequence[float] | None,
+    pose_xyz: Sequence[float] | npt.NDArray[np.floating[Any]] | None,
     *,
     label: str = "pose",
 ) -> npt.NDArray[np.uint8]:
@@ -75,7 +75,8 @@ def annotate_gate_frame(
                 1,
                 cv2.LINE_AA,
             )
-    return cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    annotated = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    return np.asarray(annotated, dtype=np.uint8)
 
 
 def present_gate_cameras(mujoco: Any, model: Any) -> list[str]:
@@ -117,9 +118,7 @@ def write_gate_cam_overlay_videos(
     stride = max(1, int(round(float(main_fps) / float(overlay_fps))))
     renderer = mujoco.Renderer(model, height=height, width=width)
     output_dir.mkdir(parents=True, exist_ok=True)
-    paths = {
-        cam: output_dir / output_name(scenario, cam) for cam in cameras
-    }
+    paths = {cam: output_dir / output_name(scenario, cam) for cam in cameras}
     writers = {cam: open_writer(paths[cam], overlay_fps) for cam in cameras}
     first_frames: dict[str, npt.NDArray[np.uint8]] = {}
     try:

--- a/tests/control/test_kinematics_open_manipulator_y.py
+++ b/tests/control/test_kinematics_open_manipulator_y.py
@@ -160,9 +160,11 @@ def test_omy_clutter_transfer_plan_detours_wall() -> None:
         seed_offset=0,
     )
     assert straight_collides, "wall should block the straight lift→place chord"
+    # Front-cone layout prefers the YAML transfer_detour (lift→via→place);
+    # RRT densification is optional when that detour is enabled.
     assert (
-        len(path) >= 4
-    ), f"expected densified plan, got {len(path)} waypoints"
+        len(path) >= 3
+    ), f"expected detour/plan path, got {len(path)} waypoints"
 
 
 @pytest.mark.slow
@@ -194,7 +196,9 @@ def test_omy_clutter_pick_place_smoke() -> None:
     place_xy = np.asarray(params["place_xy"], dtype=np.float64)
     result = run_omy_clutter_pick_place(
         duration_s=180.0,
-        joint_tol_rad=0.45,
+        # Front-cone place needs a tighter tol than the old +Y cone (0.45
+        # advanced RELEASE before place_grasp and flung the ball past rim).
+        joint_tol_rad=0.16,
         scenario_path=_CLUTTER,
         seed_offset=0,
     )

--- a/tests/control/test_pick_place_wall_maze.py
+++ b/tests/control/test_pick_place_wall_maze.py
@@ -1,4 +1,4 @@
-"""SC-v13d Γ-wall maze: back out under pick-side roof → climb → place."""
+"""SC-v13d dual Γ-wall maze: back out under roofs → climb → front place."""
 
 from __future__ import annotations
 
@@ -24,19 +24,16 @@ _SCENARIO = Path("src/fret/config/scenarios/omx_wall_maze.yml")
 def test_omx_wall_maze_mjcf_has_gamma_walls() -> None:
     path = mjcf_path("open_manipulator_x", "omx_wall_maze")
     model = mujoco.MjModel.from_xml_path(str(path))
-    assert (
-        mujoco.mj_name2id(
-            model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_stem"
-        )
-        >= 0
-    )
-    assert (
-        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_cap")
-        >= 0
-    )
-    assert (
-        mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "place_cone") >= 0
-    )
+    for name in (
+        "transfer_wall_stem",
+        "transfer_wall_cap",
+        "transfer_wall_stem_p",
+        "transfer_wall_cap_p",
+        "place_cone",
+    ):
+        assert (
+            mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, name) >= 0
+        ), name
     stem = mujoco.mj_name2id(
         model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_stem"
     )
@@ -44,13 +41,17 @@ def test_omx_wall_maze_mjcf_has_gamma_walls() -> None:
     assert int(model.geom_contype[stem]) == 1
     assert int(model.geom_conaffinity[stem]) == 1
     walls = walls_from_scenario(_SCENARIO)
-    assert len(walls) == 2
-    roof = walls[1]
-    pick_y = float(load_scenario_parameters(_SCENARIO)["pick_xy"][1])
-    # Roof overhangs toward the pick ball (negative Y), not the place side.
-    assert roof.y_min < -0.05
-    assert roof.y_min < pick_y + 0.05
-    assert roof.y_max <= 0.02
+    assert len(walls) == 4
+    params = load_scenario_parameters(_SCENARIO)
+    place_xy = np.asarray(params["place_xy"], dtype=np.float64)
+    pick_y = float(params["pick_xy"][1])
+    # Front place cone on +X (y ≈ 0).
+    assert abs(float(place_xy[1])) < 1e-6
+    # Dual roofs: one toward pick (−Y), one mirrored (+Y).
+    roofs = [w for w in walls if w.z_min >= 0.2]
+    assert len(roofs) == 2
+    assert any(r.y_min < pick_y + 0.05 and r.y_max < 0.0 for r in roofs)
+    assert any(r.y_min > 0.0 and r.y_max > 0.05 for r in roofs)
 
 
 def test_wall_maze_transfer_plan_backs_out_and_climbs() -> None:

--- a/tests/simulation/test_gate_overlay.py
+++ b/tests/simulation/test_gate_overlay.py
@@ -1,0 +1,18 @@
+"""Unit tests for gate-cam overlay annotation helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from fret.simulation.gate_overlay import annotate_gate_frame
+
+
+def test_annotate_gate_frame_draws_pose_text() -> None:
+    frame = np.zeros((120, 160, 3), dtype=np.uint8)
+    # Yellow-ish blob near tennis HSV band.
+    frame[40:80, 60:100] = (40, 200, 200)
+    out = annotate_gate_frame(frame, (0.22, -0.20, 0.0125), label="CV")
+    assert out.shape == frame.shape
+    assert out.dtype == np.uint8
+    # Text + circle should change some pixels vs the blank canvas edges.
+    assert float(out[:30].mean()) > 1.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Puts **all place cones / dispensers in front of the arm** (`+X`, `y≈0`) for OMX desk clutter, OMX dual-Γ maze, and OMY clutter — matching open pick-place. Walls were redesigned around EE-space clearance (dual Γ mirrored ±Y on the maze). Continues the v1.4 floor-ball / CV-ghost / gate-cam work already on this branch.

## Layout

| Cell | pick_xy | place_xy |
| --- | --- | --- |
| OMX open | `(0.22, −0.20)` | `(0.26, 0)` |
| OMX desk / maze | `(0.18, −0.26)` | `(0.26, 0)` |
| OMY open / clutter | `(0.35, −0.30)` | `(0.48, 0)` |

OMX clutter/maze use an **outer** mid-chord wall (and dual Γ stems/caps) so approach stays mesh-clear while occupancy still blocks the pick→place chord. OMY clutter keeps the mid-chord wall and uses the open-cell transfer via (`prefer_transfer_detour`).

## Proof (T3)

Commands:

```bash
python3 -m pytest tests/control/test_pick_place_clutter.py \
  tests/control/test_pick_place_wall_maze.py \
  tests/control/test_kinematics_open_manipulator_y.py::test_omy_clutter_transfer_plan_detours_wall \
  tests/control/test_kinematics_open_manipulator_y.py::test_omy_clutter_pick_place_smoke \
  -p no:launch_testing -p no:launch_ros -q
# → 8 passed

bash scripts/check/formatting.sh  # PASSED
```

Overview stills (place cone on +X / y≈0):

![OMX desk clutter front cone](https://cursor.com/artifacts/c/art-8b6493c1-4d8a-4097-91c7-410b8d60f78f)
![OMX dual-Γ maze front cone](https://cursor.com/artifacts/c/art-f92309b0-635e-4245-a415-af31a8e03b1a)
![OMY clutter front cone](https://cursor.com/artifacts/c/art-bab74bf0-bf1f-42f8-b980-84ec55211507)

MuJoCo `place_cone` geom XY: OMX `(0.26, 0)`, OMY `(0.48, 0)`.

## Notes

- OMX maze `lift_height_m` lowered to `0.055` (floor ball under roofs).
- OMY clutter smoke uses `joint_tol_rad=0.16` so RELEASE waits for place_grasp (0.45 flung the ball past the front rim).
- Repo-wide `types.sh` still reports pre-existing ROS/rclpy mypy noise (~44).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c882326-021b-4721-9971-d415e077527a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

