### PR TITLE
Adapt FRET to ARCO v0.3.7 classical MPCC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,8 @@ needs network access). Standard build/test/run commands live in
   config and renders a near-static clip; pass `--no-tracking` to render visible
   planned-path (ARCO RRT*) motion.
 - **Known pre-existing breakages (not environment issues):** the pinned
- pinned `arco[mpc] @ v0.3.2` provides CasADi path-following / joint-space
- MPC. Pre-existing: `mypy` reports a missing `Any` import in
+ `arco[mpc] @ v0.3.7` provides CasADi classical path-following MPCC /
+ joint-space MPC. Pre-existing: `mypy` reports a missing `Any` import in
  `planner_node_ros.py`; and the ROS `planner_node` crashes at launch because
  `declare_parameter("start_configuration", [])` is inferred as `BYTE_ARRAY`
  under rclpy Jazzy. Other nodes (mujoco_bridge, controller, perception,

--- a/docs/arco.md
+++ b/docs/arco.md
@@ -35,8 +35,8 @@ Bootstrap arm (MS-1–5) also uses `KDTreeOccupancy`, `SSTPlanner`, and
 |---|---|
 | Occupancy (`KDTreeOccupancy`) | ARCO |
 | Planner (SST, RRT*) | ARCO |
-| Dubins vehicle + path-following MPC | ARCO (≥ v0.3.2; progress-first contouring via arco#147 on main) |
-| Joint-space MPC (OMX pick-and-place) | ARCO (≥ v0.3.2) |
+| Dubins vehicle + path-following MPCC | ARCO (≥ v0.3.7 classical MPCC) |
+| Joint-space MPC (OMX pick-and-place) | ARCO (≥ v0.3.7; step dt must equal config.dt) |
 | Scene acquisition, TF | FRET |
 | Per-robot kinematics | FRET |
 | ROS 2 I/O, MuJoCo simulation | FRET |
@@ -88,28 +88,33 @@ Reuse ARCO race infrastructure:
   (grey foil retains Pure Pursuit)
 - Extend environment with 3-D columns (MuJoCo visual)
 
-### Progress-first contouring (arco#147)
+### Classical MPCC (ARCO ≥ v0.3.7)
 
-Global planners ignore vehicle dynamics, so forcing the online MPC to
-zero-fit their polylines stalls / orbits at sharp kinks. FRET’s Dubins
-race trackers therefore consume ARCO’s progress-first fields:
+Global planners ignore vehicle dynamics, so a stiff zero-fit of their
+polylines stalls / orbits at sharp kinks. ARCO v0.3.7 reworks
+`DubinsPathFollowingMPC` as classical contouring MPCC (Lam / Liniger):
+free virtual progress speed \(v_s\), **linear** progress reward, and a
+**structural** lag error that couples path parameter \(s\) to the
+vehicle. FRET’s Dubins race trackers consume:
 
 | YAML key (`dubins.yml` → `mpc`) | ARCO config field | Role |
 |---|---|---|
-| `weight_lag` | `weight_lag` | Penalty on lagging `s0 + v_cruise·t` |
-| `contour_deadzone` | `contour_deadzone` | Free lateral band (m); contour cost on `(|e_lat| − deadzone)_+²` |
+| `weight_lag` | `weight_lag` | Lag-error weight (**must be > 0**; construction rejects ≤ 0) |
+| `weight_progress` | `weight_progress` | Linear reward per meter of arc-length advancement |
+| `contour_deadzone` | `contour_deadzone` | Optional free lateral band (m); **keep 0** (flats chatter) |
+| `weight_heading` | `weight_heading` | Keep small (~1/10 of contour); tracking emerges from contour + lag |
 
 Wired in `fret.scenario.dubins_race_runner._mpc_config` via
 `PathFollowingMPCConfig.with_weight_overrides(...)`. Race agents keep
-`occupancy=None` (planner owns avoidance).
+`occupancy=None` (planner owns avoidance). `weight_slack` was removed
+upstream and is no longer forwarded.
 
-**Lab scale, not city scale.** ARCO city demos use ~8 m deadzone / 14 m/s
-cruise; FRET’s warehouse aisles are ≈1.6 m with TurtleBot half-size
-≈0.09 m and cruise ≈0.36 m/s, so `dubins.yml` uses
-`contour_deadzone: 0.10` m and softer contour/heading weights. Setting
-`contour_deadzone: 0` restores classic contouring. Always-on ARCO
-behavior even at zero lag/deadzone: no reverse progress
-(`ṡ = v · max(cos e_ψ, 0)`) and geometric projection never rewinds `s`.
+**Lab scale, not city scale.** ARCO city demos use ~14 m/s cruise and a
+5 s horizon; FRET’s warehouse aisles are ≈1.6 m with TurtleBot half-size
+≈0.09 m and cruise ≈0.36 m/s, so `dubins.yml` keeps a 1.2 s horizon
+(`24 × 0.05 s`) matching `update_rate: 20`. Model `dt` must equal the
+control period. Projection never rewinds `s`; curve-limited \(v_s\) caps
+handle corner braking.
 
 ---
 

--- a/docs/modules/control.md
+++ b/docs/modules/control.md
@@ -124,13 +124,13 @@ rate_hz: 50.0
 ```
 
 Dubins MPC / vehicle limits live in `src/fret/config/controllers/dubins.yml`.
-RRT*/SST agents use ARCO `DubinsPathFollowingMPC` with progress-first
-weights (`weight_lag`, `contour_deadzone`) loaded by
-`fret.scenario.dubins_race_runner._mpc_config`. The free lateral band is
-lab-scaled (~chassis half-width), not ARCO city meters — see
-[arco.md](../arco.md#progress-first-contouring-arco147).
-OMX joint-space MPC helpers live in `src/fret/control/joint_mpc.py`
-(unaffected by progress-first contouring).
+RRT*/SST agents use ARCO `DubinsPathFollowingMPC` classical MPCC weights
+(`weight_lag` > 0, linear `weight_progress`, `contour_deadzone: 0`)
+loaded by `fret.scenario.dubins_race_runner._mpc_config`. Lab-scale
+horizon / cruise, not ARCO city meters — see
+[arco.md](../arco.md#classical-mpcc-arco--v037).
+OMX / OMY joint-space MPC helpers live in `src/fret/control/joint_mpc.py`
+and force horizon `dt` to the 50 Hz control period (ARCO ≥ v0.3.7).
 
 ---
 

--- a/docs/robots/dubins.md
+++ b/docs/robots/dubins.md
@@ -37,13 +37,14 @@ Uses ARCO directly:
 | Grey foil tracker | `arco.control.pure_pursuit.PurePursuitController` |
 
 RRT*/SST plan in 2D against warehouse occupancy (topological corridor).
-They then track that polyline with **progress-first** path-following MPC
-(ARCO arco#147): lag weight + lab-scaled contour deadzone (~0.10 m)
-prefer arc-length progress over hugging infeasible planner kinks.
-Track-time occupancy barriers stay off so the MPC does not re-throttle
-on already-cleared corridors; avoidance remains a planner responsibility.
-The grey dummy stays on Pure Pursuit with no repulsion so it collides on
-the naive diagonal. See [arco.md § Progress-first contouring](../arco.md#progress-first-contouring-arco147).
+They then track that polyline with **classical MPCC** (ARCO ≥ v0.3.7):
+structural lag weight, linear progress reward, zero contour deadzone,
+and a lab-scaled 1.2 s horizon whose model `dt` matches the 20 Hz
+control period. Track-time occupancy barriers stay off so the MPC does
+not re-throttle on already-cleared corridors; avoidance remains a
+planner responsibility. The grey dummy stays on Pure Pursuit with no
+repulsion so it collides on the naive diagonal. See
+[arco.md § Classical MPCC](../arco.md#classical-mpcc-arco--v037).
 
 FRET adapter: `fret.control.kinematics_dubins.DubinsKinematics`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ requires-python = ">=3.12"
 dependencies = [
     "numpy>=1.26",
     "pyyaml>=6.0",
-    # Pin includes arco#147 progress-first contouring (weight_lag,
-    # contour_deadzone). Bump to a release tag when ARCO cuts one past v0.3.3.
-    "arco[mpc] @ git+https://github.com/alexandrelheinen/arco.git@5ad245a2f41ae7cdf5ca9fdf77711fc37d8f7500",
+    # ARCO v0.3.7 classical MPCC (linear progress reward, structural lag,
+    # weight_slack removed, JointSpaceMPC step dt must equal config.dt).
+    "arco[mpc] @ git+https://github.com/alexandrelheinen/arco.git@v0.3.7",
 ]
 
 [project.optional-dependencies]

--- a/src/fret/config/controllers/dubins.yml
+++ b/src/fret/config/controllers/dubins.yml
@@ -1,26 +1,24 @@
-# Dubins vehicle + ARCO path-following MPC (RRT*/SST) and Pure Pursuit foil
-# (grey dummy). Showcase runs at 2× nominal Menagerie (ω=13.34 rad/s →
-# v≈0.44 m/s), capped by the race MJCF wheel ctrlrange.
+# Dubins vehicle + ARCO classical path-following MPCC (RRT*/SST) and Pure
+# Pursuit foil (grey dummy). Showcase runs at 2× nominal Menagerie
+# (ω=13.34 rad/s → v≈0.44 m/s), capped by the race MJCF wheel ctrlrange.
 #
 # Planner agents (blue RRT* / green SST):
 #   1) RRT*/SST plan in 2D with full warehouse occupancy → topological
 #      corridor (pass here, then there). That is the obstacle avoidance.
-#   2) DubinsPathFollowingMPC tracks that polyline with progress-first
-#      contouring (ARCO ≥ arco#147): prefer arc-length progress over
-#      zero-fitting stiff planner kinks. Trackers use occupancy=None so
-#      preview-cruise taper / soft barriers cannot throttle on already-
-#      cleared corridors. Safety still sits in the planner path plus the
-#      post-hoc collision monitor in physics mode.
+#   2) DubinsPathFollowingMPC tracks that polyline with classical MPCC
+#      (ARCO ≥ v0.3.7): free virtual progress speed, linear progress
+#      reward, structural lag error, curve-limited v_s cap. Trackers use
+#      occupancy=None so preview-cruise taper / soft barriers cannot
+#      throttle on already-cleared corridors. Safety still sits in the
+#      planner path plus the post-hoc collision monitor in physics mode.
 #   3) Lab-scale weights (aisles ≈1.6 m, chassis half-width ≈0.09 m,
-#      cruise ≈0.36 m/s) — do NOT copy ARCO city meters (8 m deadzone /
-#      14 m/s). Tuned so RRT*/SST finish warehouse bends without stalling
-#      (issue-suggested contour=4/lag=12 stalled SST on showcase seed).
-#      Set contour_deadzone: 0 to restore classic contouring.
-#   4) FRET builds the MPC tracker via ``_build_vehicle_mpc_sim`` so
-#      weight_lag / contour_deadzone survive into the live NLP. ARCO's
-#      ``build_vehicle_mpc_sim`` currently rebuilds PathFollowingMPCConfig
-#      without those fields (silent drop → lag=0), which made SST crawl
-#      (~141 s). With lag preserved, showcase seed finishes ~38 s.
+#      cruise ≈0.36 m/s) — do NOT copy ARCO city meters (14 m/s cruise /
+#      5 s horizon). Keep heading small (~1/10 of contour); lag > 0 is
+#      required (construction rejects lag ≤ 0). contour_deadzone stays
+#      0 — flat lateral bands invite left/right chatter.
+#   4) Model dt must equal the control period (update_rate=20 → 0.05 s).
+#      FRET builds the tracker via ``_build_vehicle_mpc_sim`` so the full
+#      PathFollowingMPCConfig (including lag) reaches the live NLP.
 # The grey dummy keeps Pure Pursuit without repulsion so it collides on
 # the naive diagonal as a foil.
 #
@@ -39,21 +37,20 @@
     curvature_gain: 0.9
     repulsion_gain: 0.0
     update_rate: 20.0
-    # Path-following MPC (progress-first). Physical horizon T=N·dt = 1.2 s
-    # ≈ 0.43 m at cruise (~3× R_min). weight_lag pulls s forward; contour
-    # cost applies only outside contour_deadzone so the tracker may widen
-    # infeasible polyline kinks while arc-length keeps advancing.
+    # Classical MPCC (ARCO v0.3.7). Physical horizon T=N·dt = 1.2 s
+    # ≈ 0.43 m at cruise (~3× R_min). weight_lag couples virtual s to
+    # the vehicle; weight_progress is a linear reward per meter advanced
+    # (v_s hard-capped by curve-limited cruise).
     mpc:
       horizon_step_count: 24
       dt: 0.05
-      weight_contour: 8.0          # excess only (outside deadzone)
-      weight_heading: 4.0
-      weight_progress: 3.0
-      weight_lag: 10.0             # prefer advancing s
-      contour_deadzone: 0.10       # [m] ~chassis half-width scale
+      weight_contour: 10.0
+      weight_heading: 1.0           # keep small; tracking from contour+lag
+      weight_progress: 4.0          # linear reward / m (not v_ref matching)
+      weight_lag: 6.0               # structural; must be > 0
+      contour_deadzone: 0.0         # flats chatter; city keeps 0 too
       weight_control: 0.15
       weight_obstacle: 0.0
       obstacle_barrier_power: 2.0
       weight_terminal: 12.0
-      weight_slack: 1.0
       max_solver_iter_count: 40

--- a/src/fret/config/controllers/open_manipulator_x.yml
+++ b/src/fret/config/controllers/open_manipulator_x.yml
@@ -10,7 +10,8 @@
     update_rate: 50.0
     fault_threshold: 0.020
     ticks_per_waypoint: 5
-    # Carrot-on-path JointSpaceMPC (ARCO v0.3.2) for pick-and-place.
+    # Carrot-on-path JointSpaceMPC (ARCO ≥ v0.3.7) for pick-and-place.
+    # Horizon dt is forced to 1/update_rate (0.02 s) in build_joint_mpc.
     joint_mpc:
       race_speed: 0.9
       max_carrot_lag: 0.30

--- a/src/fret/control/joint_mpc.py
+++ b/src/fret/control/joint_mpc.py
@@ -33,16 +33,25 @@ def _config_with_control_dt(
     *,
     dt: float,
 ) -> JointSpaceMPCConfig:
-    """Return a joint MPC config whose horizon dt matches the control period."""
+    """Align horizon ``dt`` to the control period, preserving physical ``T``.
+
+    ARCO ≥ v0.3.7 requires ``step(dt) == config.dt``. Naively rewriting only
+    ``dt`` (0.05 → 0.02) shrinks the prediction horizon from the ARCO default
+    ``12 × 0.05 = 0.6 s`` to ``12 × 0.02 = 0.24 s``, which jerks the grasp
+    open during LIFT and FAULTs OMX clutter / wall-maze cycles. Scale
+    ``horizon_step_count`` so ``N·dt`` stays the same.
+    """
     cfg = (
         mpc_cfg
         if mpc_cfg is not None
         else JointSpaceMPCConfig.create_from_config()
     )
     ctrl_dt = float(dt)
-    if abs(cfg.dt - ctrl_dt) > 1e-9:
-        return cfg.with_horizon_overrides(dt=ctrl_dt)
-    return cfg
+    if abs(cfg.dt - ctrl_dt) <= 1e-9:
+        return cfg
+    physical_t = float(cfg.horizon_step_count) * float(cfg.dt)
+    steps = max(1, int(round(physical_t / ctrl_dt)))
+    return cfg.with_horizon_overrides(step_count=steps, dt=ctrl_dt)
 
 
 def build_joint_mpc(

--- a/src/fret/control/joint_mpc.py
+++ b/src/fret/control/joint_mpc.py
@@ -1,7 +1,12 @@
 """ARCO JointSpaceMPC helpers for OpenMANIPULATOR-X pick-and-place.
 
 Replaces proportional / Jacobian waypoint tracking with the CasADi carrot
-NMPC from ARCO v0.3.2 (``build_joint_tracker(..., tracker="mpc")``).
+NMPC from ARCO (≥ v0.3.2; ``build_joint_tracker(..., tracker="mpc")``).
+
+ARCO ≥ v0.3.7 requires ``JointSpaceMPC.step(dt)`` to equal
+``config.dt`` (same structural zigzag fix as path-following MPCC). FRET
+SITL arm loops run at 50 Hz (``_CTRL_PERIOD_S = 0.02``), so builders
+default the horizon ``dt`` to that control period.
 """
 
 from __future__ import annotations
@@ -19,6 +24,25 @@ if TYPE_CHECKING:
 _OMX_DOF = 4
 _DEFAULT_MAX_VEL_RAD_S = 1.57
 _DEFAULT_MAX_ACC_RAD_S2 = 3.0
+# Must match fret.control.pick_place_* _CTRL_PERIOD_S (50 Hz).
+_DEFAULT_CTRL_DT_S = 0.02
+
+
+def _config_with_control_dt(
+    mpc_cfg: JointSpaceMPCConfig | None,
+    *,
+    dt: float,
+) -> JointSpaceMPCConfig:
+    """Return a joint MPC config whose horizon dt matches the control period."""
+    cfg = (
+        mpc_cfg
+        if mpc_cfg is not None
+        else JointSpaceMPCConfig.create_from_config()
+    )
+    ctrl_dt = float(dt)
+    if abs(cfg.dt - ctrl_dt) > 1e-9:
+        return cfg.with_horizon_overrides(dt=ctrl_dt)
+    return cfg
 
 
 def build_joint_mpc(
@@ -28,16 +52,28 @@ def build_joint_mpc(
     max_vel: float = _DEFAULT_MAX_VEL_RAD_S,
     max_acc: float = _DEFAULT_MAX_ACC_RAD_S2,
     mpc_cfg: JointSpaceMPCConfig | None = None,
+    dt: float = _DEFAULT_CTRL_DT_S,
 ) -> JointSpaceMPC:
-    """Build a joint-space MPC tracker for ``dof`` arm joints."""
+    """Build a joint-space MPC tracker for ``dof`` arm joints.
+
+    Args:
+        dof: Number of actuated arm joints.
+        occupancy: Optional C-space occupancy for soft barriers.
+        max_vel: Per-joint velocity limit (rad/s).
+        max_acc: Per-joint acceleration limit (rad/s²).
+        mpc_cfg: Optional base config; horizon ``dt`` is forced to *dt*.
+        dt: Control period passed to ``mpc.step`` (s). Must match the
+            caller's step interval (ARCO ≥ v0.3.7 rejects mismatches).
+    """
     max_vel_vec = np.full(int(dof), float(max_vel), dtype=np.float64)
     max_acc_vec = np.full(int(dof), float(max_acc), dtype=np.float64)
+    effective_cfg = _config_with_control_dt(mpc_cfg, dt=dt)
     tracker = build_joint_tracker(
         max_vel=max_vel_vec,
         max_acc=max_acc_vec,
         occupancy=occupancy,
         tracker="mpc",
-        mpc_cfg=mpc_cfg,
+        mpc_cfg=effective_cfg,
     )
     assert isinstance(tracker, JointSpaceMPC)
     return tracker
@@ -49,6 +85,7 @@ def build_omx_joint_mpc(
     max_vel: float = _DEFAULT_MAX_VEL_RAD_S,
     max_acc: float = _DEFAULT_MAX_ACC_RAD_S2,
     mpc_cfg: JointSpaceMPCConfig | None = None,
+    dt: float = _DEFAULT_CTRL_DT_S,
 ) -> JointSpaceMPC:
     """Build a 4-DOF joint-space MPC tracker for OMX."""
     return build_joint_mpc(
@@ -57,6 +94,7 @@ def build_omx_joint_mpc(
         max_vel=max_vel,
         max_acc=max_acc,
         mpc_cfg=mpc_cfg,
+        dt=dt,
     )
 
 

--- a/src/fret/control/pick_place_clutter_sim.py
+++ b/src/fret/control/pick_place_clutter_sim.py
@@ -86,14 +86,13 @@ def _ee_body_name(model: str) -> str:
 def _joint_mpc_config(params: dict[str, Any] | None = None) -> Any | None:
     """Optional JointSpaceMPCConfig with scenario obstacle-weight overrides.
 
-    Horizon ``dt`` is aligned to :data:`_CTRL_PERIOD_S` so ARCO ≥ v0.3.7
-    accepts ``mpc.step(target, _CTRL_PERIOD_S)``.
+    Horizon ``dt`` / step count are aligned in :func:`build_joint_mpc` so
+    ARCO ≥ v0.3.7 accepts ``mpc.step(..., _CTRL_PERIOD_S)`` without
+    shrinking the physical prediction horizon.
     """
     if JointSpaceMPCConfig is None:  # pragma: no cover
         return None
     cfg = JointSpaceMPCConfig.create_from_config()
-    if abs(cfg.dt - _CTRL_PERIOD_S) > 1e-9:
-        cfg = cfg.with_horizon_overrides(dt=_CTRL_PERIOD_S)
     if not params:
         return cfg
     w_obs = params.get("mpc_weight_obstacle")

--- a/src/fret/control/pick_place_clutter_sim.py
+++ b/src/fret/control/pick_place_clutter_sim.py
@@ -84,10 +84,16 @@ def _ee_body_name(model: str) -> str:
 
 
 def _joint_mpc_config(params: dict[str, Any] | None = None) -> Any | None:
-    """Optional JointSpaceMPCConfig with scenario obstacle-weight overrides."""
+    """Optional JointSpaceMPCConfig with scenario obstacle-weight overrides.
+
+    Horizon ``dt`` is aligned to :data:`_CTRL_PERIOD_S` so ARCO ≥ v0.3.7
+    accepts ``mpc.step(target, _CTRL_PERIOD_S)``.
+    """
     if JointSpaceMPCConfig is None:  # pragma: no cover
         return None
     cfg = JointSpaceMPCConfig.create_from_config()
+    if abs(cfg.dt - _CTRL_PERIOD_S) > 1e-9:
+        cfg = cfg.with_horizon_overrides(dt=_CTRL_PERIOD_S)
     if not params:
         return cfg
     w_obs = params.get("mpc_weight_obstacle")

--- a/src/fret/scenario/dubins_race_runner.py
+++ b/src/fret/scenario/dubins_race_runner.py
@@ -631,12 +631,15 @@ def _build_vehicle_mpc_sim(
     *,
     occupancy: Any = None,
 ) -> tuple[Any, MPCTrackingLoop]:
-    """Build Dubins + path-following MPC without dropping progress-first fields.
+    """Build Dubins + classical path-following MPCC for race agents.
 
-    ARCO's ``build_vehicle_mpc_sim`` rebuilds :class:`PathFollowingMPCConfig`
-    and omits ``weight_lag`` / ``contour_deadzone`` (silently → 0). FRET keeps
-    the caller's full config and only overrides ``cruise_speed`` from
-    :class:`VehicleConfig`.
+    Uses ``dataclasses.replace`` so every :class:`PathFollowingMPCConfig`
+    field (including structural ``weight_lag`` / optional
+    ``contour_deadzone``) reaches the live NLP; only ``cruise_speed`` is
+    overridden from :class:`VehicleConfig`. ARCO ≥ v0.3.7's
+    ``build_vehicle_mpc_sim`` does the same, but FRET keeps this local
+    factory so race agents can force ``occupancy=None`` without pulling
+    ARCO city defaults.
     """
     x0, y0 = waypoints[0]
     theta0 = initial_heading(waypoints)
@@ -669,10 +672,11 @@ def _build_vehicle_mpc_sim(
 
 
 def _mpc_config(ctrl: dict[str, Any]) -> PathFollowingMPCConfig:
-    """Load path-following MPC weights; cruise comes from vehicle config.
+    """Load classical MPCC weights; cruise comes from vehicle config.
 
-    Forwards progress-first fields (``weight_lag``, ``contour_deadzone``)
-    from ``ctrl["mpc"]``. Race trackers still pass ``occupancy=None`` at
+    Forwards ARCO v0.3.7 contouring fields (``weight_lag`` must be > 0,
+    optional ``contour_deadzone``) from ``ctrl["mpc"]``. ``weight_slack``
+    was removed upstream. Race trackers still pass ``occupancy=None`` at
     construction — avoidance remains a planner responsibility.
     """
     base = PathFollowingMPCConfig.create_from_config(
@@ -699,7 +703,6 @@ def _mpc_config(ctrl: dict[str, Any]) -> PathFollowingMPCConfig:
         control=_opt_float("weight_control"),
         obstacle=_opt_float("weight_obstacle"),
         terminal=_opt_float("weight_terminal"),
-        slack=_opt_float("weight_slack"),
         contour_deadzone=_opt_float("contour_deadzone"),
     )
     barrier = _opt_float("obstacle_barrier_power")

--- a/tests/control/test_cspace_mpc_occupancy.py
+++ b/tests/control/test_cspace_mpc_occupancy.py
@@ -77,12 +77,15 @@ def test_joint_mpc_barrier_keeps_clearance_from_wall_cspace() -> None:
             break
     assert start is not None
 
+    # ARCO ≥ v0.3.7: step dt must equal config.dt (FRET default 0.02 s).
+    ctrl_dt = 0.02
+    n_steps = 113  # ≈ 2.25 s — same horizon as the former 45 × 0.05 s loop
     mpc_open = build_omx_joint_mpc()
     mpc_open.reset(start)
     q_open = start.copy()
     min_open = 1.0e9
-    for _ in range(45):
-        q_open = np.asarray(mpc_open.step(target, 0.05), dtype=np.float64)
+    for _ in range(n_steps):
+        q_open = np.asarray(mpc_open.step(target, ctrl_dt), dtype=np.float64)
         d, _ = occ.nearest_obstacle(q_open)
         min_open = min(min_open, float(d))
 
@@ -90,8 +93,8 @@ def test_joint_mpc_barrier_keeps_clearance_from_wall_cspace() -> None:
     mpc_safe.reset(start)
     q_safe = start.copy()
     min_safe = 1.0e9
-    for _ in range(45):
-        q_safe = np.asarray(mpc_safe.step(target, 0.05), dtype=np.float64)
+    for _ in range(n_steps):
+        q_safe = np.asarray(mpc_safe.step(target, ctrl_dt), dtype=np.float64)
         d, _ = occ.nearest_obstacle(q_safe)
         min_safe = min(min_safe, float(d))
 

--- a/tests/control/test_joint_mpc.py
+++ b/tests/control/test_joint_mpc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from fret.control.joint_mpc import (
     JointPathMPCTracker,
@@ -11,6 +12,14 @@ from fret.control.joint_mpc import (
     path_pos_at_arc,
 )
 
+_CTRL_DT = 0.02
+
+
+def test_build_omx_joint_mpc_matches_control_period_dt() -> None:
+    """ARCO ≥ v0.3.7 requires step(dt) == config.dt; default is 50 Hz."""
+    mpc = build_omx_joint_mpc()
+    assert abs(mpc.config.dt - _CTRL_DT) < 1e-9
+
 
 def test_build_omx_joint_mpc_tracks_target() -> None:
     mpc = build_omx_joint_mpc()
@@ -18,10 +27,18 @@ def test_build_omx_joint_mpc_tracks_target() -> None:
     target = np.array([0.4, -0.3, 0.2, 0.1], dtype=np.float64)
     mpc.reset(q0)
     q = q0.copy()
-    for _ in range(50):
-        q = np.asarray(mpc.step(target, 0.05), dtype=np.float64)
+    for _ in range(100):
+        q = np.asarray(mpc.step(target, _CTRL_DT), dtype=np.float64)
     assert float(np.linalg.norm(q - target)) < 0.05
     assert mpc.last_solver_success is True
+
+
+def test_joint_mpc_rejects_dt_mismatch() -> None:
+    """Mismatched plant/model dt must raise (ARCO zigzag guard)."""
+    mpc = build_omx_joint_mpc()
+    mpc.reset(np.zeros(4, dtype=np.float64))
+    with pytest.raises(ValueError, match="must equal config.dt"):
+        mpc.step(np.zeros(4, dtype=np.float64), 0.05)
 
 
 def test_path_carrot_tracker_reaches_goal() -> None:
@@ -43,8 +60,8 @@ def test_path_carrot_tracker_reaches_goal() -> None:
         goal_tol=0.12,
     )
     tracker.reset(path[0])
-    for _ in range(80):
-        tracker.step(0.05)
+    for _ in range(200):
+        tracker.step(_CTRL_DT)
         if tracker.complete:
             break
     assert tracker.complete is True

--- a/tests/control/test_joint_mpc.py
+++ b/tests/control/test_joint_mpc.py
@@ -19,6 +19,9 @@ def test_build_omx_joint_mpc_matches_control_period_dt() -> None:
     """ARCO ≥ v0.3.7 requires step(dt) == config.dt; default is 50 Hz."""
     mpc = build_omx_joint_mpc()
     assert abs(mpc.config.dt - _CTRL_DT) < 1e-9
+    # Preserve ARCO's default physical horizon (12 × 0.05 s = 0.6 s).
+    assert mpc.config.horizon_step_count == 30
+    assert abs(mpc.config.horizon_step_count * mpc.config.dt - 0.6) < 1e-9
 
 
 def test_build_omx_joint_mpc_tracks_target() -> None:

--- a/tests/control/test_mpc_obstacle_avoidance.py
+++ b/tests/control/test_mpc_obstacle_avoidance.py
@@ -99,6 +99,9 @@ def test_path_tracker_with_occupancy_avoids_wall_target() -> None:
         target,
     ]
 
+    # ARCO ≥ v0.3.7: step dt must equal config.dt (FRET default 0.02 s).
+    ctrl_dt = 0.02
+    n_steps = 175  # ≈ 3.5 s — same horizon as the former 70 × 0.05 s loop
     open_tracker = JointPathMPCTracker(
         path,
         build_omx_joint_mpc(),
@@ -108,8 +111,8 @@ def test_path_tracker_with_occupancy_avoids_wall_target() -> None:
     )
     open_tracker.reset(start)
     min_open = 1.0e9
-    for _ in range(70):
-        q = open_tracker.step(0.05)
+    for _ in range(n_steps):
+        q = open_tracker.step(ctrl_dt)
         d, _ = occ.nearest_obstacle(q)
         min_open = min(min_open, float(d))
 
@@ -127,8 +130,8 @@ def test_path_tracker_with_occupancy_avoids_wall_target() -> None:
     )
     safe_tracker.reset(start)
     min_safe = 1.0e9
-    for _ in range(70):
-        q = safe_tracker.step(0.05)
+    for _ in range(n_steps):
+        q = safe_tracker.step(ctrl_dt)
         d, _ = occ.nearest_obstacle(q)
         min_safe = min(min_safe, float(d))
 

--- a/tests/scenario/test_dubins_mpc_config.py
+++ b/tests/scenario/test_dubins_mpc_config.py
@@ -1,8 +1,11 @@
-"""Unit tests for Dubins race MPC config wiring (progress-first fields)."""
+"""Unit tests for Dubins race MPC config wiring (classical MPCC fields)."""
 
 from __future__ import annotations
 
 import pathlib
+
+import pytest
+from arco.control.mpc import PathFollowingMPCConfig
 
 from fret.config_loader import load_ros_parameters_yaml
 from fret.scenario.dubins_race_runner import (
@@ -21,23 +24,24 @@ _DUBINS_CTRL = (
 )
 
 
-def test_mpc_config_forwards_progress_first_fields_from_yaml() -> None:
-    """``_mpc_config`` must round-trip weight_lag / contour_deadzone."""
+def test_mpc_config_forwards_mpcc_fields_from_yaml() -> None:
+    """``_mpc_config`` must round-trip classical MPCC weights from YAML."""
     ctrl = load_ros_parameters_yaml(_DUBINS_CTRL)
     cfg = _mpc_config(ctrl)
-    assert cfg.weight_lag == 10.0
-    assert cfg.contour_deadzone == 0.10
-    assert cfg.weight_contour == 8.0
-    assert cfg.weight_heading == 4.0
-    assert cfg.weight_progress == 3.0
+    assert cfg.weight_lag == 6.0
+    assert cfg.contour_deadzone == 0.0
+    assert cfg.weight_contour == 10.0
+    assert cfg.weight_heading == 1.0
+    assert cfg.weight_progress == 4.0
     assert cfg.weight_terminal == 12.0
     assert cfg.horizon_step_count == 24
     assert cfg.dt == 0.05
     assert cfg.cruise_speed == float(ctrl["cruise_speed"])
+    assert not hasattr(cfg, "weight_slack")
 
 
-def test_mpc_config_defaults_progress_first_when_keys_absent() -> None:
-    """Missing lag/deadzone keys must not invent non-default values."""
+def test_mpc_config_defaults_lag_positive_when_keys_absent() -> None:
+    """Missing lag/deadzone keys keep ARCO defaults; lag must stay > 0."""
     ctrl = {
         "cruise_speed": 0.36,
         "mpc": {
@@ -48,12 +52,29 @@ def test_mpc_config_defaults_progress_first_when_keys_absent() -> None:
     cfg = _mpc_config(ctrl)
     assert cfg.horizon_step_count == 10
     assert cfg.weight_contour == 1.0
-    assert cfg.weight_lag == 0.0
+    assert cfg.weight_lag > 0.0
     assert cfg.contour_deadzone == 0.0
 
 
-def test_build_vehicle_mpc_sim_preserves_progress_first_fields() -> None:
-    """Live tracker must keep lag/deadzone (ARCO factory drops them)."""
+def test_zero_lag_rejected_by_arco_mpcc() -> None:
+    """ARCO ≥ v0.3.7 rejects lag ≤ 0 at tracker construction."""
+    from arco.control.mpc import DubinsPathFollowingMPC, DubinsVehicleLimits
+
+    with pytest.raises(ValueError, match="weight_lag"):
+        DubinsPathFollowingMPC(
+            vehicle_limits=DubinsVehicleLimits(
+                max_speed=1.0,
+                min_speed=0.0,
+                max_turn_rate=1.0,
+                max_acceleration=1.0,
+                max_turn_rate_dot=1.0,
+            ),
+            config=PathFollowingMPCConfig(weight_lag=0.0),
+        )
+
+
+def test_build_vehicle_mpc_sim_preserves_mpcc_fields() -> None:
+    """Live tracker must keep lag/deadzone into the NLP config."""
     ctrl = load_ros_parameters_yaml(_DUBINS_CTRL)
     vehicle_cfg = _vehicle_config(ctrl)
     mpc_cfg = _mpc_config(ctrl)
@@ -64,7 +85,7 @@ def test_build_vehicle_mpc_sim_preserves_progress_first_fields() -> None:
         occupancy=None,
     )
     live = loop.tracker.config
-    assert live.weight_lag == mpc_cfg.weight_lag == 10.0
-    assert live.contour_deadzone == mpc_cfg.contour_deadzone == 0.10
+    assert live.weight_lag == mpc_cfg.weight_lag == 6.0
+    assert live.contour_deadzone == mpc_cfg.contour_deadzone == 0.0
     assert live.weight_contour == mpc_cfg.weight_contour
     assert live.cruise_speed == vehicle_cfg.cruise_speed

--- a/tests/scenario/test_dubins_physics_showcase.py
+++ b/tests/scenario/test_dubins_physics_showcase.py
@@ -39,8 +39,9 @@ def test_physics_pose_history_non_negative_clearance() -> None:
     )
     assert result.both_reached_goal is True
     assert result.min_obstacle_clearance_m >= 0.0
-    # Progress-first lag must stay live; without it SST crawls (~141 s) and
-    # the release encode job blows the 10 min budget even with a 30 s clip.
+    # Classical MPCC lag must stay live (ARCO rejects lag ≤ 0). Without a
+    # structural lag coupling, SST crawls and the release encode job blows
+    # the 10 min budget even with a 30 s clip.
     assert result.race_duration_s < 90.0
     assert result.sst_time_to_goal_s is not None
     assert result.sst_time_to_goal_s < 90.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

ARCO [v0.3.7](https://github.com/alexandrelheinen/arco/releases/tag/v0.3.7) reworks path-following as classical contouring MPCC (linear progress reward, structural lag, free \(v_s\)) and hard-requires `JointSpaceMPC.step(dt) == config.dt`. FRET was still pinned to a pre-v0.3.7 progress-first commit and would break on:

1. Removed `weight_slack` kwarg → `TypeError` in `_mpc_config`
2. `weight_lag ≤ 0` rejected at tracker construction
3. Joint MPC called with `dt=0.02` against default `config.dt=0.05`

CI follow-up ([run 31029985480](https://github.com/alexandrelheinen/fret/actions/runs/31029985480/job/92387934733)): OMX clutter / wall-maze cycles FAULTed in **LIFT** (`wall_contact_steps=0`) because matching `dt` to 50 Hz without scaling `N` shrank the prediction horizon from `12×0.05=0.6 s` to `12×0.02=0.24 s`, jerking the grasp open.

## Fix

- Bump `arco[mpc]` pin to `v0.3.7`
- Drop `weight_slack`; retune `dubins.yml` for classical MPCC (lab-scale: contour=10, heading=1, progress=4, lag=6, deadzone=0; model dt stays 0.05 = control period)
- Align `JointSpaceMPC` horizon `dt` to 50 Hz **and** scale `horizon_step_count` so physical `T = N·dt` stays 0.6 s (`30×0.02`)
- Update docs + sibling tests that still stepped at 0.05 s

## Verification

- `bash scripts/check/formatting.sh` — pass
- Focused MPC wiring: `tests/scenario/test_dubins_mpc_config.py` + `tests/control/test_joint_mpc.py` — **pass**
- CI-failing pick-place suite (desk clutter + wall maze ×3 planners) — **9 passed** locally after horizon scale
- Dubins e2e + physics showcase (seed 11): both agents finish (~52–54 s, clearance 0.35 m)
- `types.sh` still reports 3 **pre-existing** mypy errors in untouched files; no new errors from this change

## Recurrence

Prior FRET workaround preserved `weight_lag` / `contour_deadzone` because ARCO’s factory dropped them; v0.3.7 fixed that upstream. Matching control-period `dt` alone is insufficient — ARCO’s own tracking note says tune duration via `step_count` when `dt` changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c5a5a91-8c9c-4eba-9e9c-76ebc48350ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c5a5a91-8c9c-4eba-9e9c-76ebc48350ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

