### PR TITLE
fix(mjcf): stop silent arm clipping through walls, bin, and vision gate

### DIFF
--- a/scripts/diagnose_wall_maze_contacts.py
+++ b/scripts/diagnose_wall_maze_contacts.py
@@ -10,7 +10,12 @@ Classifies contacts as:
 
 Pinned finding (seed 204, contype=5): plan/track clear; FSM FAULT with
 ``transfer_wall_stem`` ↔ ``gripper_left`` palm (geom 51, bit 4) near
-EE ≈ (0.13, −0.10, 0.23) — pick-side Γ during lift/early MOVE_PLACE.
+EE ≈ (0.13, −0.10, 0.23) — pick-side Γ during early MOVE_PLACE when the
+path was still planned from ``pick_hover``.
+
+Resolution: plan from ``lift_hover``, require zero-hit MPC dry-run on Γ
+paths, densify C-space barriers; acceptance = DONE with wall_contact_steps=0.
+
 
 Usage::
 

--- a/scripts/diagnose_wall_maze_contacts.py
+++ b/scripts/diagnose_wall_maze_contacts.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Pin OMX wall-maze wall-contact failure mode after full-arm contype=5.
+
+Writes JSON (+ optional PNG) under ``/opt/cursor/artifacts/wall_maze_diag/``.
+
+Classifies contacts as:
+  - plan_mesh: static mj_forward contacts on dense planned waypoints
+  - track: contacts during JointSpaceMPC dry-run of that path
+  - fsm_only_contacts: plan+track clear, but full FSM still hits walls
+
+Pinned finding (seed 204, contype=5): plan/track clear; FSM FAULT with
+``transfer_wall_stem`` ↔ ``gripper_left`` palm (geom 51, bit 4) near
+EE ≈ (0.13, −0.10, 0.23) — pick-side Γ during lift/early MOVE_PLACE.
+
+Usage::
+
+    PYTHONPATH=src python3 scripts/diagnose_wall_maze_contacts.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_REPO = Path(__file__).resolve().parents[1]
+_OUT = Path("/opt/cursor/artifacts/wall_maze_diag")
+
+
+def _geom_name(mj: Any, model: Any, gid: int) -> str:
+    return mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, gid) or f"geom_{gid}"
+
+
+def _wall_contacts(mj: Any, model: Any, data: Any) -> list[tuple[str, str]]:
+    hits: list[tuple[str, str]] = []
+    for ci in range(data.ncon):
+        c = data.contact[ci]
+        g1 = _geom_name(mj, model, c.geom1)
+        g2 = _geom_name(mj, model, c.geom2)
+        if g1.startswith("transfer_wall") or g2.startswith("transfer_wall"):
+            hits.append((g1, g2))
+    return hits
+
+
+def _ee_xyz(mj: Any, model: Any, data: Any) -> list[float]:
+    bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "link5")
+    if bid < 0:
+        bid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_BODY, "gripper_left")
+    return [float(x) for x in data.xpos[bid]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario",
+        default="src/fret/config/scenarios/omx_wall_maze.yml",
+    )
+    parser.add_argument(
+        "--fsm", action="store_true", help="Run full FSM cycle"
+    )
+    parser.add_argument(
+        "--duration-s", type=float, default=55.0, help="FSM duration"
+    )
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(_REPO / "src"))
+
+    import mujoco as mj
+
+    from fret.control.kinematics import Kinematics
+    from fret.control.pick_place_clutter_sim import (
+        _barrier_occupancy_for_scenario,
+        _dry_run_transfer,
+        _path_clear_of_wall_meshes,
+        plan_transfer_path,
+        run_pick_place_clutter,
+    )
+    from fret.control.pick_place_sim import waypoints_from_scenario
+    from fret.sitl_config import load_scenario_parameters, mjcf_path
+
+    scenario = Path(args.scenario)
+    params = load_scenario_parameters(scenario)
+    wp = waypoints_from_scenario(scenario)
+    kin = Kinematics("open_manipulator_x")
+
+    report: dict[str, Any] = {
+        "scenario": str(scenario),
+        "planner_rng_seed": int(params.get("planner_rng_seed", -1)),
+        "wall_inflate_m": float(params.get("wall_inflate_m", 0.0)),
+        "mpc_cspace_clearance_rad": float(
+            params.get("mpc_cspace_clearance_rad", 0.0)
+        ),
+        "mpc_weight_obstacle": float(params.get("mpc_weight_obstacle", 0.0)),
+    }
+
+    # --- Plan ---
+    try:
+        path, straight = plan_transfer_path(
+            wp.pick_hover, wp.place_hover, scenario_path=scenario
+        )
+        report["plan_ok"] = True
+        report["straight_collides"] = bool(straight)
+        report["path_len"] = len(path)
+    except Exception as exc:  # noqa: BLE001 — diagnostic surface
+        report["plan_ok"] = False
+        report["plan_error"] = f"{type(exc).__name__}: {exc}"
+        _OUT.mkdir(parents=True, exist_ok=True)
+        (_OUT / "report.json").write_text(
+            json.dumps(report, indent=2), encoding="utf-8"
+        )
+        print(json.dumps(report, indent=2))
+        return 1
+
+    ee = np.array(
+        [kin.forward_kinematics(q)[:3, 3] for q in path], dtype=np.float64
+    )
+    report["path_ee_min_r"] = float(np.min(np.linalg.norm(ee[:, :2], axis=1)))
+    report["path_ee_min_z"] = float(np.min(ee[:, 2]))
+    report["path_ee_peak_z"] = float(np.max(ee[:, 2]))
+
+    # --- Static mesh contacts on planned waypoints ---
+    xml = mjcf_path("open_manipulator_x", "omx_wall_maze")
+    model = mj.MjModel.from_xml_path(str(xml))
+    data = mj.MjData(model)
+    names = ("Joint1", "Joint2", "Joint3", "Joint4")
+    qadrs = [
+        int(model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, n)])
+        for n in names
+    ]
+    box_jid = mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, "pick_box_joint")
+    data.qpos[
+        int(model.jnt_qposadr[box_jid]) : int(model.jnt_qposadr[box_jid]) + 3
+    ] = [
+        0.5,
+        0.5,
+        0.5,
+    ]
+    plan_hits: list[dict[str, Any]] = []
+    pair_counts: Counter[str] = Counter()
+    stride = max(1, len(path) // 50)
+    for idx, q in enumerate(path[::stride]):
+        for i, adr in enumerate(qadrs):
+            data.qpos[adr] = float(q[i])
+        data.qvel[:] = 0.0
+        mj.mj_forward(model, data)
+        hits = _wall_contacts(mj, model, data)
+        if hits:
+            for a, b in hits:
+                pair_counts[f"{a}|{b}"] += 1
+            plan_hits.append(
+                {
+                    "waypoint_index": int(idx * stride),
+                    "q": [float(x) for x in q],
+                    "ee": _ee_xyz(mj, model, data),
+                    "pairs": hits,
+                }
+            )
+    report["plan_mesh_clear"] = _path_clear_of_wall_meshes(
+        path, scenario_id="omx_wall_maze"
+    )
+    report["plan_mesh_contact_waypoints"] = len(plan_hits)
+    report["plan_mesh_pair_counts"] = dict(pair_counts.most_common(20))
+    report["plan_mesh_first_hits"] = plan_hits[:5]
+
+    # --- MPC dry-run tracking ---
+    mpc_occ = _barrier_occupancy_for_scenario(
+        params,
+        robot_model="open_manipulator_x",
+        scenario_id="omx_wall_maze",
+        seed=int(params.get("planner_rng_seed", 7)),
+    )
+    track_ok = _dry_run_transfer(
+        path,
+        wp.pick_hover,
+        wp.place_hover,
+        joint_tol_rad=0.12,
+        scenario_id="omx_wall_maze",
+        robot_model="open_manipulator_x",
+        occupancy=mpc_occ,
+        params=params,
+    )
+    report["track_dry_run_ok"] = bool(track_ok)
+
+    # Instrumented dry-run contact log (same tracker as sim).
+    from fret.control.joint_mpc import JointPathMPCTracker
+    from fret.control.pick_place_clutter_sim import _joint_mpc_for_model
+
+    model = mj.MjModel.from_xml_path(str(xml))
+    data = mj.MjData(model)
+    data.qpos[
+        int(model.jnt_qposadr[box_jid]) : int(model.jnt_qposadr[box_jid]) + 3
+    ] = [
+        0.5,
+        0.5,
+        0.5,
+    ]
+    for i, n in enumerate(names):
+        data.qpos[
+            model.jnt_qposadr[mj.mj_name2id(model, mj.mjtObj.mjOBJ_JOINT, n)]
+        ] = float(wp.pick_hover[i])
+    data.qvel[:] = 0.0
+    mj.mj_forward(model, data)
+    mpc = _joint_mpc_for_model(
+        "open_manipulator_x", occupancy=mpc_occ, params=params
+    )
+    tracker = JointPathMPCTracker(
+        path,
+        mpc,
+        race_speed=1.2,
+        max_carrot_lag=0.40,
+        goal_tol=0.12,
+    )
+    tracker.reset(wp.pick_hover.copy())
+    track_events: list[dict[str, Any]] = []
+    track_pairs: Counter[str] = Counter()
+    dt = float(model.opt.timestep)
+    ctrl_period = 0.02
+    accum = 0.0
+    q_cmd = wp.pick_hover.copy()
+    for step in range(int(12.0 / dt)):
+        accum += dt
+        if accum >= ctrl_period:
+            accum -= ctrl_period
+            if not tracker.complete:
+                q_cmd = tracker.step(ctrl_period)
+        for i, n in enumerate(names):
+            data.ctrl[mj.mj_name2id(model, mj.mjtObj.mjOBJ_ACTUATOR, n)] = (
+                float(q_cmd[i])
+            )
+        mj.mj_step(model, data)
+        hits = _wall_contacts(mj, model, data)
+        if hits:
+            for a, b in hits:
+                track_pairs[f"{a}|{b}"] += 1
+            if len(track_events) < 40:
+                track_events.append(
+                    {
+                        "t_s": float(step * dt),
+                        "ee": _ee_xyz(mj, model, data),
+                        "pairs": hits,
+                    }
+                )
+        if tracker.complete and step * dt > 2.0:
+            break
+    report["track_contact_events"] = len(track_events)
+    report["track_pair_counts"] = dict(track_pairs.most_common(20))
+    report["track_first_events"] = track_events[:8]
+
+    # Classification
+    if report["plan_mesh_contact_waypoints"] > 0:
+        kind = "bad_plan_mesh"
+    elif report["track_contact_events"] > 0:
+        kind = "good_plan_bad_tracking"
+    else:
+        kind = "plan_and_track_clear"
+    report["failure_class"] = kind
+
+    if args.fsm:
+        # Instrument FSM: record phase + geom pairs on every wall contact tick.
+        import fret.control.pick_place_clutter_sim as _clutter
+
+        fsm_events: list[dict[str, Any]] = []
+        fsm_pairs: Counter[str] = Counter()
+        fsm_phases: Counter[str] = Counter()
+        _orig = _clutter.arm_contacts_transfer_wall
+
+        def _wrapped(mj_: Any, model_: Any, data_: Any) -> bool:
+            hit = _orig(mj_, model_, data_)
+            if hit and len(fsm_events) < 80:
+                # Best-effort phase from FSM if present on the stack caller.
+                phase = "?"
+                pairs = _wall_contacts(mj_, model_, data_)
+                for a, b in pairs:
+                    fsm_pairs[f"{a}|{b}"] += 1
+                fsm_events.append(
+                    {
+                        "ee": _ee_xyz(mj_, model_, data_),
+                        "pairs": pairs,
+                        "phase": phase,
+                    }
+                )
+            if hit:
+                fsm_phases["contact_ticks"] += 1
+            return hit
+
+        _clutter.arm_contacts_transfer_wall = _wrapped  # type: ignore[assignment]
+        try:
+            result = run_pick_place_clutter(
+                duration_s=float(args.duration_s),
+                scenario_path=scenario,
+                max_attempts=3,
+            )
+            report["fsm_state"] = result.state.name
+            report["fsm_wall_contact_steps"] = int(result.wall_contact_steps)
+            report["fsm_faulted_on_wall"] = bool(
+                result.faulted_on_wall_contact
+            )
+        except RuntimeError as exc:
+            report["fsm_error"] = str(exc)
+            report["fsm_state"] = "ERROR"
+            report["fsm_wall_contact_steps"] = -1
+            report["fsm_faulted_on_wall"] = True
+        finally:
+            _clutter.arm_contacts_transfer_wall = _orig  # type: ignore[assignment]
+        report["fsm_contact_pair_counts"] = dict(fsm_pairs.most_common(20))
+        report["fsm_contact_events"] = fsm_events[:20]
+        report["fsm_contact_ticks_logged"] = int(fsm_phases["contact_ticks"])
+        if (
+            report.get("plan_mesh_contact_waypoints", 0) == 0
+            and report.get("track_contact_events", 0) == 0
+        ):
+            if int(
+                report.get("fsm_wall_contact_steps", 0) or 0
+            ) > 0 or report.get("fsm_faulted_on_wall"):
+                report["failure_class"] = "fsm_only_contacts"
+                kind = "fsm_only_contacts"
+
+    _OUT.mkdir(parents=True, exist_ok=True)
+    (_OUT / "report.json").write_text(
+        json.dumps(report, indent=2), encoding="utf-8"
+    )
+    # Lightweight EE path dump for charts
+    np.save(_OUT / "path_ee.npy", ee)
+    print(json.dumps(report, indent=2))
+    print(f"wrote {_OUT / 'report.json'}", file=sys.stderr)
+    return 0 if kind == "plan_and_track_clear" and report.get("plan_ok") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regen_cell_layout_v14.py
+++ b/scripts/regen_cell_layout_v14.py
@@ -65,28 +65,28 @@ def gate_body_xml(
     <body name="vision_gate" pos="{x:.5f} 0 0">
       <geom name="gate_post_l" type="box" size="{bar:.4f} {bar:.4f} {post_h:.4f}"
             pos="0 {half_y:.5f} {post_h:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="{bar:.4f} {bar:.4f} {post_h:.4f}"
             pos="0 {-half_y:.5f} {post_h:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="{bar:.4f} {half_y + bar:.5f} {bar:.4f}"
             pos="0 0 {z_top:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="{bar:.4f} {half_y + bar:.5f} {bar:.4f}"
             pos="0 0 {2.0 * bar:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="{0.7 * bar:.4f} {brace_len:.5f} {0.7 * bar:.4f}"
             pos="0 0 {0.5 * z_top:.5f}" quat="{q_a}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="{0.7 * bar:.4f} {brace_len:.5f} {0.7 * bar:.4f}"
             pos="0 0 {0.5 * z_top:.5f}" quat="{q_b}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 {half_y:.5f} {z_top - 0.02:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 {-half_y:.5f} {z_top - 0.02:.5f}" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 {half_y:.5f} {z_top - 0.02:.5f}"
               xyaxes="{xy_l}" fovy="{fovy:.1f}"/>
       <camera name="gate_cam_right" pos="0.04 {-half_y:.5f} {z_top - 0.02:.5f}"

--- a/scripts/rewrite_place_bin_scenes.py
+++ b/scripts/rewrite_place_bin_scenes.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Replace AWS mop-bucket place mesh with a single open square bin.
 
-Walls/bottom use ``contype=1`` (proximal arm bit only): the arm cannot
-clip through the receptacle, while distal pads/wrist (bit 4) stay free for
-a top-down drop. The ball does **not** hit the visual walls (avoids rim
-perching); catch is the invisible tip-down ``funnel_w*`` (bit 2). Planner
-place-shell occupancy remains for transfer detours.
+Walls/bottom use ``contype=5`` (bits 1|4): proximal arm **and** distal
+pads/wrist collide with the receptacle — no silent gripper clipping.
+The ball (bits 2|4|8) also contacts the shell. Catch assist remains the
+invisible tip-down ``funnel_w*`` (bit 2). Planner place-shell occupancy
+remains for transfer detours. Drop from above the rim.
 """
 
 from __future__ import annotations
@@ -107,29 +107,29 @@ def _bin_block(
     bot_h = min(0.004, 0.25 * t)
     lines = [
         "    <!-- Place bin: open square receptacle.",
-        "         Walls/bottom contype=1: proximal arm only (no ball rim perch).",
-        "         Distal pads/wrist (bit 4) free for top-down drop.",
-        "         Ball catch = invisible funnel_w* (bit 2). -->",
+        "         Walls/bottom contype=5: proximal (1) + distal/pads (4);",
+        "         ball also contacts the shell (no clipping). Drop from",
+        "         above the rim. Ball catch assist = funnel_w* (bit 2). -->",
         f'    <geom name="place_bin_bottom" type="box" '
         f'pos="{cx:.5f} {cy:.5f} {0.5 * bot_h:.5f}" '
         f'size="{inner:.5f} {inner:.5f} {0.5 * bot_h:.5f}" '
-        f'material="place_bin" contype="1" conaffinity="1"/>',
+        f'material="place_bin" contype="5" conaffinity="5"/>',
         f'    <geom name="place_bin_wall_px" type="box" '
         f'pos="{cx + inner + 0.5 * t:.5f} {cy:.5f} {z_c:.5f}" '
         f'size="{0.5 * t:.5f} {outer:.5f} {hz:.5f}" '
-        f'material="place_bin" contype="1" conaffinity="1"/>',
+        f'material="place_bin" contype="5" conaffinity="5"/>',
         f'    <geom name="place_bin_wall_nx" type="box" '
         f'pos="{cx - inner - 0.5 * t:.5f} {cy:.5f} {z_c:.5f}" '
         f'size="{0.5 * t:.5f} {outer:.5f} {hz:.5f}" '
-        f'material="place_bin" contype="1" conaffinity="1"/>',
+        f'material="place_bin" contype="5" conaffinity="5"/>',
         f'    <geom name="place_bin_wall_py" type="box" '
         f'pos="{cx:.5f} {cy + inner + 0.5 * t:.5f} {z_c:.5f}" '
         f'size="{inner:.5f} {0.5 * t:.5f} {hz:.5f}" '
-        f'material="place_bin" contype="1" conaffinity="1"/>',
+        f'material="place_bin" contype="5" conaffinity="5"/>',
         f'    <geom name="place_bin_wall_ny" type="box" '
         f'pos="{cx:.5f} {cy - inner - 0.5 * t:.5f} {z_c:.5f}" '
         f'size="{inner:.5f} {0.5 * t:.5f} {hz:.5f}" '
-        f'material="place_bin" contype="1" conaffinity="1"/>',
+        f'material="place_bin" contype="5" conaffinity="5"/>',
         *funnel_lines,
     ]
     return "\n".join(lines) + "\n"
@@ -178,7 +178,8 @@ def _patch_header(text: str, radius: float, height: float) -> str:
     )
     _BITS_NEW = (
         "Contact bits: arm=1, catcher=2, pads/distal=4, floor=1|8.\n"
-        "         Ball=2|4|8; place_bin contype=1 hits proximal arm only."
+        "         Ball=2|4|8; place_bin/walls/gate contype=5 "
+        "(bits 1|4) hit full arm."
     )
     for old in (
         "Contact bits: arm=1, place-bin=3 (arm|catcher), pads=4, floor=1|8.\n"

--- a/src/fret/config/scenarios/omx_wall_maze.yml
+++ b/src/fret/config/scenarios/omx_wall_maze.yml
@@ -55,7 +55,8 @@
         y_max: 0.24
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.03
+    # Palm (bit 4) now collides with Γ stems; keep a thicker planning shell.
+    wall_inflate_m: 0.035
     # JointSpaceMPC soft barriers (C-space KDTree of wall-contact configs).
     mpc_cspace_clearance_rad: 0.28
     mpc_cspace_samples: 14000

--- a/src/fret/config/scenarios/omx_wall_maze.yml
+++ b/src/fret/config/scenarios/omx_wall_maze.yml
@@ -58,10 +58,11 @@
     # Palm (bit 4) now collides with Γ stems; keep a thicker planning shell.
     wall_inflate_m: 0.035
     # JointSpaceMPC soft barriers (C-space KDTree of wall-contact configs).
-    mpc_cspace_clearance_rad: 0.28
-    mpc_cspace_samples: 14000
+    # Sample denser after contype=5 so palm/bit-4 collisions populate the tree.
+    mpc_cspace_clearance_rad: 0.30
+    mpc_cspace_samples: 18000
     # Stronger than ARCO default (60) so carrot cuts cannot ignore walls.
-    mpc_weight_obstacle: 120.0
+    mpc_weight_obstacle: 140.0
     # Sticky FAULT if arm↔transfer_wall contact persists (showcase honesty).
     fault_on_wall_contact: true
     wall_contact_fault_steps: 5

--- a/src/fret/config/scenarios/omx_wall_maze_rrt.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_rrt.yml
@@ -53,9 +53,9 @@
         z_max: 0.265
     wall_inflate_m: 0.035
     # Must match omx_wall_maze.yml — release variants are full YAML copies.
-    mpc_cspace_clearance_rad: 0.28
-    mpc_cspace_samples: 14000
-    mpc_weight_obstacle: 120.0
+    mpc_cspace_clearance_rad: 0.30
+    mpc_cspace_samples: 18000
+    mpc_weight_obstacle: 140.0
     fault_on_wall_contact: true
     wall_contact_fault_steps: 5
 

--- a/src/fret/config/scenarios/omx_wall_maze_rrt.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_rrt.yml
@@ -51,7 +51,7 @@
         y_max: 0.24
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.03
+    wall_inflate_m: 0.035
     # Must match omx_wall_maze.yml — release variants are full YAML copies.
     mpc_cspace_clearance_rad: 0.28
     mpc_cspace_samples: 14000

--- a/src/fret/config/scenarios/omx_wall_maze_sst.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_sst.yml
@@ -53,9 +53,9 @@
         z_max: 0.265
     wall_inflate_m: 0.035
     # Must match omx_wall_maze.yml — release variants are full YAML copies.
-    mpc_cspace_clearance_rad: 0.28
-    mpc_cspace_samples: 14000
-    mpc_weight_obstacle: 120.0
+    mpc_cspace_clearance_rad: 0.30
+    mpc_cspace_samples: 18000
+    mpc_weight_obstacle: 140.0
     fault_on_wall_contact: true
     wall_contact_fault_steps: 5
 

--- a/src/fret/config/scenarios/omx_wall_maze_sst.yml
+++ b/src/fret/config/scenarios/omx_wall_maze_sst.yml
@@ -51,7 +51,7 @@
         y_max: 0.24
         z_min: 0.225
         z_max: 0.265
-    wall_inflate_m: 0.03
+    wall_inflate_m: 0.035
     # Must match omx_wall_maze.yml — release variants are full YAML copies.
     mpc_cspace_clearance_rad: 0.28
     mpc_cspace_samples: 14000

--- a/src/fret/control/cspace_mpc_occupancy.py
+++ b/src/fret/control/cspace_mpc_occupancy.py
@@ -106,7 +106,12 @@ def mujoco_wall_occupied_predicate(
     joint_names: tuple[str, ...] = ("Joint1", "Joint2", "Joint3", "Joint4"),
     wall_prefix: str | tuple[str, ...] = "transfer_wall",
 ) -> Callable[[npt.NDArray[np.float64]], bool]:
-    """Return ``is_occupied(q)`` using MuJoCo contacts with wall geoms."""
+    """Return ``is_occupied(q)`` using MuJoCo contacts with wall geoms.
+
+    With scene obstacles on contype=5 (bits 1|4), palm/distal meshes (bit 4)
+    contribute colliding samples — barriers cover the gripper, not only the
+    proximal arm.
+    """
     import mujoco as mj
 
     prefixes = (

--- a/src/fret/control/pick_place_clutter_sim.py
+++ b/src/fret/control/pick_place_clutter_sim.py
@@ -298,8 +298,15 @@ def _dry_run_transfer(
     robot_model: str = "open_manipulator_x",
     occupancy: Any | None = None,
     params: dict[str, Any] | None = None,
+    mpc: Any | None = None,
+    max_wall_hits: int | None = None,
 ) -> bool:
-    """Return True if joint-space MPC tracking reaches ``goal`` without wall jams."""
+    """Return True if joint-space MPC tracking reaches ``goal`` without wall jams.
+
+    ``max_wall_hits`` defaults to 0 for Γ-maze scenarios (``peak`` transfer)
+    and 40 for open clutter cells (legacy soft brush tolerance). Pass a
+    pre-built ``mpc`` to avoid rebuilding CasADi on every planner attempt.
+    """
     try:
         import mujoco as mj
     except ImportError:  # pragma: no cover
@@ -320,6 +327,16 @@ def _dry_run_transfer(
 
     is_omy = robot_model in _OMY_MODELS
     grip_settle = OMY_GRIPPER_CLOSED if is_omy else GRIPPER_CLOSED
+    hit_budget = (
+        int(max_wall_hits)
+        if max_wall_hits is not None
+        else (
+            0
+            if params is not None
+            and float(params.get("min_transfer_peak_ee_z_m", 0.0)) > 0.0
+            else 40
+        )
+    )
 
     def settle(cmd: npt.NDArray[np.float64], steps: int) -> None:
         for _ in range(steps):
@@ -335,10 +352,13 @@ def _dry_run_transfer(
         if is_omy
         else np.array([0.0, -1.05, 0.7, 0.7], dtype=np.float64)
     )
-    settle(idle, 300)
-    settle(start, 700)
+    settle(idle, 200)
+    settle(start, 400)
 
-    mpc = _joint_mpc_for_model(robot_model, occupancy=occupancy, params=params)
+    if mpc is None:
+        mpc = _joint_mpc_for_model(
+            robot_model, occupancy=occupancy, params=params
+        )
     if occupancy is not None:
         _require_mpc_occupancy(mpc, context="_dry_run_transfer")
     tracker = JointPathMPCTracker(
@@ -375,6 +395,8 @@ def _dry_run_transfer(
             g2 = mj.mj_id2name(model, mj.mjtObj.mjOBJ_GEOM, c.geom2)
             if _is_wall_geom(g1) or _is_wall_geom(g2):
                 hits += 1
+                if hits > hit_budget:
+                    return False
         if tracker.complete:
             settle_after_complete += 1
             q = np.array(
@@ -405,9 +427,7 @@ def _dry_run_transfer(
         ],
         dtype=np.float64,
     )
-    # Soft contacts while brushing inflated padding are tolerated; sustained
-    # wall jams (MPC cutting the chord through a slab) are not.
-    return float(np.linalg.norm(q - goal)) < 0.15 and hits < 40
+    return float(np.linalg.norm(q - goal)) < 0.15 and hits <= hit_budget
 
 
 def plan_transfer_path(
@@ -463,6 +483,12 @@ def plan_transfer_path(
         scenario_id=scenario_id,
         seed=seed0,
     )
+    # Reuse one CasADi MPC across dry-run attempts (rebuild is multi-second).
+    dry_run_mpc = (
+        _joint_mpc_for_model(robot_model, occupancy=mpc_occ, params=params)
+        if validate_mujoco
+        else None
+    )
 
     from fret.scenario.planner_rng import deterministic_planner_rng
 
@@ -516,8 +542,23 @@ def plan_transfer_path(
             )
             continue
         if validate_mujoco and peak_z > 0.0:
+            # Γ maze: static mesh clear is necessary but not sufficient —
+            # also dry-run JointSpaceMPC tracking from ``start`` (lift pose).
             if not _path_clear_of_wall_meshes(dense, scenario_id=scenario_id):
                 last_err = "mujoco wall-mesh contact on path"
+                continue
+            if not _dry_run_transfer(
+                dense,
+                start,
+                goal,
+                joint_tol_rad=0.12,
+                scenario_id=scenario_id,
+                robot_model=robot_model,
+                occupancy=mpc_occ,
+                params=params,
+                mpc=dry_run_mpc,
+            ):
+                last_err = "mujoco dry-run rejected"
                 continue
         elif validate_mujoco and not _dry_run_transfer(
             dense,
@@ -528,6 +569,7 @@ def plan_transfer_path(
             robot_model=robot_model,
             occupancy=mpc_occ,
             params=params,
+            mpc=dry_run_mpc,
         ):
             last_err = "mujoco dry-run rejected"
             continue
@@ -616,11 +658,10 @@ def simulate_pick_place_clutter(
     act_ar = _actuator_id(mj, model, "grip_right")
     is_omy = robot_model in _OMY_MODELS
 
-    # OMY transfers from the post-grasp lift pose (pad-mid carry above floor ball).
+    # Transfer starts after LIFT: plan from lift_hover so the tracked path
+    # matches the FSM's MOVE_PLACE entry pose (palms clear of the pick-side Γ).
     transfer_start = (
-        wp.lift_hover
-        if is_omy and wp.lift_hover is not None
-        else wp.pick_hover
+        wp.lift_hover if wp.lift_hover is not None else wp.pick_hover
     )
     if is_omy:
         # Shared arm planner (detour YAML + RRT*/SST) — same module OMX clutter

--- a/src/fret/mjcf/omx.py
+++ b/src/fret/mjcf/omx.py
@@ -126,8 +126,9 @@ _FLOOR_PICK_SCENES: frozenset[str] = frozenset(
 def _enable_floor_pick_contacts(robot_xml: str) -> str:
     """Remap palm collision bits for floor-ball grasp (all OM-X pick cells).
 
-    Palms match pad bit 4 so the STL does not fight the plane while closing
-    on a table-resting ball (pick-place, desk clutter, Γ maze).
+    Palms match pad bit 4 so the STL does not fight the floor (bit 1|8) while
+    closing on a table-resting ball. Scene obstacles use contype=5 (1|4) so
+    palms still collide with Γ walls / place bin / vision gate.
     """
     robot_xml = robot_xml.replace(
         '<geom mesh="gripper_left_palm" class="collision"/>',

--- a/src/fret/mjcf/omx_desk_clutter.xml
+++ b/src/fret/mjcf/omx_desk_clutter.xml
@@ -45,19 +45,19 @@
     <!-- Mid-chord wall in EE workspace (blocks pick −Y → front place). -->
     <geom name="transfer_wall" type="box" pos="0.270 -0.100 0.11" size="0.040 0.010 0.11"
           material="transfer_wall" friction="1.0 0.1 0.01"
-          contype="1" conaffinity="1"/>
+          contype="5" conaffinity="5"/>
 
     <!-- Ø 40 mm tennis-like ball on the floor (grippy felt). -->
 
     <!-- Place bin: open square receptacle.
-         Walls/bottom contype=1: proximal arm only (no ball rim perch).
-         Distal pads/wrist (bit 4) free for top-down drop.
-         Ball catch = invisible funnel_w* (bit 2). -->
-    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
+         Walls/bottom contype=5: proximal (1) + distal/pads (4); ball also
+         contacts the shell (no clipping). Drop from above the rim.
+         Ball catch assist = invisible funnel_w* (bit 2). -->
+    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
     <geom name="funnel_w0" type="box" size="0.00250 0.00757 0.05501" pos="0.28800 0.00000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w1" type="box" size="0.00250 0.00757 0.05501" pos="0.28730 0.00623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w2" type="box" size="0.00250 0.00757 0.05501" pos="0.28523 0.01215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
@@ -109,28 +109,28 @@
     <body name="vision_gate" pos="-0.16000 0 0">
       <geom name="gate_post_l" type="box" size="0.0120 0.0120 0.3600"
             pos="0 0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="0.0120 0.0120 0.3600"
             pos="0 -0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.72000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.02400" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 -0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 -0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 0.30000 0.70000"
               xyaxes="-0.745241 -0.666795 0.000000 0.514999 -0.575587 0.635198" fovy="42.0"/>
       <camera name="gate_cam_right" pos="0.04 -0.30000 0.70000"

--- a/src/fret/mjcf/omx_pick_place.xml
+++ b/src/fret/mjcf/omx_pick_place.xml
@@ -36,7 +36,7 @@
     <light name="key" pos="0.8 0.5 1.4" dir="0 0 -1" directional="true"
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
     <!-- Contact bits: arm=1, catcher=2, pads/distal=4, floor=1|8.
-         Ball=2|4|8; place_bin contype=1 hits proximal arm only. -->
+         Ball=2|4|8; place_bin/walls/gate contype=5 (bits 1|4) hit full arm. -->
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 
@@ -45,14 +45,14 @@
     <!-- Ø 40 mm tennis-like ball on the floor (grippy felt). -->
 
     <!-- Place bin: open square receptacle.
-         Walls/bottom contype=1: proximal arm only (no ball rim perch).
-         Distal pads/wrist (bit 4) free for top-down drop.
-         Ball catch = invisible funnel_w* (bit 2). -->
-    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
+         Walls/bottom contype=5: proximal (1) + distal/pads (4); ball also
+         contacts the shell (no clipping). Drop from above the rim.
+         Ball catch assist = invisible funnel_w* (bit 2). -->
+    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
     <geom name="funnel_w0" type="box" size="0.00250 0.00757 0.05501" pos="0.28800 0.00000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w1" type="box" size="0.00250 0.00757 0.05501" pos="0.28730 0.00623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w2" type="box" size="0.00250 0.00757 0.05501" pos="0.28523 0.01215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
@@ -104,28 +104,28 @@
     <body name="vision_gate" pos="-0.16000 0 0">
       <geom name="gate_post_l" type="box" size="0.0120 0.0120 0.3600"
             pos="0 0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="0.0120 0.0120 0.3600"
             pos="0 -0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.72000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.02400" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 -0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 -0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 0.30000 0.70000"
               xyaxes="-0.745241 -0.666795 0.000000 0.514999 -0.575587 0.635198" fovy="42.0"/>
       <camera name="gate_cam_right" pos="0.04 -0.30000 0.70000"

--- a/src/fret/mjcf/omx_wall_maze.xml
+++ b/src/fret/mjcf/omx_wall_maze.xml
@@ -46,28 +46,28 @@
     <!-- Dual Γ flanking front place; outer stems + ±Y roofs. -->
     <geom name="transfer_wall_stem" type="box" pos="0.270 -0.100 0.11" size="0.040 0.010 0.11"
           material="transfer_wall" friction="1.0 0.1 0.01"
-          contype="1" conaffinity="1"/>
+          contype="5" conaffinity="5"/>
     <geom name="transfer_wall_cap" type="box" pos="0.275 -0.165 0.245" size="0.035 0.075 0.02"
           material="transfer_wall" friction="1.0 0.1 0.01"
-          contype="1" conaffinity="1"/>
+          contype="5" conaffinity="5"/>
     <geom name="transfer_wall_stem_p" type="box" pos="0.270 0.100 0.11" size="0.040 0.010 0.11"
           material="transfer_wall" friction="1.0 0.1 0.01"
-          contype="1" conaffinity="1"/>
+          contype="5" conaffinity="5"/>
     <geom name="transfer_wall_cap_p" type="box" pos="0.275 0.165 0.245" size="0.035 0.075 0.02"
           material="transfer_wall" friction="1.0 0.1 0.01"
-          contype="1" conaffinity="1"/>
+          contype="5" conaffinity="5"/>
 
     <!-- Ø 40 mm tennis-like ball on the floor (grippy felt). -->
 
     <!-- Place bin: open square receptacle.
-         Walls/bottom contype=1: proximal arm only (no ball rim perch).
-         Distal pads/wrist (bit 4) free for top-down drop.
-         Ball catch = invisible funnel_w* (bit 2). -->
-    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="1" conaffinity="1"/>
+         Walls/bottom contype=5: proximal (1) + distal/pads (4); ball also
+         contacts the shell (no clipping). Drop from above the rim.
+         Ball catch assist = invisible funnel_w* (bit 2). -->
+    <geom name="place_bin_bottom" type="box" pos="0.26000 0.00000 0.00063" size="0.05000 0.05000 0.00063" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_px" type="box" pos="0.31250 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_nx" type="box" pos="0.20750 0.00000 0.04900" size="0.00250 0.05500 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_py" type="box" pos="0.26000 0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_ny" type="box" pos="0.26000 -0.05250 0.04900" size="0.05000 0.00250 0.04900" material="place_bin" contype="5" conaffinity="5"/>
     <geom name="funnel_w0" type="box" size="0.00250 0.00757 0.05501" pos="0.28800 0.00000 0.04900" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w1" type="box" size="0.00250 0.00757 0.05501" pos="0.28730 0.00623 0.04900" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w2" type="box" size="0.00250 0.00757 0.05501" pos="0.28523 0.01215 0.04900" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="1.4 0.1 0.01" contype="2" conaffinity="2"/>
@@ -119,28 +119,28 @@
     <body name="vision_gate" pos="-0.16000 0 0">
       <geom name="gate_post_l" type="box" size="0.0120 0.0120 0.3600"
             pos="0 0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="0.0120 0.0120 0.3600"
             pos="0 -0.30000 0.36000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.72000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="0.0120 0.31200 0.0120"
             pos="0 0 0.02400" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="0.0084 0.45044 0.0084"
             pos="0 0 0.36000" quat="0.912693 -0.408647 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 -0.30000 0.70000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 0.30000 0.70000"
               xyaxes="-0.745241 -0.666795 0.000000 0.514999 -0.575587 0.635198" fovy="42.0"/>
       <camera name="gate_cam_right" pos="0.04 -0.30000 0.70000"

--- a/src/fret/mjcf/omy.py
+++ b/src/fret/mjcf/omy.py
@@ -7,7 +7,8 @@ Same materialization pattern as :mod:`fret.mjcf.omx` — resolve Menagerie
 Pads sit on the inner fingertip faces (toward the grasp volume) and are the
 gripping surfaces. No arm ``qpos`` snaps. Floor pick-place remaps distal
 collision bits so wrist/finger STLs can close on a floor ball without fighting
-the plane (and without jamming the place funnel on transfer).
+the plane. Scene obstacles (walls, place bin, vision gate) use contype=5
+(bits 1|4) so distal links still collide with them — no silent clipping.
 """
 
 from __future__ import annotations
@@ -148,8 +149,10 @@ def _enable_floor_pick_contacts(robot_xml: str) -> str:
     """Remap distal collision bits for floor-ball grasp (SC-v14b/c).
 
     Menagerie wrist/finger STLs penetrate the plane at a true floor pinch.
-    Distal meshes use pad bit 4 (ball only): no floor fight on pinch, and no
-    place-funnel jam on transfer (funnel is bit 2). Proximal links keep bit 1.
+    Distal meshes use pad bit 4: collide with the ball (14) but not the floor
+    (9). Scene obstacles use contype=5 (1|4) so distal links still hit walls /
+    bin / gate. Funnel catcher stays bit 2 (ball only). Proximal links keep
+    bit 1.
     """
     # Wrist / flange / fingers: ball only (same bit as pads).
     for mesh in ("link5", "link6", "r1", "r2", "l1", "l2"):

--- a/src/fret/mjcf/omy_clutter.xml
+++ b/src/fret/mjcf/omy_clutter.xml
@@ -39,7 +39,7 @@
     <light name="key" pos="0.95 0.0 1.6" dir="0 0 -1" directional="true"
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
     <!-- Contact bits: arm=1, catcher=2, pads/distal=4, floor=1|8.
-         Ball=2|4|8; place_bin contype=1 hits proximal arm only. -->
+         Ball=2|4|8; place_bin/walls/gate contype=5 (bits 1|4) hit full arm. -->
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 
@@ -47,14 +47,14 @@
 
 
     <!-- Place bin: open square receptacle.
-         Walls/bottom contype=1: proximal arm only (no ball rim perch).
-         Distal pads/wrist (bit 4) free for top-down drop.
-         Ball catch = invisible funnel_w* (bit 2). -->
-    <geom name="place_bin_bottom" type="box" pos="0.48000 0.00000 0.00150" size="0.14000 0.14000 0.00150" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_px" type="box" pos="0.62600 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_nx" type="box" pos="0.33400 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_py" type="box" pos="0.48000 0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_ny" type="box" pos="0.48000 -0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="1" conaffinity="1"/>
+         Walls/bottom contype=5: proximal (1) + distal/pads (4); ball also
+         contacts the shell (no clipping). Drop from above the rim.
+         Ball catch assist = invisible funnel_w* (bit 2). -->
+    <geom name="place_bin_bottom" type="box" pos="0.48000 0.00000 0.00150" size="0.14000 0.14000 0.00150" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_px" type="box" pos="0.62600 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_nx" type="box" pos="0.33400 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_py" type="box" pos="0.48000 0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_ny" type="box" pos="0.48000 -0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="5" conaffinity="5"/>
     <geom name="funnel_w0" type="box" size="0.00700 0.02120 0.15717" pos="0.55840 0.00000 0.14000" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w1" type="box" size="0.00700 0.02120 0.15717" pos="0.55644 0.01744 0.14000" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w2" type="box" size="0.00700 0.02120 0.15717" pos="0.55064 0.03402 0.14000" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
@@ -100,7 +100,7 @@
           pos="0.41500 -0.12000 0.09000"
           size="0.05000 0.02500 0.09000"
           material="transfer_wall"
-          friction="1.0 0.1 0.01" contype="1" conaffinity="1"/>
+          friction="1.0 0.1 0.01" contype="5" conaffinity="5"/>
 
 
     <!-- CV estimate ghost (visual only; updated by pick_place_vision). -->
@@ -115,28 +115,28 @@
     <body name="vision_gate" pos="-0.22000 0 0">
       <geom name="gate_post_l" type="box" size="0.0160 0.0160 0.5000"
             pos="0 0.42000 0.50000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="0.0160 0.0160 0.5000"
             pos="0 -0.42000 0.50000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="0.0160 0.43600 0.0160"
             pos="0 0 1.00000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="0.0160 0.43600 0.0160"
             pos="0 0 0.03200" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="0.0112 0.62883 0.0112"
             pos="0 0 0.50000" quat="0.913211 0.407486 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="0.0112 0.62883 0.0112"
             pos="0 0 0.50000" quat="0.913211 -0.407486 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 0.42000 0.98000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 -0.42000 0.98000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 0.42000 0.98000"
               xyaxes="-0.680451 -0.732793 0.000000 0.553287 -0.513766 0.655681" fovy="45.0"/>
       <camera name="gate_cam_right" pos="0.04 -0.42000 0.98000"

--- a/src/fret/mjcf/omy_pick_place.xml
+++ b/src/fret/mjcf/omy_pick_place.xml
@@ -36,7 +36,7 @@
     <light name="key" pos="0.95 0.0 1.6" dir="0 0 -1" directional="true"
            diffuse="0.45 0.46 0.48" specular="0.05 0.05 0.05"/>
     <!-- Contact bits: arm=1, catcher=2, pads/distal=4, floor=1|8.
-         Ball=2|4|8; place_bin contype=1 hits proximal arm only. -->
+         Ball=2|4|8; place_bin/walls/gate contype=5 (bits 1|4) hit full arm. -->
     <geom name="floor" type="plane" size="0 0 0.05" material="groundplane"
           friction="1.0 0.1 0.01" contype="9" conaffinity="9"/>
 
@@ -44,14 +44,14 @@
 
 
     <!-- Place bin: open square receptacle.
-         Walls/bottom contype=1: proximal arm only (no ball rim perch).
-         Distal pads/wrist (bit 4) free for top-down drop.
-         Ball catch = invisible funnel_w* (bit 2). -->
-    <geom name="place_bin_bottom" type="box" pos="0.48000 0.00000 0.00150" size="0.14000 0.14000 0.00150" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_px" type="box" pos="0.62600 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_nx" type="box" pos="0.33400 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_py" type="box" pos="0.48000 0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="1" conaffinity="1"/>
-    <geom name="place_bin_wall_ny" type="box" pos="0.48000 -0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="1" conaffinity="1"/>
+         Walls/bottom contype=5: proximal (1) + distal/pads (4); ball also
+         contacts the shell (no clipping). Drop from above the rim.
+         Ball catch assist = invisible funnel_w* (bit 2). -->
+    <geom name="place_bin_bottom" type="box" pos="0.48000 0.00000 0.00150" size="0.14000 0.14000 0.00150" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_px" type="box" pos="0.62600 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_nx" type="box" pos="0.33400 0.00000 0.14000" size="0.00600 0.15200 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_py" type="box" pos="0.48000 0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="5" conaffinity="5"/>
+    <geom name="place_bin_wall_ny" type="box" pos="0.48000 -0.14600 0.14000" size="0.14000 0.00600 0.14000" material="place_bin" contype="5" conaffinity="5"/>
     <geom name="funnel_w0" type="box" size="0.00700 0.02120 0.15717" pos="0.55840 0.00000 0.14000" quat="0.972307 0.000000 0.233707 0.000000" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w1" type="box" size="0.00700 0.02120 0.15717" pos="0.55644 0.01744 0.14000" quat="0.966193 -0.026167 0.232238 0.108864" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
     <geom name="funnel_w2" type="box" size="0.00700 0.02120 0.15717" pos="0.55064 0.03402 0.14000" quat="0.947929 -0.052005 0.227848 0.216359" rgba="0.55 0.42 0.35 0" friction="0.45 0.05 0.01" contype="2" conaffinity="2"/>
@@ -104,28 +104,28 @@
     <body name="vision_gate" pos="-0.22000 0 0">
       <geom name="gate_post_l" type="box" size="0.0160 0.0160 0.5000"
             pos="0 0.42000 0.50000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_post_r" type="box" size="0.0160 0.0160 0.5000"
             pos="0 -0.42000 0.50000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_top" type="box" size="0.0160 0.43600 0.0160"
             pos="0 0 1.00000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_beam_bot" type="box" size="0.0160 0.43600 0.0160"
             pos="0 0 0.03200" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_a" type="box" size="0.0112 0.62883 0.0112"
             pos="0 0 0.50000" quat="0.913211 0.407486 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_brace_b" type="box" size="0.0112 0.62883 0.0112"
             pos="0 0 0.50000" quat="0.913211 -0.407486 0.000000 0.000000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_l" type="box" size="0.03 0.025 0.012"
             pos="0.04 0.42000 0.98000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <geom name="gate_cam_plate_r" type="box" size="0.03 0.025 0.012"
             pos="0.04 -0.42000 0.98000" material="vision_portal"
-            contype="0" conaffinity="0" group="1"/>
+            contype="5" conaffinity="5" group="1"/>
       <camera name="gate_cam_left" pos="0.04 0.42000 0.98000"
               xyaxes="-0.680451 -0.732793 0.000000 0.553287 -0.513766 0.655681" fovy="45.0"/>
       <camera name="gate_cam_right" pos="0.04 -0.42000 0.98000"

--- a/src/fret/scenario/__init__.py
+++ b/src/fret/scenario/__init__.py
@@ -1,18 +1,36 @@
 """Scenario orchestration for FRET release showcases.
 
 - v1.1: ``DubinsRaceRunner`` (SC-v11)
+
+Heavy Dubins / MuJoCo / vision imports are lazy so lightweight helpers
+(``planner_rng``) used by arm pick-place planning do not pull OpenCV.
 """
 
 from __future__ import annotations
 
-from fret.scenario.dubins_race_runner import (
-    DubinsRaceRunner,
-    DubinsRaceRunResult,
-    DubinsRaceSimulation,
-)
+from typing import TYPE_CHECKING, Any
 
 __all__ = [
     "DubinsRaceRunResult",
     "DubinsRaceRunner",
     "DubinsRaceSimulation",
 ]
+
+if TYPE_CHECKING:
+    from fret.scenario.dubins_race_runner import (
+        DubinsRaceRunner,
+        DubinsRaceRunResult,
+        DubinsRaceSimulation,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    if name in {
+        "DubinsRaceRunner",
+        "DubinsRaceRunResult",
+        "DubinsRaceSimulation",
+    }:
+        from fret.scenario import dubins_race_runner as _runner
+
+        return getattr(_runner, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/control/test_obstacle_contact_bits.py
+++ b/tests/control/test_obstacle_contact_bits.py
@@ -1,0 +1,128 @@
+"""Regression: obstacles must physically collide with the full arm.
+
+Prior agents left the vision gate on ``contype=0`` (ghost) and scene walls /
+place-bin shells on ``contype=1`` while remapping pads/wrist to bit 4. MuJoCo's
+contact filter then allowed the gripper to occupy the same volume as a solid
+brown Γ wall or gray portal with **zero** pad–obstacle contacts — exactly the
+clipping in the maintainer screenshots.
+
+Obstacles use ``contype=5`` (bits 1|4) so proximal **and** distal collide.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fret.sitl_config import mjcf_path
+
+mujoco = pytest.importorskip("mujoco")
+
+_SCENES = (
+    ("open_manipulator_x", "omx_wall_maze"),
+    ("open_manipulator_x", "omx_desk_clutter"),
+    ("open_manipulator_x", "omx_pick_place"),
+    ("open_manipulator_y", "omy_clutter"),
+    ("open_manipulator_y", "omy_pick_place"),
+)
+
+_FULL_ARM_BITS = 5  # proximal=1 | distal/pads=4
+_GATE_STRUCTURAL = (
+    "gate_post_l",
+    "gate_post_r",
+    "gate_beam_top",
+    "gate_beam_bot",
+    "gate_brace_a",
+    "gate_brace_b",
+)
+
+
+def _filter_allows(model: object, i: int, j: int) -> bool:
+    return bool(
+        (int(model.geom_contype[i]) & int(model.geom_conaffinity[j]))
+        and (int(model.geom_contype[j]) & int(model.geom_conaffinity[i]))
+    )
+
+
+@pytest.mark.parametrize(("robot", "scene"), _SCENES)
+def test_obstacles_use_full_arm_contact_bits(robot: str, scene: str) -> None:
+    path = mjcf_path(robot, scene)
+    model = mujoco.MjModel.from_xml_path(str(path))
+    for i in range(model.ngeom):
+        name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, i) or ""
+        if name.startswith("place_bin") or name.startswith("transfer_wall"):
+            assert int(model.geom_contype[i]) == _FULL_ARM_BITS, name
+            assert int(model.geom_conaffinity[i]) == _FULL_ARM_BITS, name
+        if name in _GATE_STRUCTURAL:
+            assert int(model.geom_contype[i]) == _FULL_ARM_BITS, name
+            assert int(model.geom_conaffinity[i]) == _FULL_ARM_BITS, name
+
+
+def test_pad_collides_with_gamma_wall_and_gate() -> None:
+    """Pad↔Γ wall and proximal↔gate filters must be live (not silent ghosts)."""
+    path = mjcf_path("open_manipulator_x", "omx_wall_maze")
+    model = mujoco.MjModel.from_xml_path(str(path))
+    pad = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "pad_left")
+    stem = mujoco.mj_name2id(
+        model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_stem"
+    )
+    gate = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "gate_beam_bot")
+    assert pad >= 0 and stem >= 0 and gate >= 0
+    assert _filter_allows(model, pad, stem)
+    assert _filter_allows(model, pad, gate)
+
+    # Geometric penetration of pad into the stem must produce a pad–stem contact.
+    data = mujoco.MjData(model)
+    names = ("Joint1", "Joint2", "Joint3", "Joint4")
+    qadrs = [
+        int(
+            model.jnt_qposadr[
+                mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, n)
+            ]
+        )
+        for n in names
+    ]
+    box_jid = mujoco.mj_name2id(
+        model, mujoco.mjtObj.mjOBJ_JOINT, "pick_box_joint"
+    )
+    data.qpos[int(model.jnt_qposadr[box_jid]) : int(model.jnt_qposadr[box_jid]) + 3] = [
+        0.5,
+        0.5,
+        0.5,
+    ]
+    data.qpos[qadrs[0]] = -0.40
+    data.qpos[qadrs[1]] = 0.75
+    data.qpos[qadrs[2]] = -1.20
+    data.qpos[qadrs[3]] = 0.50
+    data.qvel[:] = 0.0
+    mujoco.mj_forward(model, data)
+    fromto = np.empty(6)
+    dist = float(
+        mujoco.mj_geomDistance(model, data, pad, stem, 10.0, fromto)
+    )
+    assert dist < 0.0, f"expected pad–stem penetration, got dist={dist}"
+    pad_stem_hits = 0
+    for ci in range(data.ncon):
+        c = data.contact[ci]
+        g1 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, c.geom1) or ""
+        g2 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, c.geom2) or ""
+        pair = {g1, g2}
+        if "pad_left" in pair and "transfer_wall_stem" in pair:
+            pad_stem_hits += 1
+    assert pad_stem_hits >= 1, (
+        f"pad penetrated stem (dist={dist:.4f}) but no pad–stem contact "
+        f"(ncon={data.ncon}) — contact filter still wrong"
+    )
+
+
+def test_omy_distal_collides_with_transfer_wall() -> None:
+    path = mjcf_path("open_manipulator_y", "omy_clutter")
+    model = mujoco.MjModel.from_xml_path(str(path))
+    pad = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "pad_left")
+    wall = mujoco.mj_name2id(
+        model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_a"
+    )
+    gate = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "gate_brace_a")
+    assert pad >= 0 and wall >= 0 and gate >= 0
+    assert _filter_allows(model, pad, wall)
+    assert _filter_allows(model, pad, gate)

--- a/tests/control/test_pick_place_fsm.py
+++ b/tests/control/test_pick_place_fsm.py
@@ -148,14 +148,14 @@ def test_omx_pick_place_mjcf_loads() -> None:
         mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "place_bin_bottom")
         >= 0
     )
-    # Bin walls collide with proximal arm (bit 1); funnel catcher is ball-only
-    # (bit 2). Distal pads stay on bit 4 so top-down drops are still free.
+    # Bin walls collide with full arm (bits 1|4=5); funnel catcher is ball-only
+    # (bit 2). Distal pads stay on bit 4 (no floor fight) but still hit the bin.
     wall = mujoco.mj_name2id(
         model, mujoco.mjtObj.mjOBJ_GEOM, "place_bin_wall_px"
     )
     assert wall >= 0
-    assert int(model.geom_contype[wall]) == 1
-    assert int(model.geom_conaffinity[wall]) == 1
+    assert int(model.geom_contype[wall]) == 5
+    assert int(model.geom_conaffinity[wall]) == 5
     funnel = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, "funnel_w0")
     assert funnel >= 0
     assert int(model.geom_contype[funnel]) == 2
@@ -178,7 +178,7 @@ def test_omy_place_bin_blocks_proximal_arm() -> None:
     names = [model.geom(i).name for i in range(model.ngeom)]
     joints = ("Joint1", "Joint2", "Joint3", "Joint4", "Joint5", "Joint6")
     # Historical elbow-down place_grasp that penetrates wall_nx when walls
-    # collide (contype=1). Must produce a place_bin contact.
+    # collide (contype=5). Must produce a place_bin contact.
     dunk = [0.4298, 0.3654, 1.8952, -0.2575, -0.9997, -0.0128]
     for name, val in zip(joints, dunk, strict=True):
         adr = int(

--- a/tests/control/test_pick_place_wall_maze.py
+++ b/tests/control/test_pick_place_wall_maze.py
@@ -43,9 +43,9 @@ def test_omx_wall_maze_mjcf_has_gamma_walls() -> None:
     stem = mujoco.mj_name2id(
         model, mujoco.mjtObj.mjOBJ_GEOM, "transfer_wall_stem"
     )
-    # Arm (contype/affinity 1) must collide with the Γ walls.
-    assert int(model.geom_contype[stem]) == 1
-    assert int(model.geom_conaffinity[stem]) == 1
+    # Full arm (bits 1|4 = 5) must collide with the Γ walls — including pads.
+    assert int(model.geom_contype[stem]) == 5
+    assert int(model.geom_conaffinity[stem]) == 5
     walls = walls_from_scenario(_SCENARIO)
     # 4 Γ slabs + 4 place-bin side shells.
     assert len(walls) == 8

--- a/tests/control/test_pick_place_wall_maze.py
+++ b/tests/control/test_pick_place_wall_maze.py
@@ -65,13 +65,17 @@ def test_wall_maze_transfer_plan_backs_out_and_climbs() -> None:
     wp = waypoints_from_scenario(_SCENARIO)
     params = load_scenario_parameters(_SCENARIO)
     peak_req = float(params["min_transfer_peak_ee_z_m"])
+    # Plan from lift_hover — matches FSM MOVE_PLACE entry after grasp/lift.
+    transfer_start = (
+        wp.lift_hover if wp.lift_hover is not None else wp.pick_hover
+    )
     path = None
     straight_collides = False
     last_err: Exception | None = None
     for seed_offset in range(0, 85, 17):
         try:
             path, straight_collides = plan_transfer_path(
-                wp.pick_hover,
+                transfer_start,
                 wp.place_hover,
                 scenario_path=_SCENARIO,
                 seed_offset=seed_offset,
@@ -213,7 +217,9 @@ def test_arm_contacts_transfer_wall_detects_collision_pose() -> None:
     box_jid = mujoco.mj_name2id(
         model, mujoco.mjtObj.mjOBJ_JOINT, "pick_box_joint"
     )
-    data.qpos[int(model.jnt_qposadr[box_jid]) : int(model.jnt_qposadr[box_jid]) + 3] = [
+    data.qpos[
+        int(model.jnt_qposadr[box_jid]) : int(model.jnt_qposadr[box_jid]) + 3
+    ] = [
         0.5,
         0.5,
         0.5,

--- a/tests/scenario/test_planner_rng.py
+++ b/tests/scenario/test_planner_rng.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
+
 import numpy as np
 
 from fret.scenario.planner_rng import (
@@ -39,3 +43,25 @@ def test_deterministic_planner_rng_honours_a_non_default_seed() -> None:
         SHOWCASE_PLANNER_RNG_SEED
     ).integers(0, 1_000_000, 3)
     assert list(actual) != list(default_expected)
+
+
+def test_planner_rng_import_does_not_load_opencv() -> None:
+    """Arm planners import planner_rng; that must not pull broken OpenCV."""
+    src = Path(__file__).resolve().parents[2] / "src"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; "
+            f"sys.path.insert(0, {str(src)!r}); "
+            "from fret.scenario.planner_rng import deterministic_planner_rng; "
+            "assert 'cv2' not in sys.modules; "
+            "assert 'fret.scenario.dubins_race_runner' not in sys.modules; "
+            "print('ok')",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Your screenshots showed the arm/gripper crossing brown Γ walls and the gray vision gate. Two separate bugs stacked:

1. **Silent clipping** — vision gate `contype=0`; walls/bin `contype=1` while pads/distal used bit `4` → MuJoCo filter produced **no** pad–wall contacts.
2. **False “avoidance”** — after enabling `contype=5`, FSM FAULTed with `wall_contact_steps=8` because OMX still planned transfer from `pick_hover` while MOVE_PLACE starts at `lift_hover`, so tracking grazed `transfer_wall_stem` with the gripper palm.

## Fix (one commit per plan step)

| Step | Commit | What |
| --- | --- | --- |
| 0 | `020bae0` | MJCF: walls / place bin / vision gate → `contype=5` (full arm) |
| 1 | `7f31b7d` | Diagnose script: classifies plan / track / FSM-only contacts |
| 2 | `f00b886` | Lazy `scenario` imports so `planner_rng` does not pull OpenCV |
| 3 | `6c53944` | Plan from `lift_hover`, inflate 0.035 m, **zero-hit** MPC dry-run |
| 4 | `9f2c8d5` | Denser MPC C-space barriers (samples/clearance/weight) for palms |
| 5 | `eb6a625` | Record acceptance resolution in the diagnostic docstring |

## Verification

```bash
PYTHONPATH=src python3 -m pytest \
  tests/control/test_obstacle_contact_bits.py \
  tests/control/test_pick_place_wall_maze.py \
  tests/scenario/test_planner_rng.py \
  -q -p no:launch_testing -p no:launch_ros
# → 18 passed

bash scripts/check/formatting.sh   # PASSED
bash scripts/check/types.sh        # PASSED

# Flake batch: 8/8 DONE with wall_contact_steps=0
# Acceptance run: DONE, wall=0, ball at place bin
```

| Metric | Before plan steps | After |
| --- | --- | --- |
| pad ↔ Γ wall contact filter | False (silent clip) | True |
| FSM `wall_contact_steps` (seed 204) | 8 → FAULT | **0 → DONE** |
| 8-trial batch | — | **8/8 DONE** |

![wall_contact_steps before vs after](https://cursor.com/artifacts/c/art-3f7a8a00-90d6-4cf8-a71b-38e330a6000a)
![Successful wall-maze DONE overview](https://cursor.com/artifacts/c/art-956cd50f-986a-4653-b31d-673e0049cc6f)

Diagnostic: `PYTHONPATH=src python3 scripts/diagnose_wall_maze_contacts.py --fsm`

## Recurrence

Do **not** green “no wall contacts” by disabling distal/gate bits again. Contact simulation stays on (`contype=5`); avoidance is fixed by planning/tracking the pose the FSM actually starts from.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b3f482d-0ebe-4b5f-af3d-155d4275ebc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b3f482d-0ebe-4b5f-af3d-155d4275ebc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

