### PR TITLE
docs(release): mark v1.4.3 shipped in version table

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -279,7 +279,7 @@ this repository documentation** — see [roadmap.md](roadmap.md).
 | `v1.4.0` | CV ↔ manipulation + MuJoCo cameras | ✅ |
 | `v1.4.1` | Showcase honesty (MPC barriers, OM-X grasp, Ø40 mm ball) | ✅ |
 | `v1.4.2` | ARCO v0.3.7 MPCC + full-arm obstacle contacts | ✅ |
-| `v1.4.3` | OMY APPROACH_PICK plans around colliding place-bin shell | 🔲 |
+| `v1.4.3` | OMY APPROACH_PICK plans around colliding place-bin shell | ✅ |
 | `v1.5.0` | Dynamic ball + industrial place | 🔲 |
 | `v2.0.0+` | Hardware line (modular) | 🔲 |
 | `v3.0.0` | Definitive product (north-star) | ○ |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tiny follow-up so `main` matches the `v1.4.3` tag tip. The release tag already includes this docs-only line; branch protection blocked pushing it straight to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1088eace-d36b-4af2-abd7-d0e465c8b0d2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1088eace-d36b-4af2-abd7-d0e465c8b0d2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

